### PR TITLE
encode: share witness data when it is repeated

### DIFF
--- a/src/bitwriter.rs
+++ b/src/bitwriter.rs
@@ -84,9 +84,11 @@ impl<W: io::Write> BitWriter<W> {
     /// Write out all cached bits.
     /// This may write up to two bytes and flushes the underlying [`io::Write`].
     pub fn flush_all(&mut self) -> io::Result<()> {
-        self.w.write_all(&[self.cache])?;
-        self.cache_len = 0;
-        self.cache = 0;
+        if self.cache_len > 0 {
+            self.w.write_all(&[self.cache])?;
+            self.cache_len = 0;
+            self.cache = 0;
+        }
 
         io::Write::flush(&mut self.w)
     }


### PR DESCRIPTION
There are three bugs in our `RedeemNode` encoding logic:
* We forgot to flush the `BitWriter` after writing, meaning that sometimes trailing bits would not get written.
* Flushing a `BitWriter` always writes a byte to the underlying writer even if there is nothing to write.
* We used sharing logic when encoding program nodes but not witnesses. In the case of repeated witnesses, this means that we would sometimes encode witnesses that we were not supposed to.

This fixes all three bugs and adds unit tests that both encoding and decoding work correctly.
