### PR TITLE
policy: do not parse invalid thresholds

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,3 +29,7 @@ path = "fuzz_targets/decode_program.rs"
 [[bin]]
 name = "decode_witness"
 path = "fuzz_targets/decode_witness.rs"
+
+[[bin]]
+name = "parse_compile"
+path = "fuzz_targets/parse_compile.rs"

--- a/fuzz/fuzz_targets/parse_compile.rs
+++ b/fuzz/fuzz_targets/parse_compile.rs
@@ -1,0 +1,53 @@
+// Rust Simplicity Library
+// Written in 2022 by
+//   Christian Lewe <clewe@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+extern crate simplicity;
+
+use simplicity::bitcoin::XOnlyPublicKey;
+use simplicity::policy::ast::Policy;
+use std::str::{self, FromStr};
+
+fn do_test(data: &[u8]) {
+    let s = match str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let pol: Policy<XOnlyPublicKey> = match FromStr::from_str(s) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    pol.compile(&mut Default::default());
+}
+
+#[cfg(feature = "afl")]
+#[macro_use]
+extern crate afl;
+#[cfg(feature = "afl")]
+fn main() {
+    fuzz!(|data| {
+        do_test(&data);
+    });
+}
+
+#[cfg(feature = "honggfuzz")]
+#[macro_use]
+extern crate honggfuzz;
+#[cfg(feature = "honggfuzz")]
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}

--- a/src/policy/embed.rs
+++ b/src/policy/embed.rs
@@ -79,6 +79,11 @@ where
                 if nsubs == 0 {
                     return Err(msError::Unexpected("thresh without args".to_owned()));
                 }
+                if nsubs < 3 {
+                    return Err(msError::Unexpected(
+                        "thresh must have a threshold value and at least 2 children".to_owned(),
+                    ));
+                }
                 if !top.args[0].args.is_empty() {
                     return Err(msError::Unexpected(top.args[0].args[0].name.to_owned()));
                 }
@@ -154,5 +159,47 @@ impl<'a, Pk: MiniscriptKey, Ctx: ScriptContext> TryFrom<&'a Miniscript<Pk, Ctx>>
                 Err(Error::ParseError("Multisig is not supported"))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bad_thresh() {
+        assert_eq!(
+            Policy::<String>::from_str("thresh()"),
+            Err(msError::Unexpected(
+                "thresh must have a threshold value and at least 2 children".to_string()
+            )),
+        );
+
+        assert_eq!(
+            Policy::<String>::from_str("thresh"),
+            Err(msError::Unexpected("thresh without args".to_string())),
+        );
+
+        assert_eq!(
+            Policy::<String>::from_str("thresh(0)"),
+            Err(msError::Unexpected(
+                "thresh must have a threshold value and at least 2 children".to_string()
+            )),
+        );
+
+        assert_eq!(
+            Policy::<String>::from_str("thresh(0,TRIVIAL)"),
+            Err(msError::Unexpected(
+                "thresh must have a threshold value and at least 2 children".to_string()
+            )),
+        );
+
+        assert!(Policy::<String>::from_str("thresh(0,TRIVIAL,TRIVIAL)").is_ok());
+        assert!(Policy::<String>::from_str("thresh(2,TRIVIAL,TRIVIAL)").is_ok());
+
+        assert_eq!(
+            Policy::<String>::from_str("thresh(3,TRIVIAL,TRIVIAL)"),
+            Err(msError::Unexpected("3".to_string())),
+        );
     }
 }


### PR DESCRIPTION
Right now we are willing to parse policies like `thresh(0)` which are not valid. If you pass these to the compiler it will panic, meaning that a user cannot simply "parse then compile" without their code panicking.

This fixes that bug (3 lines) and adds a bunch of extra tests (the rest).