### PR TITLE
imr: fix IMR computation for constant words

### DIFF
--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -68,7 +68,7 @@ impl Cmr {
     // FIXME avoid calling `powers_of_two_vec`; also replace this "construct the scribe then
     //  compute its CMR" logic with the inline algorithm from the C code, which avoids any
     //  allocations.
-    fn const_word_cmr(v: &Value) -> Cmr {
+    pub fn const_word_cmr(v: &Value) -> Cmr {
         assert_eq!(v.len().count_ones(), 1);
         let w = 1 + v.len().trailing_zeros() as usize;
         // 1. compute scribe pass-one IMR

--- a/src/merkle/imr.rs
+++ b/src/merkle/imr.rs
@@ -84,8 +84,8 @@ impl Imr {
             CommitNodeInner::Iden
             | CommitNodeInner::Unit
             | CommitNodeInner::Hidden(..)
-            | CommitNodeInner::Jet(..)
-            | CommitNodeInner::Word(..) => imr_iv,
+            | CommitNodeInner::Jet(..) => imr_iv,
+            CommitNodeInner::Word(ref value) => Cmr::const_word_cmr(value).into_inner().into(),
             CommitNodeInner::Fail(left, right) => imr_iv.update(left.into(), right.into()),
             CommitNodeInner::InjL(_)
             | CommitNodeInner::InjR(_)


### PR DESCRIPTION
The IMR of a constant word is the same as its CMR; our code was using the CMR *initialization vector*, since for other "same as CMR" cases (jets, hidden, etc) means "same as CMR IV". For words, not so.