### PR TITLE
Several improvements to ergronomics; eliminate tons of error paths

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,12 +125,9 @@ jobs:
           FEATURES: honggfuzz_fuzz
         run: |
           cd fuzz/
-          for f in $FEATURES; do echo "Features: $f" && RUSTFLAGS=--cfg=fuzzing cargo test --no-default-features --features="$f"; done
-          echo "No default features" && RUSTFLAGS=--cfg=fuzzing cargo test --no-default-features
-          echo "All features" && RUSTFLAGS=--cfg=fuzzing cargo test --all-features
+          cargo test
+          RUSTFLAGS=--cfg=fuzzing cargo test
       - name: Running fuzz tests
-        env:
-          FEATURES: honggfuzz_fuzz
         run: |
           cd fuzz/
           ./travis-fuzz.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ actual-serde = { package = "serde", version = "1.0.103", features = ["derive"], 
 
 [dev-dependencies]
 simplicity_sys = { version = "0.1.0", path = "./simplicity-sys", features = ["test-utils"] }
+
+[workspace]
+members = ["simplicity-sys", "fuzz"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,10 +12,6 @@ cargo-fuzz = true
 honggfuzz = { version = "0.5.55", default-features = false }
 simplicity = { path = ".." }
 
-# Prevent this from interfering with workspaces
-[workspace]
-members = ["."]
-
 [[bin]]
 name = "decode_natural"
 path = "fuzz_targets/decode_natural.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "simplicity-fuzz"
 version = "0.0.1"
+edition = "2018"
 authors = ["Automatically generated"]
 publish = false
 
 [package.metadata]
 cargo-fuzz = true
 
-[features]
-honggfuzz_fuzz = ["honggfuzz"]
-
 [dependencies]
-honggfuzz = { version = "0.5", optional = true, default-features = false }
+honggfuzz = { version = "0.5.55", default-features = false }
 simplicity = { path = ".." }
 
 # Prevent this from interfering with workspaces

--- a/fuzz/fuzz_targets/decode_natural.rs
+++ b/fuzz/fuzz_targets/decode_natural.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-extern crate simplicity;
+use honggfuzz::fuzz;
 
 use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
@@ -42,20 +42,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-#[cfg(feature = "afl")]
-#[macro_use]
-extern crate afl;
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|data| {
-        do_test(&data);
-    });
-}
-
-#[cfg(feature = "honggfuzz")]
-#[macro_use]
-extern crate honggfuzz;
-#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|data| {

--- a/fuzz/fuzz_targets/decode_natural.rs
+++ b/fuzz/fuzz_targets/decode_natural.rs
@@ -16,18 +16,18 @@ extern crate simplicity;
 
 use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
-use simplicity::{decode, encode};
+use simplicity::{decode_natural, encode_natural};
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
-    if let Ok(natural) = decode::decode_natural(&mut iter, None) {
+    if let Ok(natural) = decode_natural(&mut iter, None) {
         // println!("{:?}", natural);
         let bit_len = iter.n_total_read();
 
         let mut sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut sink);
-        encode::encode_natural(natural, &mut w).expect("encoding to vector");
+        encode_natural(natural, &mut w).expect("encoding to vector");
         w.flush_all().expect("flushing");
         assert_eq!(w.n_total_written(), bit_len);
 
@@ -85,11 +85,6 @@ mod tests {
 
     #[test]
     fn duplicate_crash() {
-        #[cfg(not(fuzzing))]
-        compile_error!(
-            "To build this target or run the unit tests you must set RUSTFLAGS=--cfg=fuzzing"
-        );
-
         let mut a = Vec::new();
         extend_vec_from_hex("00", &mut a);
         super::do_test(&a);

--- a/fuzz/fuzz_targets/decode_program.rs
+++ b/fuzz/fuzz_targets/decode_program.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-extern crate simplicity;
+use honggfuzz::fuzz;
 
 use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
@@ -42,20 +42,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-#[cfg(feature = "afl")]
-#[macro_use]
-extern crate afl;
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|data| {
-        do_test(&data);
-    });
-}
-
-#[cfg(feature = "honggfuzz")]
-#[macro_use]
-extern crate honggfuzz;
-#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|data| {

--- a/fuzz/fuzz_targets/decode_witness.rs
+++ b/fuzz/fuzz_targets/decode_witness.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-extern crate simplicity;
+use honggfuzz::fuzz;
 
 use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
@@ -62,20 +62,6 @@ fn do_test(data: &[u8]) {
     }
 }
 
-#[cfg(feature = "afl")]
-#[macro_use]
-extern crate afl;
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|data| {
-        do_test(&data);
-    });
-}
-
-#[cfg(feature = "honggfuzz")]
-#[macro_use]
-extern crate honggfuzz;
-#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|data| {

--- a/fuzz/fuzz_targets/decode_witness.rs
+++ b/fuzz/fuzz_targets/decode_witness.rs
@@ -18,7 +18,7 @@ use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
 use simplicity::core::iter::WitnessIterator;
 use simplicity::core::types::Type;
-use simplicity::{WitnessDecoder, encode_witness};
+use simplicity::{encode_witness, WitnessDecoder};
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());

--- a/fuzz/fuzz_targets/decode_witness.rs
+++ b/fuzz/fuzz_targets/decode_witness.rs
@@ -18,8 +18,7 @@ use simplicity::bititer::BitIter;
 use simplicity::bitwriter::BitWriter;
 use simplicity::core::iter::WitnessIterator;
 use simplicity::core::types::Type;
-use simplicity::decode::WitnessDecoder;
-use simplicity::encode;
+use simplicity::{WitnessDecoder, encode_witness};
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
@@ -48,7 +47,7 @@ fn do_test(data: &[u8]) {
 
         let mut sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut sink);
-        encode::encode_witness(witness.iter(), &mut w).expect("encoding to vector");
+        encode_witness(witness.iter(), &mut w).expect("encoding to vector");
         w.flush_all().expect("flushing");
         assert_eq!(w.n_total_written(), bit_len);
 

--- a/fuzz/fuzz_targets/parse_compile.rs
+++ b/fuzz/fuzz_targets/parse_compile.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-extern crate simplicity;
+use honggfuzz::fuzz;
 
 use simplicity::bitcoin::XOnlyPublicKey;
 use simplicity::policy::ast::Policy;
@@ -27,23 +27,9 @@ fn do_test(data: &[u8]) {
         Ok(p) => p,
         Err(_) => return,
     };
-    pol.compile(&mut Default::default());
+    let _ = pol.compile(&mut Default::default());
 }
 
