### PR TITLE
Satisfy threshold policy

### DIFF
--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -552,6 +552,22 @@ impl<J: Jet> CommitNode<J> {
         Self::case(context, drop_right, drop_left)
     }
 
+    pub fn cond_branch(
+        context: &mut Context<J>,
+        left: Rc<Self>,
+        right: Rc<Self>,
+        branch: UsedCaseBranch,
+    ) -> Result<Rc<Self>, Error> {
+        let drop_left = Self::drop(context, left);
+        let drop_right = Self::drop(context, right);
+
+        match branch {
+            UsedCaseBranch::Left => Self::assertr(context, drop_right.cmr, drop_left),
+            UsedCaseBranch::Right => Self::assertl(context, drop_right, drop_left.cmr),
+            UsedCaseBranch::Both => Self::case(context, drop_right, drop_left),
+        }
+    }
+
     /// Create a DAG that asserts that its child returns `true`, and fails otherwise.
     /// The `hash` identifies the assertion and is returned upon failure.
     ///

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -449,16 +449,16 @@ mod tests {
             .map(|x| satisfier.preimages.get(x).unwrap())
             .collect();
 
-        let assert_branch = |policy: &Policy<bitcoin::XOnlyPublicKey>, branch: u8| {
+        let assert_branch = |policy: &Policy<bitcoin::XOnlyPublicKey>, bit: bool| {
             let program = policy.satisfy(&satisfier).expect("satisfiable");
             let witness = to_witness(&program);
             assert_eq!(2, witness.len());
 
-            assert_eq!(&Value::u1(branch), witness[0]);
+            assert_eq!(&Value::u1(bit as u8), witness[0]);
             let preimage_bytes = witness[1].try_to_bytes().expect("to bytes");
             let witness_preimage =
                 Preimage32::try_from(preimage_bytes.as_slice()).expect("to array");
-            assert_eq!(preimages[branch as usize], &witness_preimage);
+            assert_eq!(preimages[bit as usize], &witness_preimage);
 
             execute_successful(program, &satisfier.env);
         };
@@ -466,7 +466,7 @@ mod tests {
         // Policy 0
 
         let policy0 = Policy::Or(vec![Policy::Sha256(images[0]), Policy::Sha256(images[1])]);
-        assert_branch(&policy0, 0);
+        assert_branch(&policy0, false);
 
         // Policy 1
 
@@ -474,7 +474,7 @@ mod tests {
             Policy::Sha256(images[0]),
             Policy::Sha256(sha256::Hash::from_inner([1; 32])),
         ]);
-        assert_branch(&policy1, 0);
+        assert_branch(&policy1, false);
 
         // Policy 2
 
@@ -482,7 +482,7 @@ mod tests {
             Policy::Sha256(sha256::Hash::from_inner([0; 32])),
             Policy::Sha256(images[1]),
         ]);
-        assert_branch(&policy2, 1);
+        assert_branch(&policy2, true);
 
         // Policy 3
 


### PR DESCRIPTION
Adds satisfier for threshold policy. This is a little involved because of optimization.

First the `k` cheapest satisfiable children are determined. Those are sorted by index. Finally the satisfier goes through all children in index order and uses the satisfiable ones.