### PR TITLE
Add tests from FFI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           override: true
       - name: Running cargo test
         env:
-          FEATURES: bitcoin elements
+          FEATURES: bitcoin elements test-utils
         run: |
           for f in $FEATURES; do echo "Features: $f" && cargo test --no-default-features --features="$f"; done
           echo "No default features" && cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [features]
 default = [ "bitcoin", "elements" ]
+test-utils = ["simplicity_sys/test-utils"]
 
 [lib]
 name = "simplicity"
@@ -20,3 +21,6 @@ byteorder = "1.3"
 elements = { version = "0.21.1", optional = true }
 miniscript = "9.0.0"
 simplicity_sys = { version = "0.1.0", path = "./simplicity-sys" }
+
+[dev-dependencies]
+simplicity_sys = { version = "0.1.0", path = "./simplicity-sys", features = ["test-utils"] }

--- a/simplicity-sys/Cargo.toml
+++ b/simplicity-sys/Cargo.toml
@@ -10,3 +10,6 @@ cc = "1.0"
 
 [dependencies]
 libc = "0.2"
+
+[features]
+test-utils = []

--- a/simplicity-sys/src/c_jets/exec_ffi.rs
+++ b/simplicity-sys/src/c_jets/exec_ffi.rs
@@ -1,0 +1,95 @@
+//! Execution related FFIs, only used for testing rust-simplicity
+//! Also exports test cases from C simplicity
+use std::os::raw::c_uchar;
+
+use libc::size_t;
+
+extern "C" {
+    // These structures are stored as C arrays arr[]
+    // The FFI bindings give the value of the first element and NOT the address
+    // of the first element. This is why we have schnorr0 as u8 and not *const u8.
+    // Another cleaner/longer way to do this would be write a wrapper function that
+    // takes a rust allocated array and copies the C array into it.
+    static schnorr0: [c_uchar; 0usize];
+    static sizeof_schnorr0: size_t;
+    static schnorr0_cmr: [u32; 8]; // size 8
+    static schnorr0_amr: [u32; 8]; // size 8
+    static schnorr0_imr: [u32; 8]; // size 8
+
+    static schnorr6: [c_uchar; 0usize];
+    static sizeof_schnorr6: size_t;
+    static schnorr6_cmr: [u32; 8]; // size 8
+    static schnorr6_amr: [u32; 8]; // size 8
+    static schnorr6_imr: [u32; 8]; // size 8
+
+    static hashBlock: [c_uchar; 0usize];
+    static sizeof_hashBlock: size_t;
+    static hashBlock_cmr: [u32; 8]; // size 8
+    static hashBlock_amr: [u32; 8]; // size 8
+    static hashBlock_imr: [u32; 8]; // size 8
+}
+
+pub fn parse_root(ptr: &[u32; 8]) -> [u8; 32] {
+    let mut a = [0u8; 32];
+    for i in 0..8 {
+        let x = ptr[i];
+        a[i * 4] = (x >> 24) as u8;
+        a[i * 4 + 1] = (x >> 16) as u8;
+        a[i * 4 + 2] = (x >> 8) as u8;
+        a[i * 4 + 3] = x as u8;
+    }
+    a
+}
+
+pub fn parse_prog(ptr: *const u8, len: usize) -> Vec<u8> {
+    // Could construct from raw parts, but we just allocate because
+    // this is only used in tests
+    let mut v = Vec::with_capacity(len);
+    unsafe {
+        for i in 0..len {
+            v.push(*ptr.offset(i as isize));
+        }
+    }
+    v
+}
+
+/// Data structure to hold test cases from C simplicity
+pub struct TestData {
+    pub cmr: [u8; 32],
+    pub amr: [u8; 32],
+    pub imr: [u8; 32],
+    pub prog: Vec<u8>,
+}
+
+pub fn schnorr0_test_data() -> TestData {
+    unsafe {
+        TestData {
+            cmr: parse_root(&schnorr0_cmr),
+            amr: parse_root(&schnorr0_amr),
+            imr: parse_root(&schnorr0_imr),
+            prog: parse_prog(schnorr0.as_ptr(), sizeof_schnorr0 as usize),
+        }
+    }
+}
+
+pub fn schnorr6_test_data() -> TestData {
+    unsafe {
+        TestData {
+            cmr: parse_root(&schnorr6_cmr),
+            amr: parse_root(&schnorr6_amr),
+            imr: parse_root(&schnorr6_imr),
+            prog: parse_prog(schnorr6.as_ptr(), sizeof_schnorr6 as usize),
+        }
+    }
+}
+
+pub fn hash_block_test_data() -> TestData {
+    unsafe {
+        TestData {
+            cmr: parse_root(&hashBlock_cmr),
+            amr: parse_root(&hashBlock_amr),
+            imr: parse_root(&hashBlock_imr),
+            prog: parse_prog(hashBlock.as_ptr(), sizeof_hashBlock as usize),
+        }
+    }
+}