-#[cfg(feature = "afl")]
-#[macro_use]
-extern crate afl;
-#[cfg(feature = "afl")]
-fn main() {
-    fuzz!(|data| {
-        do_test(&data);
-    });
-}
-
-#[cfg(feature = "honggfuzz")]
-#[macro_use]
-extern crate honggfuzz;
-#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|data| {

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -16,7 +16,7 @@ for TARGET in fuzz_targets/*; do
 	if [ -d hfuzz_input/$FILE ]; then
 	    HFUZZ_INPUT_ARGS="-f hfuzz_input/$FILE/input"
 	fi
-	HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" HFUZZ_RUN_ARGS="--run_time 30 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
+	HFUZZ_RUN_ARGS="--run_time 30 --exit_upon_crash -v $HFUZZ_INPUT_ARGS" cargo hfuzz run $FILE
 
 	if [ -f hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT ]; then
 		cat hfuzz_workspace/$FILE/HONGGFUZZ.REPORT.TXT

--- a/simplicity-sys/src/c_jets/c_frame.rs
+++ b/simplicity-sys/src/c_jets/c_frame.rs
@@ -19,6 +19,10 @@ impl CFrameItem {
     ///
     /// Note: The C implementation uses array of UWORD for `from`. UWORD maps to uint_fast16_t which
     /// maps to usize on both 32-bit and 64-bit platforms.
+    ///
+    /// # Safety
+    ///
+    /// `from` must be a valid pointer to a contiguous allocation of at least `n` usizes.
     pub unsafe fn new_read(n: usize, from: *const usize) -> Self {
         // Allocate a new vector of required size
         let mut frame = CFrameItem::new_unchecked();
@@ -29,6 +33,11 @@ impl CFrameItem {
     /// Initialize a new write frame.
     /// 'n' is the number of cells for the write frame.
     /// 'from' is a pointer to the one-past-the-end of the new slice for the array of UWORDS to hold the frame's cells.
+    ///
+    /// # Safety
+    ///
+    /// `from` must be a valid pointer **one past the end** of a contiguous allocation
+    /// of at least `n` usizes.
     pub unsafe fn new_write(n: usize, from: *mut usize) -> Self {
         // Allocate a new vector of required size
         let mut frame = CFrameItem::new_unchecked();
@@ -39,9 +48,7 @@ impl CFrameItem {
 
 // Number of uwords required to hold n bits
 pub fn round_u_word(n: usize) -> usize {
-    unsafe {
-        (n + 8 * frame_ffi::c_sizeof_UWORD - 1) as usize / (8 * frame_ffi::c_sizeof_UWORD as usize)
-    }
+    unsafe { (n + 8 * frame_ffi::c_sizeof_UWORD - 1) / (8 * frame_ffi::c_sizeof_UWORD) }
 }
 
 pub fn ffi_bytes_size(n: usize) -> usize {

--- a/simplicity-sys/src/c_jets/exec_ffi.rs
+++ b/simplicity-sys/src/c_jets/exec_ffi.rs
@@ -1,6 +1,7 @@
 //! Execution related FFIs, only used for testing rust-simplicity
 //! Also exports test cases from C simplicity
 use std::os::raw::c_uchar;
+use std::slice;
 
 use libc::size_t;
 
@@ -41,18 +42,6 @@ pub fn parse_root(ptr: &[u32; 8]) -> [u8; 32] {
     a
 }
 
-pub fn parse_prog(ptr: *const u8, len: usize) -> Vec<u8> {
-    // Could construct from raw parts, but we just allocate because
-    // this is only used in tests
-    let mut v = Vec::with_capacity(len);
-    unsafe {
-        for i in 0..len {
-            v.push(*ptr.offset(i as isize));
-        }
-    }
-    v
-}
-
 /// Data structure to hold test cases from C simplicity
 pub struct TestData {
     pub cmr: [u8; 32],
@@ -67,7 +56,7 @@ pub fn schnorr0_test_data() -> TestData {
             cmr: parse_root(&schnorr0_cmr),
             amr: parse_root(&schnorr0_amr),
             imr: parse_root(&schnorr0_imr),
-            prog: parse_prog(schnorr0.as_ptr(), sizeof_schnorr0 as usize),
+            prog: slice::from_raw_parts(schnorr0.as_ptr(), sizeof_schnorr0).into(),
         }
     }
 }
@@ -78,7 +67,7 @@ pub fn schnorr6_test_data() -> TestData {
             cmr: parse_root(&schnorr6_cmr),
             amr: parse_root(&schnorr6_amr),
             imr: parse_root(&schnorr6_imr),
-            prog: parse_prog(schnorr6.as_ptr(), sizeof_schnorr6 as usize),
+            prog: slice::from_raw_parts(schnorr6.as_ptr(), sizeof_schnorr6).into(),
         }
     }
 }
@@ -89,7 +78,7 @@ pub fn hash_block_test_data() -> TestData {
             cmr: parse_root(&hashBlock_cmr),
             amr: parse_root(&hashBlock_amr),
             imr: parse_root(&hashBlock_imr),
-            prog: parse_prog(hashBlock.as_ptr(), sizeof_hashBlock as usize),
+            prog: slice::from_raw_parts(hashBlock.as_ptr(), sizeof_hashBlock).into(),
         }
     }
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -47,7 +47,7 @@ fn compute_extra_cells_bound<J: Jet>(
     right: Option<Rc<RedeemNode<J>>>,
     ty: &NodeType,
 ) -> usize {
-    match untyped_node.inner {
+    match untyped_node.inner() {
         CommitNodeInner::Iden
         | CommitNodeInner::Unit
         | CommitNodeInner::Fail(_, _)
@@ -86,7 +86,7 @@ fn compute_extra_frames_bound<J: Jet>(
     left: Option<Rc<RedeemNode<J>>>,
     right: Option<Rc<RedeemNode<J>>>,
 ) -> usize {
-    match untyped_node.inner {
+    match untyped_node.inner() {
         CommitNodeInner::Iden
         | CommitNodeInner::Unit
         | CommitNodeInner::Witness

--- a/src/bititer.rs
+++ b/src/bititer.rs
@@ -35,6 +35,28 @@ pub struct BitIter<I: Iterator<Item = u8>> {
     total_read: usize,
 }
 
+impl From<Vec<u8>> for BitIter<std::vec::IntoIter<u8>> {
+    fn from(v: Vec<u8>) -> Self {
+        BitIter {
+            iter: v.into_iter(),
+            cached_byte: 0,
+            read_bits: 8,
+            total_read: 0,
+        }
+    }
+}
+
+impl<'a> From<&'a [u8]> for BitIter<std::iter::Copied<std::slice::Iter<'a, u8>>> {
+    fn from(sl: &'a [u8]) -> Self {
+        BitIter {
+            iter: sl.iter().copied(),
+            cached_byte: 0,
+            read_bits: 8,
+            total_read: 0,
+        }
+    }
+}
+
 impl<I: Iterator<Item = u8>> From<I> for BitIter<I> {
     fn from(iter: I) -> Self {
         BitIter {

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -191,79 +191,77 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that computes the identity function.
     ///
     /// _Overall type: A → A_
-    pub fn iden(context: &mut Context<J>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Iden,
-            None,
-            None,
-            "Iden is of type A → A",
-        )
+    pub fn iden(context: &mut Context<J>) -> Rc<Self> {
+        let inner = CommitNodeInner::Iden;
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow: UnificationArrow::for_iden(&mut context.naming),
+        })
     }
 
     /// Create a DAG that returns the unit constant.
     ///
     /// _Overall type: A → 1_
-    pub fn unit(context: &mut Context<J>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Unit,
-            None,
-            None,
-            "Unit is of type A → 1",
-        )
+    pub fn unit(context: &mut Context<J>) -> Rc<Self> {
+        let inner = CommitNodeInner::Unit;
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow: UnificationArrow::for_unit(&mut context.naming),
+        })
     }
 
     /// Create a DAG that computes the left injection of the given `child`.
     ///
     /// _Overall type: A → B + C where `child`: A → B_
-    pub fn injl(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::InjL(child.clone()),
-            Some(child),
-            None,
-            "Injl is of type A → B + C where `child`: A → B",
-        )
+    pub fn injl(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+        let arrow = UnificationArrow::for_injl(&child, &mut context.naming);
+        let inner = CommitNodeInner::InjL(child);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow,
+        })
     }
 
     /// Create a DAG that computes the right injection of the given `child`.
     ///
     /// _Overall type: A → B + C where `child`: A → C_
-    pub fn injr(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::InjR(child.clone()),
-            Some(child),
-            None,
-            "Injr is of type A → B + C where `child`: A → C",
-        )
+    pub fn injr(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+        let arrow = UnificationArrow::for_injr(&child, &mut context.naming);
+        let inner = CommitNodeInner::InjR(child);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow,
+        })
     }
 
     /// Create a DAG with that computes _take_ of the given `child`.
     ///
     /// _Overall type: A × B → C where `child`: A → C_
-    pub fn take(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Take(child.clone()),
-            Some(child),
-            None,
-            "Take is of type A × B → C where `child`: A → C",
-        )
+    pub fn take(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+        let arrow = UnificationArrow::for_take(&child, &mut context.naming);
+        let inner = CommitNodeInner::Take(child);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow,
+        })
     }
 
     /// Create a DAG with that computes _drop_ of the given `child`.
     ///
     /// _Overall type: A × B → C where `child`: B → C_
-    pub fn drop(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Drop(child.clone()),
-            Some(child),
-            None,
-            "Drop is of type A × B → C where `child`: B → C",
-        )
+    pub fn drop(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+        let arrow = UnificationArrow::for_drop(&child, &mut context.naming);
+        let inner = CommitNodeInner::Drop(child);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow,
+        })
     }
 
     /// Create a DAG that computes the composition of the given `left` and `right` child.
@@ -394,28 +392,26 @@ impl<J: Jet> CommitNode<J> {
     /// The value is missing during commitment and inserted during redemption.
     ///
     /// _Overall type: A → B_
-    pub fn witness(context: &mut Context<J>) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Witness,
-            None,
-            None,
-            "Witness is of type A → B",
-        )
+    pub fn witness(context: &mut Context<J>) -> Rc<Self> {
+        let inner = CommitNodeInner::Witness;
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow: UnificationArrow::for_witness(&mut context.naming),
+        })
     }
 
     /// Create a DAG that universally fails.
     /// The given `left` and `right` hashes form a block for the CMR computation.
     ///
     /// _Overall type: A → B_
-    pub fn fail(context: &mut Context<J>, left: Cmr, right: Cmr) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Fail(left, right),
-            None,
-            None,
-            "Fail is of type A → B",
-        )
+    pub fn fail(context: &mut Context<J>, left: Cmr, right: Cmr) -> Rc<Self> {
+        let inner = CommitNodeInner::Fail(left, right);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow: UnificationArrow::for_fail(&mut context.naming),
+        })
     }
 
     /// Create a hidden DAG that contains the given `hash` as its CMR.
@@ -423,46 +419,47 @@ impl<J: Jet> CommitNode<J> {
     /// **This DAG must only be used as child for left or right assertions.**
     ///
     /// _The Bit Machine will crash upon seeing this node._
-    pub fn hidden(context: &mut Context<J>, hash: Cmr) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(
-            context,
-            CommitNodeInner::Hidden(hash),
-            None,
-            None,
-            "Hidden is of type A → B",
-        )
+    pub fn hidden(context: &mut Context<J>, hash: Cmr) -> Rc<Self> {
+        let inner = CommitNodeInner::Hidden(hash);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow: UnificationArrow::for_hidden(&mut context.naming),
+        })
     }
 
     /// Create a DAG that computes some black-box function that is associated with the given `jet`.
     ///
     /// _Overall type: A → B where jet: A → B_
-    pub fn jet(context: &mut Context<J>, jet: J) -> Result<Rc<Self>, Error> {
-        Self::node_from_inner(context,
-            CommitNodeInner::Jet(jet),
-            None,
-            None,
-            "Jet is of type A → B where `jet`: A → B. Check the jet definition for its source and target type.",
-        )
+    pub fn jet(_: &mut Context<J>, jet: J) -> Rc<Self> {
+        let arrow = UnificationArrow::for_jet(&jet);
+        let inner = CommitNodeInner::Jet(jet);
+        Rc::new(CommitNode {
+            cmr: Cmr::compute(&inner),
+            inner,
+            arrow,
+        })
     }
 
     /// Create a DAG that takes any input and returns `value` as constant output.
     ///
     /// _Overall type: A → B where value: B_
-    pub fn scribe(context: &mut Context<J>, value: &Value) -> Result<Rc<CommitNode<J>>, Error> {
+    pub fn scribe(context: &mut Context<J>, value: &Value) -> Rc<CommitNode<J>> {
         match value {
             Value::Unit => CommitNode::unit(context),
             Value::SumL(l) => {
-                let l = CommitNode::scribe(context, l)?;
+                let l = CommitNode::scribe(context, l);
                 CommitNode::injl(context, l)
             }
             Value::SumR(r) => {
-                let r = CommitNode::scribe(context, r)?;
+                let r = CommitNode::scribe(context, r);
                 CommitNode::injr(context, r)
             }
             Value::Prod(l, r) => {
-                let l = CommitNode::scribe(context, l)?;
-                let r = CommitNode::scribe(context, r)?;
+                let l = CommitNode::scribe(context, l);
+                let r = CommitNode::scribe(context, r);
                 CommitNode::pair(context, l, r)
+                    .expect("source of scribe has no constraints")
             }
         }
     }
@@ -470,16 +467,16 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that takes any input and returns bit `0` as constant output.
     ///
     /// _Overall type: A → 2_
-    pub fn bit_false(context: &mut Context<J>) -> Result<Rc<Self>, Error> {
-        let unit = Self::unit(context)?;
+    pub fn bit_false(context: &mut Context<J>) -> Rc<Self> {
+        let unit = Self::unit(context);
         Self::injl(context, unit)
     }
 
     /// Create a DAG that takes any input and returns bit `1` as constant output.
     ///
     /// _Overall type: A → 2_
-    pub fn bit_true(context: &mut Context<J>) -> Result<Rc<Self>, Error> {
-        let unit = Self::unit(context)?;
+    pub fn bit_true(context: &mut Context<J>) -> Rc<Self> {
+        let unit = Self::unit(context);
         Self::injr(context, unit)
     }
 
@@ -495,8 +492,8 @@ impl<J: Jet> CommitNode<J> {
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, Error> {
-        let drop_left = Self::drop(context, left)?;
-        let drop_right = Self::drop(context, right)?;
+        let drop_left = Self::drop(context, left);
+        let drop_right = Self::drop(context, right);
         Self::case(context, drop_right, drop_left)
     }
 
@@ -507,10 +504,10 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn assert(context: &mut Context<J>, child: Rc<Self>, hash: Cmr) -> Result<Rc<Self>, Error> {
-        let unit = Self::unit(context)?;
+        let unit = Self::unit(context);
         let pair_child_unit = Self::pair(context, child, unit)?;
-        let hidden = Self::hidden(context, hash)?;
-        let unit = Self::unit(context)?;
+        let hidden = Self::hidden(context, hash);
+        let unit = Self::unit(context);
         let assertr_hidden_unit = Self::assertr(context, hidden, unit)?;
 
         Self::comp(context, pair_child_unit, assertr_hidden_unit)
@@ -523,10 +520,10 @@ impl<J: Jet> CommitNode<J> {
     /// _Type inference will fail if children are not of the correct type._
     #[allow(clippy::should_implement_trait)]
     pub fn not(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, Error> {
-        let unit = Self::unit(context)?;
+        let unit = Self::unit(context);
         let pair_child_unit = Self::pair(context, child, unit)?;
-        let bit_true = Self::bit_true(context)?;
-        let bit_false = Self::bit_false(context)?;
+        let bit_true = Self::bit_true(context);
+        let bit_false = Self::bit_false(context);
         let case_true_false = Self::case(context, bit_true, bit_false)?;
 
         Self::comp(context, pair_child_unit, case_true_false)
@@ -542,10 +539,10 @@ impl<J: Jet> CommitNode<J> {
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, Error> {
-        let iden = Self::iden(context)?;
+        let iden = Self::iden(context);
         let pair_left_iden = Self::pair(context, left, iden)?;
-        let bit_false = Self::bit_false(context)?;
-        let drop_right = Self::drop(context, right)?;
+        let bit_false = Self::bit_false(context);
+        let drop_right = Self::drop(context, right);
         let case_false_right = Self::case(context, bit_false, drop_right)?;
 
         Self::comp(context, pair_left_iden, case_false_right)
@@ -561,10 +558,10 @@ impl<J: Jet> CommitNode<J> {
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, Error> {
-        let iden = Self::iden(context)?;
+        let iden = Self::iden(context);
         let pair_left_iden = Self::pair(context, left, iden)?;
-        let drop_right = Self::drop(context, right)?;
-        let bit_true = Self::bit_true(context)?;
+        let drop_right = Self::drop(context, right);
+        let bit_true = Self::bit_true(context);
         let case_right_true = Self::case(context, drop_right, bit_true)?;
 
         Self::comp(context, pair_left_iden, case_right_true)
@@ -734,7 +731,7 @@ mod tests {
     #[test]
     fn occurs_check_error() {
         let mut context = Context::<Core>::new();
-        let iden = CommitNode::iden(&mut context).unwrap();
+        let iden = CommitNode::iden(&mut context);
         let node = CommitNode::disconnect(&mut context, iden.clone(), iden).unwrap();
 
         if let Err(Error::OccursCheck) = node.finalize(std::iter::empty()) {
@@ -746,7 +743,7 @@ mod tests {
     #[test]
     fn type_check_error() {
         let mut context = Context::<Core>::new();
-        let unit = CommitNode::unit(&mut context).unwrap();
+        let unit = CommitNode::unit(&mut context);
         let case = CommitNode::case(&mut context, unit.clone(), unit.clone()).unwrap();
 
         if let Err(Error::TypeCheck { .. }) = CommitNode::disconnect(&mut context, case, unit) {

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -158,6 +158,13 @@ pub struct CommitNode<J: Jet> {
     pub arrow: UnificationArrow,
 }
 
+impl<J: Jet> PartialEq for CommitNode<J> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmr == other.cmr
+    }
+}
+impl<J: Jet> Eq for CommitNode<J> {}
+
 impl<J: Jet> CommitNode<J> {
     /// Create a node from its underlying combinator.
     fn node_from_inner(

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -17,6 +17,7 @@ use crate::bititer::BitIter;
 use crate::bitwriter::BitWriter;
 use crate::core::iter::{DagIterable, WitnessIterator};
 use crate::core::redeem::{NodeType, RedeemNodeInner};
+use crate::core::types::RcVar;
 use crate::core::{Context, RedeemNode, Value};
 use crate::inference::UnificationArrow;
 use crate::jet::Jet;
@@ -151,11 +152,11 @@ impl<J: Jet> fmt::Display for CommitNodeInner<J> {
 #[derive(Debug)]
 pub struct CommitNode<J: Jet> {
     /// Underlying combinator of the node
-    pub inner: CommitNodeInner<J>,
+    inner: CommitNodeInner<J>,
     /// Commitment Merkle root of the node
-    pub cmr: Cmr,
+    cmr: Cmr,
     /// Unification arrow of the node
-    pub arrow: UnificationArrow,
+    arrow: UnificationArrow,
 }
 
 impl<J: Jet> PartialEq for CommitNode<J> {
@@ -166,6 +167,31 @@ impl<J: Jet> PartialEq for CommitNode<J> {
 impl<J: Jet> Eq for CommitNode<J> {}
 
 impl<J: Jet> CommitNode<J> {
+    /// Accessor for the node's "inner value", i.e. its combinator
+    pub fn inner(&self) -> &CommitNodeInner<J> {
+        &self.inner
+    }
+
+    /// Accessor for the node's CMR
+    pub fn cmr(&self) -> Cmr {
+        self.cmr
+    }
+
+    /// Accessor for the nodes's unification arrow
+    pub fn unification_arrow(&self) -> &UnificationArrow {
+        &self.arrow
+    }
+
+    /// Accessor for the node's source type
+    pub(crate) fn source_ty(&self) -> RcVar {
+        self.arrow.source_ty()
+    }
+
+    /// Accessor for the node's target type
+    pub(crate) fn target_ty(&self) -> RcVar {
+        self.arrow.target_ty()
+    }
+
     /// Create a node from its underlying combinator.
     fn node_from_inner(
         context: &mut Context<J>,

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -23,7 +23,7 @@ use crate::jet::Jet;
 use crate::merkle::amr::Amr;
 use crate::merkle::cmr::Cmr;
 use crate::merkle::imr::Imr;
-use crate::{analysis, decode, impl_ref_wrapper, inference, Error};
+use crate::{analysis, decode, impl_ref_wrapper, Error};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::rc::Rc;
@@ -174,7 +174,7 @@ impl<J: Jet> CommitNode<J> {
         _right: Option<Rc<CommitNode<J>>>,
         hint: &'static str,
     ) -> Result<Rc<CommitNode<J>>, Error> {
-        match inference::get_arrow(&inner, &mut context.naming) {
+        match UnificationArrow::for_node(&inner, &mut context.naming) {
             Ok(arrow) => Ok(Rc::new(CommitNode {
                 cmr: Cmr::compute(&inner),
                 inner,

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -452,8 +452,7 @@ impl<J: Jet> CommitNode<J> {
             Value::Prod(l, r) => {
                 let l = CommitNode::scribe(context, l);
                 let r = CommitNode::scribe(context, r);
-                CommitNode::pair(context, l, r)
-                    .expect("source of scribe has no constraints")
+                CommitNode::pair(context, l, r).expect("source of scribe has no constraints")
             }
         }
     }

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -311,19 +311,16 @@ impl<J: Jet> CommitNode<J> {
     pub fn assertl(
         context: &mut Context<J>,
         left: Rc<Self>,
-        right: Rc<Self>,
+        right: Cmr,
     ) -> Result<Rc<Self>, Error> {
-        if let CommitNodeInner::Hidden(_) = right.inner {
-            Self::node_from_inner(
-                context,
-                CommitNodeInner::AssertL(left.clone(), right.clone()),
-                Some(left),
-                Some(right),
-                "Assertl is of type (A + B) × C → D where `left`: A × C → D",
-            )
-        } else {
-            Err(Error::RightChildNotHidden)
-        }
+        let right = Self::hidden(context, right);
+        Self::node_from_inner(
+            context,
+            CommitNodeInner::AssertL(left.clone(), right.clone()),
+            Some(left),
+            Some(right),
+            "Assertl is of type (A + B) × C → D where `left`: A × C → D",
+        )
     }
 
     /// Create a DAG that computes the right assertion of the given `right` child.
@@ -334,20 +331,17 @@ impl<J: Jet> CommitNode<J> {
     /// _Type inference will fail if children are not of the correct type._
     pub fn assertr(
         context: &mut Context<J>,
-        left: Rc<Self>,
+        left: Cmr,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, Error> {
-        if let CommitNodeInner::Hidden(_) = left.inner {
-            Self::node_from_inner(
-                context,
-                CommitNodeInner::AssertR(left.clone(), right.clone()),
-                Some(left),
-                Some(right),
-                "Assertr is of type (A + B) × C → D where `right`: B × C → D",
-            )
-        } else {
-            Err(Error::LeftChildNotHidden)
-        }
+        let left = Self::hidden(context, left);
+        Self::node_from_inner(
+            context,
+            CommitNodeInner::AssertR(left.clone(), right.clone()),
+            Some(left),
+            Some(right),
+            "Assertr is of type (A + B) × C → D where `right`: B × C → D",
+        )
     }
 
     /// Create a DAG that computes the pair of the given `left` and `right` child.
@@ -506,9 +500,8 @@ impl<J: Jet> CommitNode<J> {
     pub fn assert(context: &mut Context<J>, child: Rc<Self>, hash: Cmr) -> Result<Rc<Self>, Error> {
         let unit = Self::unit(context);
         let pair_child_unit = Self::pair(context, child, unit)?;
-        let hidden = Self::hidden(context, hash);
         let unit = Self::unit(context);
-        let assertr_hidden_unit = Self::assertr(context, hidden, unit)?;
+        let assertr_hidden_unit = Self::assertr(context, hash, unit)?;
 
         Self::comp(context, pair_child_unit, assertr_hidden_unit)
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -129,16 +129,16 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
                     match subcode {
                         0 => CommitNode::comp(context, left, right),
                         1 => {
-                            if let CommitNodeInner::Hidden(..) = left.inner {
-                                if let CommitNodeInner::Hidden(..) = right.inner {
+                            if let CommitNodeInner::Hidden(..) = left.inner() {
+                                if let CommitNodeInner::Hidden(..) = right.inner() {
                                     return Err(Error::CaseMultipleHiddenChildren);
                                 }
                             }
 
-                            if let CommitNodeInner::Hidden(right_hash) = right.inner {
-                                CommitNode::assertl(context, left, right_hash)
-                            } else if let CommitNodeInner::Hidden(left_hash) = left.inner {
-                                CommitNode::assertr(context, left_hash, right)
+                            if let CommitNodeInner::Hidden(right_hash) = right.inner() {
+                                CommitNode::assertl(context, left, *right_hash)
+                            } else if let CommitNodeInner::Hidden(left_hash) = left.inner() {
+                                CommitNode::assertr(context, *left_hash, right)
                             } else {
                                 CommitNode::case(context, left, right)
                             }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -151,13 +151,13 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
                 1 => {
                     index_dag.push((Some(i_abs), None));
 
-                    match subcode {
+                    Ok(match subcode {
                         0 => CommitNode::injl(context, left),
                         1 => CommitNode::injr(context, left),
                         2 => CommitNode::take(context, left),
                         3 => CommitNode::drop(context, left),
                         _ => unreachable!("2-bit subcode"),
-                    }
+                    })
                 }
                 _ => unreachable!("code < 2"),
             }
@@ -168,12 +168,12 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
             match maybe_code {
                 None => match bits.next() {
                     None => return Err(Error::EndOfStream),
-                    Some(true) => CommitNode::jet(context, J::decode(bits)?),
+                    Some(true) => Ok(CommitNode::jet(context, J::decode(bits)?)),
                     Some(false) => {
                         return Err(Error::ParseError("we don't yet support const words"))
                     }
                 },
-                Some(2) => match subcode {
+                Some(2) => Ok(match subcode {
                     0 => CommitNode::iden(context),
                     1 => CommitNode::unit(context),
                     2 => CommitNode::fail(
@@ -183,13 +183,13 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
                     ),
                     3 => return Err(Error::ParseError("01011 (stop code)")),
                     _ => unreachable!("2-bit subcode"),
-                },
-                Some(3) => match subcode {
+                }),
+                Some(3) => Ok(match subcode {
                     0 => CommitNode::hidden(context, Cmr::from(decode_hash(bits)?)),
                     1 if fresh_witness => return Ok(()),
                     1 => CommitNode::witness(context),
                     _ => unreachable!("1-bit subcode"),
-                },
+                }),
                 Some(_) => unreachable!("2-bit code"),
             }
         }
@@ -212,7 +212,7 @@ fn get_child_from_index<J: Jet>(
     match index_to_node.get(&index) {
         Some(child) => child.clone(),
         // Absence of child means that child is a skipped witness node
-        None => CommitNode::witness(context).unwrap(),
+        None => CommitNode::witness(context),
     }
 }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -135,10 +135,10 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
                                 }
                             }
 
-                            if let CommitNodeInner::Hidden(..) = right.inner {
-                                CommitNode::assertl(context, left, right)
-                            } else if let CommitNodeInner::Hidden(..) = left.inner {
-                                CommitNode::assertr(context, left, right)
+                            if let CommitNodeInner::Hidden(right_hash) = right.inner {
+                                CommitNode::assertl(context, left, right_hash)
+                            } else if let CommitNodeInner::Hidden(left_hash) = left.inner {
+                                CommitNode::assertr(context, left_hash, right)
                             } else {
                                 CommitNode::case(context, left, right)
                             }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -316,7 +316,7 @@ impl UnificationArrow {
                     CommitNodeInner::AssertL(..) => {
                         bind(
                             &find_root(lchild.arrow.source.clone()),
-                            VariableType::Product(a, c.clone()),
+                            VariableType::Product(a, c),
                             "Case: Left source = A × C",
                         )?;
                         lchild.arrow.target.clone()
@@ -375,8 +375,8 @@ impl UnificationArrow {
 
                 let pow2s = Variable::powers_of_two();
                 let prod_256_a = VariableType::Product(pow2s[8].clone(), a.clone());
-                let prod_b_c = VariableType::Product(b.clone(), c.clone());
-                let prod_b_d = VariableType::Product(b, d.clone());
+                let prod_b_c = VariableType::Product(b.clone(), c);
+                let prod_b_d = VariableType::Product(b, d);
 
                 bind(
                     &lchild.arrow.source,
@@ -390,7 +390,7 @@ impl UnificationArrow {
                 )?;
 
                 Ok(UnificationArrow {
-                    source: a.clone(),
+                    source: a,
                     target: Variable::bound(prod_b_d),
                 })
             }

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -83,7 +83,7 @@ fn unify(mut x: RcVar, mut y: RcVar, hint: &'static str) -> Result<(), Error> {
 /// Fails if `x` is already bound to a type that is incompatible with `ty`.
 fn bind(x: &RcVar, ty: VariableType, hint: &'static str) -> Result<(), Error> {
     // Clone inner to un-borrow the root; see comment inside `find_root` for more explanation
-    let x_var = find_root(x.clone()).borrow().inner.clone(); //x.borrow().inner.clone();
+    let x_var = find_root(x.clone()).borrow().inner.clone();
     match x_var {
         VariableInner::Free(_) => {
             x.borrow_mut().inner = VariableInner::Bound(ty, false);
@@ -240,10 +240,7 @@ impl UnificationArrow {
     pub(crate) fn for_injl<J: Jet>(child: &CommitNode<J>, naming: &mut VariableFactory) -> Self {
         // Again, we "unify" by just cloning Rcs
         let source = child.source_ty();
-        let target = Variable::bound(VariableType::Sum(
-            child.target_ty(),
-            naming.free_variable(),
-        ));
+        let target = Variable::bound(VariableType::Sum(child.target_ty(), naming.free_variable()));
         UnificationArrow { source, target }
     }
 
@@ -251,10 +248,7 @@ impl UnificationArrow {
     pub(crate) fn for_injr<J: Jet>(child: &CommitNode<J>, naming: &mut VariableFactory) -> Self {
         // Again, we "unify" by just cloning Rcs
         let source = child.source_ty();
-        let target = Variable::bound(VariableType::Sum(
-            naming.free_variable(),
-            child.target_ty(),
-        ));
+        let target = Variable::bound(VariableType::Sum(naming.free_variable(), child.target_ty()));
         UnificationArrow { source, target }
     }
 
@@ -325,7 +319,7 @@ impl UnificationArrow {
                 let target = match node {
                     CommitNodeInner::AssertL(..) => {
                         bind(
-                            &find_root(lchild.source_ty()),
+                            &lchild.source_ty(),
                             VariableType::Product(a, c),
                             "Case: Left source = A × C",
                         )?;
@@ -333,7 +327,7 @@ impl UnificationArrow {
                     }
                     CommitNodeInner::AssertR(..) => {
                         bind(
-                            &find_root(rchild.source_ty()),
+                            &rchild.source_ty(),
                             VariableType::Product(b, c),
                             "Case: Right source = B × C",
                         )?;
@@ -341,12 +335,12 @@ impl UnificationArrow {
                     }
                     CommitNodeInner::Case(..) => {
                         bind(
-                            &find_root(lchild.source_ty()),
+                            &lchild.source_ty(),
                             VariableType::Product(a, c.clone()),
                             "Case: Left source = A × C",
                         )?;
                         bind(
-                            &find_root(rchild.source_ty()),
+                            &rchild.source_ty(),
                             VariableType::Product(b, c),
                             "Case: Right source = B × C",
                         )?;

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -227,53 +227,45 @@ impl UnificationArrow {
     }
 
     /// Create a unification arrow for a fresh jet combinator
-    pub(crate) fn for_injl<J: Jet>(
-        child: &CommitNode<J>,
-        naming: &mut VariableFactory
-    ) -> Self {
+    pub(crate) fn for_injl<J: Jet>(child: &CommitNode<J>, naming: &mut VariableFactory) -> Self {
         // Again, we "unify" by just cloning Rcs
         let source = child.arrow.source.clone();
-        let target = Variable::bound(
-            VariableType::Sum(child.arrow.target.clone(), naming.free_variable()),
-        );
+        let target = Variable::bound(VariableType::Sum(
+            child.arrow.target.clone(),
+            naming.free_variable(),
+        ));
         UnificationArrow { source, target }
     }
 
     /// Create a unification arrow for a fresh jet combinator
-    pub(crate) fn for_injr<J: Jet>(
-        child: &CommitNode<J>,
-        naming: &mut VariableFactory
-    ) -> Self {
+    pub(crate) fn for_injr<J: Jet>(child: &CommitNode<J>, naming: &mut VariableFactory) -> Self {
         // Again, we "unify" by just cloning Rcs
         let source = child.arrow.source.clone();
-        let target = Variable::bound(
-            VariableType::Sum(naming.free_variable(), child.arrow.target.clone()),
-        );
+        let target = Variable::bound(VariableType::Sum(
+            naming.free_variable(),
+            child.arrow.target.clone(),
+        ));
         UnificationArrow { source, target }
     }
 
     /// Create a unification arrow for a fresh jet combinator
-    pub(crate) fn for_take<J: Jet>(
-        child: &CommitNode<J>,
-        naming: &mut VariableFactory
-    ) -> Self {
+    pub(crate) fn for_take<J: Jet>(child: &CommitNode<J>, naming: &mut VariableFactory) -> Self {
         // Again, we "unify" by just cloning Rcs
-        let source = Variable::bound(
-            VariableType::Product(child.arrow.source.clone(), naming.free_variable()),
-        );
+        let source = Variable::bound(VariableType::Product(
+            child.arrow.source.clone(),
+            naming.free_variable(),
+        ));
         let target = child.arrow.target.clone();
         UnificationArrow { source, target }
     }
 
     /// Create a unification arrow for a fresh jet combinator
-    pub(crate) fn for_drop<J: Jet>(
-        child: &CommitNode<J>,
-        naming: &mut VariableFactory
-    ) -> Self {
+    pub(crate) fn for_drop<J: Jet>(child: &CommitNode<J>, naming: &mut VariableFactory) -> Self {
         // Again, we "unify" by just cloning Rcs
-        let source = Variable::bound(
-            VariableType::Product(naming.free_variable(), child.arrow.source.clone()),
-        );
+        let source = Variable::bound(VariableType::Product(
+            naming.free_variable(),
+            child.arrow.source.clone(),
+        ));
         let target = child.arrow.target.clone();
         UnificationArrow { source, target }
     }
@@ -308,7 +300,7 @@ impl UnificationArrow {
                     "Composition: Left target = right source",
                 )?;
                 Ok(arrow)
-            },
+            }
             CommitNodeInner::Case(ref lchild, ref rchild)
             | CommitNodeInner::AssertL(ref lchild, ref rchild)
             | CommitNodeInner::AssertR(ref lchild, ref rchild) => {
@@ -328,7 +320,7 @@ impl UnificationArrow {
                             "Case: Left source = A × C",
                         )?;
                         lchild.arrow.target.clone()
-                    },
+                    }
                     CommitNodeInner::AssertR(..) => {
                         bind(
                             &find_root(rchild.arrow.source.clone()),
@@ -336,7 +328,7 @@ impl UnificationArrow {
                             "Case: Right source = B × C",
                         )?;
                         rchild.arrow.target.clone()
-                    },
+                    }
                     CommitNodeInner::Case(..) => {
                         bind(
                             &find_root(lchild.arrow.source.clone()),
@@ -354,12 +346,12 @@ impl UnificationArrow {
                             "Case: Left target = right target",
                         )?;
                         rchild.arrow.target.clone()
-                    },
+                    }
                     _ => unreachable!(),
                 };
 
                 Ok(UnificationArrow { source, target })
-            },
+            }
             CommitNodeInner::Pair(ref lchild, ref rchild) => {
                 unify(
                     lchild.arrow.source.clone(),
@@ -374,7 +366,7 @@ impl UnificationArrow {
                         rchild.arrow.target.clone(),
                     )),
                 })
-            },
+            }
             CommitNodeInner::Disconnect(ref lchild, ref rchild) => {
                 let a = naming.free_variable();
                 let b = naming.free_variable();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,10 +77,6 @@ pub enum Error {
     NonCaseHiddenChild,
     /// 'case' nodes may have at most one hidden child
     CaseMultipleHiddenChildren,
-    /// Right child of left assertion must be hidden
-    RightChildNotHidden,
-    /// Left child of right assertion must be hidden
-    LeftChildNotHidden,
     /// Bitstream ended early
     EndOfStream,
     /// Program must not be empty
@@ -126,12 +122,6 @@ impl fmt::Debug for Error {
             }
             Error::CaseMultipleHiddenChildren => {
                 f.write_str("'case' nodes may have at most one hidden child")
-            }
-            Error::RightChildNotHidden => {
-                f.write_str("The right child of a left assertion must be a hidden node")
-            }
-            Error::LeftChildNotHidden => {
-                f.write_str("The left child of a right assertion must be a hidden node")
             }
             Error::EndOfStream => f.write_str("Bitstream ended early"),
             Error::EmptyProgram => f.write_str("Program must not be empty"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,7 @@ pub mod bit_machine;
 pub mod bititer;
 pub mod bitwriter;
 pub mod core;
-#[cfg(fuzzing)]
-pub mod decode;
-#[cfg(not(fuzzing))]
 mod decode;
-#[cfg(fuzzing)]
-pub mod encode;
-#[cfg(not(fuzzing))]
 mod encode;
 mod inference;
 pub mod jet;
@@ -56,6 +50,8 @@ pub use crate::policy::Policy;
 
 pub use crate::bit_machine::exec;
 pub use crate::core::{CommitNode, Context, RedeemNode};
+pub use crate::decode::{decode_natural, WitnessDecoder};
+pub use crate::encode::{encode_natural, encode_witness};
 pub use simplicity_sys as ffi;
 use std::fmt;
 

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -74,12 +74,12 @@ impl Cmr {
             | CommitNodeInner::InjR(l)
             | CommitNodeInner::Take(l)
             | CommitNodeInner::Drop(l)
-            | CommitNodeInner::Disconnect(l, _) => cmr_iv.update_1(l.cmr),
+            | CommitNodeInner::Disconnect(l, _) => cmr_iv.update_1(l.cmr()),
             CommitNodeInner::Comp(l, r)
             | CommitNodeInner::Case(l, r)
             | CommitNodeInner::Pair(l, r)
             | CommitNodeInner::AssertL(l, r)
-            | CommitNodeInner::AssertR(l, r) => cmr_iv.update(l.cmr, r.cmr),
+            | CommitNodeInner::AssertR(l, r) => cmr_iv.update(l.cmr(), r.cmr()),
         }
     }
 }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -55,7 +55,11 @@ pub fn compile<Pk: MiniscriptKey + PublicKey32>(
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
     match policy {
         // TODO: Choose specific Merkle roots for unsatisfiable policies
-        Policy::Unsatisfiable => Ok(CommitNode::fail(context, Cmr::from([0; 32]), Cmr::from([0; 32]))),
+        Policy::Unsatisfiable => Ok(CommitNode::fail(
+            context,
+            Cmr::from([0; 32]),
+            Cmr::from([0; 32]),
+        )),
         Policy::Trivial => Ok(CommitNode::unit(context)),
         Policy::Key(key) => {
             let key_value = Value::u256_from_slice(&key.to_32_bytes());

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -30,11 +30,11 @@ fn compute_sha256(
     context: &mut Context<Elements>,
     witness256: Rc<CommitNode<Elements>>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
-    let ctx = CommitNode::jet(context, Elements::Sha256Ctx8Init)?;
+    let ctx = CommitNode::jet(context, Elements::Sha256Ctx8Init);
     let pair_ctx_witness = CommitNode::pair(context, ctx, witness256)?;
-    let add256 = CommitNode::jet(context, Elements::Sha256Ctx8Add32)?;
+    let add256 = CommitNode::jet(context, Elements::Sha256Ctx8Add32);
     let digest_ctx = CommitNode::comp(context, pair_ctx_witness, add256)?;
-    let finalize = CommitNode::jet(context, Elements::Sha256Ctx8Finalize)?;
+    let finalize = CommitNode::jet(context, Elements::Sha256Ctx8Finalize);
     CommitNode::comp(context, digest_ctx, finalize)
 }
 
@@ -44,7 +44,7 @@ fn verify_bexp(
     bexp: Rc<CommitNode<Elements>>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
     let computed_bexp = CommitNode::comp(context, input, bexp)?;
-    let verify = CommitNode::jet(context, Elements::Verify)?;
+    let verify = CommitNode::jet(context, Elements::Verify);
     CommitNode::comp(context, computed_bexp, verify)
 }
 
@@ -55,40 +55,40 @@ pub fn compile<Pk: MiniscriptKey + PublicKey32>(
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
     match policy {
         // TODO: Choose specific Merkle roots for unsatisfiable policies
-        Policy::Unsatisfiable => CommitNode::fail(context, Cmr::from([0; 32]), Cmr::from([0; 32])),
-        Policy::Trivial => CommitNode::unit(context),
+        Policy::Unsatisfiable => Ok(CommitNode::fail(context, Cmr::from([0; 32]), Cmr::from([0; 32]))),
+        Policy::Trivial => Ok(CommitNode::unit(context)),
         Policy::Key(key) => {
             let key_value = Value::u256_from_slice(&key.to_32_bytes());
-            let scribe_key = CommitNode::scribe(context, &key_value)?;
-            let sighash_all = CommitNode::jet(context, Elements::SigAllHash)?;
+            let scribe_key = CommitNode::scribe(context, &key_value);
+            let sighash_all = CommitNode::jet(context, Elements::SigAllHash);
             let pair_key_msg = CommitNode::pair(context, scribe_key, sighash_all)?;
-            let witness = CommitNode::witness(context)?;
+            let witness = CommitNode::witness(context);
             let pair_key_msg_sig = CommitNode::pair(context, pair_key_msg, witness)?;
-            let bip_0340_verify = CommitNode::jet(context, Elements::Bip0340Verify)?;
+            let bip_0340_verify = CommitNode::jet(context, Elements::Bip0340Verify);
 
             CommitNode::comp(context, pair_key_msg_sig, bip_0340_verify)
         }
         Policy::After(n) => {
             let n_value = Value::u32(*n);
-            let scribe_n = CommitNode::scribe(context, &n_value)?;
-            let check_lock_height = CommitNode::jet(context, Elements::CheckLockHeight)?;
+            let scribe_n = CommitNode::scribe(context, &n_value);
+            let check_lock_height = CommitNode::jet(context, Elements::CheckLockHeight);
 
             CommitNode::comp(context, scribe_n, check_lock_height)
         }
         Policy::Older(n) => {
             let n_value = Value::u16(*n);
-            let scribe_n = CommitNode::scribe(context, &n_value)?;
-            let check_lock_distance = CommitNode::jet(context, Elements::CheckLockDistance)?;
+            let scribe_n = CommitNode::scribe(context, &n_value);
+            let check_lock_distance = CommitNode::jet(context, Elements::CheckLockDistance);
 
             CommitNode::comp(context, scribe_n, check_lock_distance)
         }
         Policy::Sha256(hash) => {
             let hash_value = Value::u256_from_slice(&Pk::hash_to_32_bytes(hash));
-            let scribe_hash = CommitNode::scribe(context, &hash_value)?;
-            let witness256 = CommitNode::witness(context)?;
+            let scribe_hash = CommitNode::scribe(context, &hash_value);
+            let witness256 = CommitNode::witness(context);
             let computed_hash = compute_sha256(context, witness256)?;
             let pair_hash_computed_hash = CommitNode::pair(context, scribe_hash, computed_hash)?;
-            let eq256 = CommitNode::jet(context, Elements::Eq256)?;
+            let eq256 = CommitNode::jet(context, Elements::Eq256);
 
             verify_bexp(context, pair_hash_computed_hash, eq256)
         }
@@ -121,8 +121,8 @@ pub fn compile<Pk: MiniscriptKey + PublicKey32>(
             let right = compile(context, &sub_policies[1])?;
 
             let cond_right_left = CommitNode::cond(context, right, left)?;
-            let witness = CommitNode::witness(context)?;
-            let unit = CommitNode::unit(context)?;
+            let witness = CommitNode::witness(context);
+            let unit = CommitNode::unit(context);
             let selector = CommitNode::pair(context, witness, unit)?;
 
             CommitNode::comp(context, selector, cond_right_left)
@@ -134,18 +134,18 @@ pub fn compile<Pk: MiniscriptKey + PublicKey32>(
             );
 
             // 1 → 2^32
-            let scribe_zero = CommitNode::scribe(context, &Value::u32(0))?;
+            let scribe_zero = CommitNode::scribe(context, &Value::u32(0));
             // 1 → 2^32
-            let scribe_one = CommitNode::scribe(context, &Value::u32(1))?;
+            let scribe_one = CommitNode::scribe(context, &Value::u32(1));
 
             // 1 → 2^32
             let get_summand = |policy: &Policy<Pk>, context: &mut Context<Elements>| {
                 // 1 → 1
                 let child = compile(context, policy)?;
                 // 1 → 2
-                let witness = CommitNode::witness(context)?;
+                let witness = CommitNode::witness(context);
                 // 1 → 1
-                let unit = CommitNode::unit(context)?;
+                let unit = CommitNode::unit(context);
                 // 1 → 2 x 1
                 let selector = CommitNode::pair(context, witness, unit)?;
                 // 1 → 2^32
@@ -164,13 +164,13 @@ pub fn compile<Pk: MiniscriptKey + PublicKey32>(
                 // 1 → 2^32 × 2^32
                 let pair_sum_summand = CommitNode::pair(context, sum, summand)?;
                 // 2^32 × 2^32 → 2 × 2^32
-                let add32 = CommitNode::jet(context, Elements::Add32)?;
+                let add32 = CommitNode::jet(context, Elements::Add32);
                 // 1 → 2 x 2^32
                 let full_sum = CommitNode::comp(context, pair_sum_summand, add32)?;
                 // 2^32 → 2^32
-                let iden = CommitNode::iden(context)?;
+                let iden = CommitNode::iden(context);
                 // 2 × 2^32 → 2^32
-                let drop_iden = CommitNode::drop(context, iden)?;
+                let drop_iden = CommitNode::drop(context, iden);
 
                 // Discard the overflow bit.
                 // FIXME: enforce that sum of weights is less than 2^32
@@ -179,11 +179,11 @@ pub fn compile<Pk: MiniscriptKey + PublicKey32>(
             }
 
             // 1 → 2^32
-            let scribe_k = CommitNode::scribe(context, &Value::u32(*k as u32))?;
+            let scribe_k = CommitNode::scribe(context, &Value::u32(*k as u32));
             // 1 → 2^32 × 2^32
             let pair_k_sum = CommitNode::pair(context, scribe_k, sum)?;
             // 2^32 × 2^32 → 2
-            let eq32 = CommitNode::jet(context, Elements::Eq32)?;
+            let eq32 = CommitNode::jet(context, Elements::Eq32);
 
             // 1 → 1
             verify_bexp(context, pair_k_sum, eq32)


### PR DESCRIPTION
Right now our type inference logic is far too eager to use the `?` operator even for error paths that are logically impossible. This PR refactors a bunch of things so that the constructors for most of the `CommitNode` nodes are infallible, `scribe` is infallible, etc., which eliminates a lot of downstream error-checking code.