--- a/simplicity-sys/src/c_jets/mod.rs
+++ b/simplicity-sys/src/c_jets/mod.rs
@@ -19,6 +19,9 @@ pub use jets_ffi as elements_ffi;
 
 use crate::c_jets::c_env::{CRawBuffer, CRawInput, CRawOutput, CRawTapEnv, CRawTransaction};
 
+#[cfg(feature = "test-utils")]
+pub mod exec_ffi;
+
 /// sanity checks for using the types.
 /// We are not using the internal representation of the types at all, but
 /// we do care about the size and alignments of the types.

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -51,7 +51,7 @@ impl CommitMerkleRoot for Cmr {
             CommitNodeInner::Witness => Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1fwitness"),
             CommitNodeInner::Fail(_, _) => Cmr::tag_iv(b"Simplicity-Draft\x1fCommitment\x1ffail"),
             CommitNodeInner::Hidden(h) => *h,
-            CommitNodeInner::Jet(jet) => jet.cmr(),
+            CommitNodeInner::Jet(j) => Cmr::tag_iv(b"Simplicity-Draft\x1fJet").update_1(j.cmr()),
         }
     }
 }

--- a/src/merkle/tmr.rs
+++ b/src/merkle/tmr.rs
@@ -31,7 +31,7 @@ impl_midstate_wrapper!(Tmr);
 impl TypeMerkleRoot for Tmr {
     fn get_iv(ty: &TypeInner) -> Self {
         match ty {
-            TypeInner::Unit => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fone"),
+            TypeInner::Unit => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1funit"),
             TypeInner::Sum(..) => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fsum"),
             TypeInner::Product(..) => Tmr::tag_iv(b"Simplicity-Draft\x1fType\x1fprod"),
         }

--- a/src/test_progs/mod.rs
+++ b/src/test_progs/mod.rs
@@ -13,90 +13,34 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-/// Test programs for simplicity.
-pub(crate) mod hashblock;
-pub(crate) mod schnorr0;
-pub(crate) mod schnorr6;
-pub(crate) mod sighash_all;
-
 #[cfg(test)]
+#[cfg(feature = "test-utils")]
 mod tests {
-    use super::hashblock::{HASHBLOCK, HASHBLOCK_CMR};
+
+    use simplicity_sys::c_jets::exec_ffi;
+
     use crate::bititer::BitIter;
-    use crate::core::{CommitNode, RedeemNode, Value};
-    use crate::exec::BitMachine;
-    use crate::jet::Core;
+    use crate::jet::Elements;
     use crate::merkle::common::MerkleRoot;
-    use crate::test_progs::schnorr0::{SCHNORR0, SCHNORR0_CMR};
-    use crate::test_progs::schnorr6::{SCHNORR6, SCHNORR6_CMR};
+    use crate::RedeemNode;
 
-    // TODO: check IMR
-    fn check_merkle_roots(bytes: &[u8], cmr: [u8; 32]) {
-        let mut bits = BitIter::new(bytes.iter().cloned());
-        let commit = CommitNode::<Core>::decode(&mut bits).expect("decoding program");
-        assert_eq!(commit.cmr.into_inner(), cmr);
-    }
-
-    fn exec_prog(bytes: &[u8]) {
-        let mut bits = BitIter::new(bytes.iter().cloned());
-        let program = RedeemNode::<Core>::decode(&mut bits).expect("decode");
-
-        let mut mac = BitMachine::for_program(&program);
-        mac.exec(&program, &()).unwrap();
+    // // TODO: check AMR(if we implement it)
+    // The new IMR also has type commitments, so we don't really need to check AMR
+    fn check_merkle_roots(test: &exec_ffi::TestData) {
+        let mut bits = BitIter::new(test.prog.iter().cloned());
+        let prog = RedeemNode::<Elements>::decode(&mut bits).unwrap();
+        assert_eq!(prog.cmr.into_inner(), test.cmr);
+        // assert_eq!(redeem.amr.into_inner(), test.amr);
+        assert_eq!(prog.imr.into_inner(), test.imr);
     }
 
     #[test]
     fn progs_cmr() {
-        check_merkle_roots(&HASHBLOCK, HASHBLOCK_CMR);
-        check_merkle_roots(&SCHNORR0, SCHNORR0_CMR);
-        check_merkle_roots(&SCHNORR6, SCHNORR6_CMR);
+        let hash_block = exec_ffi::hash_block_test_data();
+        let schnorr0 = exec_ffi::schnorr0_test_data();
+        let schnorr6 = exec_ffi::schnorr6_test_data();
+        check_merkle_roots(&hash_block);
+        check_merkle_roots(&schnorr0);
+        check_merkle_roots(&schnorr6);
     }
-
-    #[test]
-    fn exec_hashblock() {
-        let mut bits = BitIter::new(HASHBLOCK.iter().cloned());
-        let program = RedeemNode::<Core>::decode(&mut bits).expect("decoding program");
-
-        let state = Value::u256_from_slice(&[
-            0x6a, 0x09, 0xe6, 0x67, 0xbb, 0x67, 0xae, 0x85, 0x3c, 0x6e, 0xf3, 0x72, 0xa5, 0x4f,
-            0xf5, 0x3a, 0x51, 0x0e, 0x52, 0x7f, 0x9b, 0x05, 0x68, 0x8c, 0x1f, 0x83, 0xd9, 0xab,
-            0x5b, 0xe0, 0xcd, 0x19,
-        ]);
-        let mut block = [0u8; 64];
-        block[0] = 0x61;
-        block[1] = 0x62;
-        block[2] = 0x63;
-        block[3] = 0x80;
-        block[63] = 0x18;
-        let block = Value::u512_from_slice(&block);
-
-        let hash: [u8; 32] = [
-            0xba, 0x78, 0x16, 0xbf, 0x8f, 0x1, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae,
-            0x22, 0x23, 0xb0, 0x3, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61,
-            0xf2, 0x0, 0x15, 0xad,
-        ];
-
-        let mut mac = BitMachine::for_program(&program);
-        mac.input(&Value::prod(state, block));
-        let output = mac.exec(&program, &()).unwrap();
-
-        assert_eq!(output.try_to_bytes().unwrap(), hash);
-    }
-
-    #[test]
-    #[ignore] // too expensive to run. Run with -- --ignored and --release to run this
-    #[should_panic]
-    fn schnorr6() {
-        exec_prog(&SCHNORR6);
-    }
-
-    /*
-    TODO: Add c_jet_ptr for used jets and re-enable tests
-
-    #[test]
-    #[ignore] // too expensive to run. Run with -- --ignored and --release to run this
-    fn schnorr0() {
-        exec_prog(&SCHNORR0);
-    }
-    */
 }


### PR DESCRIPTION
Fixes several bugs with tmr/imr/cmr respectively. Based on #61 . All the tests based on FFI are still disabled. We will re-enable them in the next PR. 