### PR TITLE
Redo iteration logic

### DIFF
--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -15,10 +15,10 @@
 
 use crate::bititer::BitIter;
 use crate::bitwriter::BitWriter;
-use crate::core::iter::{DagIterable, PostOrderIter, WitnessIterator};
+use crate::core::iter::{DagIterable, WitnessIterator};
 use crate::core::redeem::RedeemNodeInner;
 use crate::core::{Context, RedeemNode, Value};
-use crate::dag::DagLike;
+use crate::dag::{DagLike, PostOrderIter};
 use crate::jet::Jet;
 use crate::merkle::amr::Amr;
 use crate::merkle::cmr::Cmr;
@@ -150,8 +150,8 @@ impl<J: Jet> CommitNode<J> {
     }
 
     /// Return an iterator over the unshared nodes of the program
-    pub fn iter(&self) -> PostOrderIter<self::RefWrapper<J>> {
-        RefWrapper(self).iter_post_order()
+    pub fn iter(&self) -> PostOrderIter<&Self> {
+        <&Self as DagLike>::post_order_iter(self)
     }
 
     // FIXME: Compute length without iterating over entire DAG?
@@ -798,9 +798,9 @@ impl<J: Jet> CommitNode<J> {
 
 impl<J: Jet> fmt::Display for CommitNode<J> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        RefWrapper(self).display(
+        self.iter().into_display(
             f,
-            |node, f| fmt::Display::fmt(&node.0.inner, f),
+            |node, f| fmt::Display::fmt(&node.inner, f),
             |_, _| Ok(()),
         )
     }

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -18,6 +18,7 @@ use crate::bitwriter::BitWriter;
 use crate::core::iter::{DagIterable, PostOrderIter, WitnessIterator};
 use crate::core::redeem::RedeemNodeInner;
 use crate::core::{Context, RedeemNode, Value};
+use crate::dag::DagLike;
 use crate::jet::Jet;
 use crate::merkle::amr::Amr;
 use crate::merkle::cmr::Cmr;
@@ -66,54 +67,6 @@ pub enum CommitNodeInner<J: Jet> {
     Jet(J),
     /// Constant word
     Word(Value),
-}
-
-impl<J: Jet> CommitNodeInner<J> {
-    /// Return the left child of the node, if there is such a child.
-    pub fn get_left(&self) -> Option<&CommitNode<J>> {
-        match self {
-            CommitNodeInner::Iden
-            | CommitNodeInner::Unit
-            | CommitNodeInner::Witness
-            | CommitNodeInner::Fail(_, _)
-            | CommitNodeInner::Hidden(_)
-            | CommitNodeInner::Jet(_)
-            | CommitNodeInner::Word(_) => None,
-            CommitNodeInner::InjL(l)
-            | CommitNodeInner::InjR(l)
-            | CommitNodeInner::Take(l)
-            | CommitNodeInner::Drop(l)
-            | CommitNodeInner::Comp(l, _)
-            | CommitNodeInner::Case(l, _)
-            | CommitNodeInner::AssertL(l, _)
-            | CommitNodeInner::AssertR(l, _)
-            | CommitNodeInner::Pair(l, _)
-            | CommitNodeInner::Disconnect(l, _) => Some(l),
-        }
-    }
-
-    /// Return the right child of the node, if there is such a child.
-    pub fn get_right(&self) -> Option<&CommitNode<J>> {
-        match self {
-            CommitNodeInner::Iden
-            | CommitNodeInner::Unit
-            | CommitNodeInner::Witness
-            | CommitNodeInner::Fail(_, _)
-            | CommitNodeInner::Hidden(_)
-            | CommitNodeInner::Jet(_)
-            | CommitNodeInner::Word(_)
-            | CommitNodeInner::InjL(_)
-            | CommitNodeInner::InjR(_)
-            | CommitNodeInner::Take(_)
-            | CommitNodeInner::Drop(_) => None,
-            CommitNodeInner::Comp(_, r)
-            | CommitNodeInner::Case(_, r)
-            | CommitNodeInner::AssertL(_, r)
-            | CommitNodeInner::AssertR(_, r)
-            | CommitNodeInner::Pair(_, r)
-            | CommitNodeInner::Disconnect(_, r) => Some(r),
-        }
-    }
 }
 
 impl<J: Jet> fmt::Display for CommitNodeInner<J> {
@@ -627,12 +580,12 @@ impl<J: Jet> CommitNode<J> {
 
     /// Return the left child of the node, if there is such a child.
     pub fn get_left(&self) -> Option<&Self> {
-        self.inner.get_left()
+        <&Self as DagLike>::left_child(&self)
     }
 
     /// Return the right child of the node, if there is such a child.
     pub fn get_right(&self) -> Option<&Self> {
-        self.inner.get_right()
+        <&Self as DagLike>::right_child(&self)
     }
 
     /// Create a new DAG, enriched with the witness and computed metadata.

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -154,6 +154,12 @@ impl<J: Jet> CommitNode<J> {
         <&Self as DagLike>::post_order_iter(self)
     }
 
+    /// Return an iterator over the unshared nodes of the program, returning
+    /// refcounted pointers to each node.
+    pub fn rc_iter(self: Rc<Self>) -> PostOrderIter<Rc<Self>> {
+        <Rc<Self> as DagLike>::post_order_iter(self)
+    }
+
     // FIXME: Compute length without iterating over entire DAG?
     /// Return the number of unshared nodes in the program
     #[allow(clippy::len_without_is_empty)]

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -16,6 +16,7 @@ use crate::bititer::BitIter;
 use crate::bitwriter::BitWriter;
 use crate::core::iter::{DagIterable, PostOrderIter};
 use crate::core::{iter, Value};
+use crate::dag::DagLike;
 use crate::decode::WitnessDecoder;
 use crate::jet::Jet;
 use crate::merkle::amr::Amr;
@@ -66,54 +67,6 @@ pub enum RedeemNodeInner<J: Jet> {
     Jet(J),
     /// Constant word
     Word(Value),
-}
-
-impl<J: Jet> RedeemNodeInner<J> {
-    /// Return the left child of the node, if there is such a child.
-    pub fn get_left(&self) -> Option<&RedeemNode<J>> {
-        match self {
-            RedeemNodeInner::Iden
-            | RedeemNodeInner::Unit
-            | RedeemNodeInner::Witness(..)
-            | RedeemNodeInner::Fail(..)
-            | RedeemNodeInner::Hidden(..)
-            | RedeemNodeInner::Jet(..)
-            | RedeemNodeInner::Word(..) => None,
-            RedeemNodeInner::InjL(l)
-            | RedeemNodeInner::InjR(l)
-            | RedeemNodeInner::Take(l)
-            | RedeemNodeInner::Drop(l)
-            | RedeemNodeInner::Comp(l, _)
-            | RedeemNodeInner::Case(l, _)
-            | RedeemNodeInner::AssertL(l, _)
-            | RedeemNodeInner::AssertR(l, _)
-            | RedeemNodeInner::Pair(l, _)
-            | RedeemNodeInner::Disconnect(l, _) => Some(l),
-        }
-    }
-
-    /// Return the right child of the node, if there is such a child.
-    pub fn get_right(&self) -> Option<&RedeemNode<J>> {
-        match self {
-            RedeemNodeInner::Iden
-            | RedeemNodeInner::Unit
-            | RedeemNodeInner::Witness(..)
-            | RedeemNodeInner::Fail(..)
-            | RedeemNodeInner::Hidden(..)
-            | RedeemNodeInner::Jet(..)
-            | RedeemNodeInner::Word(..)
-            | RedeemNodeInner::InjL(_)
-            | RedeemNodeInner::InjR(_)
-            | RedeemNodeInner::Take(_)
-            | RedeemNodeInner::Drop(_) => None,
-            RedeemNodeInner::Comp(_, r)
-            | RedeemNodeInner::Case(_, r)
-            | RedeemNodeInner::AssertL(_, r)
-            | RedeemNodeInner::AssertR(_, r)
-            | RedeemNodeInner::Pair(_, r)
-            | RedeemNodeInner::Disconnect(_, r) => Some(r),
-        }
-    }
 }
 
 impl<J: Jet> fmt::Display for RedeemNodeInner<J> {
@@ -175,12 +128,12 @@ pub struct RedeemNode<J: Jet> {
 impl<J: Jet> RedeemNode<J> {
     /// Return the left child of the node, if there is such a child.
     pub fn get_left(&self) -> Option<&Self> {
-        self.inner.get_left()
+        <&Self as DagLike>::left_child(&self)
     }
 
     /// Return the right child of the node, if there is such a child.
     pub fn get_right(&self) -> Option<&Self> {
-        self.inner.get_right()
+        <&Self as DagLike>::right_child(&self)
     }
 
     /// Return an iterator over the unshared nodes of the program

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -15,7 +15,7 @@
 use crate::bititer::BitIter;
 use crate::bitwriter::BitWriter;
 use crate::core::Value;
-use crate::dag::DagLike;
+use crate::dag::{DagLike, PostOrderIter};
 use crate::decode::WitnessDecoder;
 use crate::jet::Jet;
 use crate::merkle::amr::Amr;
@@ -136,8 +136,14 @@ impl<J: Jet> RedeemNode<J> {
     }
 
     /// Return an iterator over the unshared nodes of the program
-    pub fn iter(&self) -> crate::dag::PostOrderIter<&Self> {
+    pub fn iter(&self) -> PostOrderIter<&Self> {
         <&Self as DagLike>::post_order_iter(self)
+    }
+
+    /// Return an iterator over the unshared nodes of the program, returning
+    /// refcounted pointers to each node.
+    pub fn rc_iter(self: Rc<Self>) -> PostOrderIter<Rc<Self>> {
+        <Rc<Self> as DagLike>::post_order_iter(self)
     }
 
     // FIXME: Compute length without iterating over entire DAG?

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,0 +1,207 @@
+// Rust Simplicity Library
+// Written in 2020 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! General DAG iteration utilities
+
+use std::ops::Deref;
+use std::rc::Rc;
+
+use crate::core::commit::{CommitNode, CommitNodeInner};
+use crate::core::redeem::{RedeemNode, RedeemNodeInner};
+use crate::jet;
+
+/// Generic container for Simplicity DAGs
+pub enum Dag<T> {
+    /// Identity
+    Iden,
+    /// Unit constant
+    Unit,
+    /// Left injection of some child
+    InjL(T),
+    /// Right injection of some child
+    InjR(T),
+    /// Take of some child
+    Take(T),
+    /// Drop of some child
+    Drop(T),
+    /// Composition of a left and right child
+    Comp(T, T),
+    /// Case of a left and right child
+    Case(T, T),
+    /// Pair of a left and right child
+    Pair(T, T),
+    /// Disconnect of a left and right child
+    Disconnect(T, T),
+    /// Witness data (missing during commitment, inserted during redemption)
+    Witness,
+    /// Universal fail
+    Fail,
+    /// Hidden CMR
+    Hidden,
+    /// Application jet
+    Jet,
+    /// Constant word
+    Word,
+}
+
+/// A trait for any structure which has the shape of a Simplicity DAG
+///
+/// This should be implemented on any reference type for `CommitNode` and `RedeemNode`;
+/// it cannot be implemented on these structures themselves because they depend on
+pub trait DagLike: Deref + Sized {
+    /// Interpret the node as a DAG node
+    fn as_dag_node(&self) -> Dag<Self>;
+
+    /// Accessor for the left child of the node, if one exists
+    fn left_child(&self) -> Option<Self> {
+        match self.as_dag_node() {
+            Dag::Iden => None,
+            Dag::Unit => None,
+            Dag::InjL(sub) => Some(sub),
+            Dag::InjR(sub) => Some(sub),
+            Dag::Take(sub) => Some(sub),
+            Dag::Drop(sub) => Some(sub),
+            Dag::Comp(left, _) => Some(left),
+            Dag::Case(left, _) => Some(left),
+            Dag::Pair(left, _) => Some(left),
+            Dag::Disconnect(left, _) => Some(left),
+            Dag::Witness => None,
+            Dag::Fail => None,
+            Dag::Hidden => None,
+            Dag::Jet => None,
+            Dag::Word => None,
+        }
+    }
+
+    /// Accessor for the right child of the node, if one exists
+    fn right_child(&self) -> Option<Self> {
+        match self.as_dag_node() {
+            Dag::Iden => None,
+            Dag::Unit => None,
+            Dag::InjL(_) => None,
+            Dag::InjR(_) => None,
+            Dag::Take(_) => None,
+            Dag::Drop(_) => None,
+            Dag::Comp(_, right) => Some(right),
+            Dag::Case(_, right) => Some(right),
+            Dag::Pair(_, right) => Some(right),
+            Dag::Disconnect(_, right) => Some(right),
+            Dag::Witness => None,
+            Dag::Fail => None,
+            Dag::Hidden => None,
+            Dag::Jet => None,
+            Dag::Word => None,
+        }
+    }
+}
+
+impl<'a, J: jet::Jet> DagLike for &'a CommitNode<J> {
+    #[rustfmt::skip]
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self.inner() {
+            CommitNodeInner::Iden => Dag::Iden,
+            CommitNodeInner::Unit => Dag::Unit,
+            CommitNodeInner::InjL(ref sub) => Dag::InjL(sub),
+            CommitNodeInner::InjR(ref sub) => Dag::InjR(sub),
+            CommitNodeInner::Take(ref sub) => Dag::Take(sub),
+            CommitNodeInner::Drop(ref sub) => Dag::Drop(sub),
+            CommitNodeInner::Comp(ref left, ref right) => Dag::Comp(left, right),
+            CommitNodeInner::Case(ref left, ref right) => Dag::Case(left, right),
+            CommitNodeInner::AssertL(ref left, ref right) => Dag::Case(left, right),
+            CommitNodeInner::AssertR(ref left, ref right) => Dag::Case(left, right),
+            CommitNodeInner::Pair(ref left, ref right) => Dag::Pair(left, right),
+            CommitNodeInner::Disconnect(ref left, ref right) => Dag::Disconnect(left, right),
+            CommitNodeInner::Witness => Dag::Witness,
+            CommitNodeInner::Fail(..) => Dag::Fail,
+            CommitNodeInner::Hidden(..) => Dag::Hidden,
+            CommitNodeInner::Jet(..) => Dag::Jet,
+            CommitNodeInner::Word(..) => Dag::Word,
+        }
+    }
+}
+
+impl<J: jet::Jet> DagLike for Rc<CommitNode<J>> {
+    #[rustfmt::skip]
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self.inner() {
+            CommitNodeInner::Iden => Dag::Iden,
+            CommitNodeInner::Unit => Dag::Unit,
+            CommitNodeInner::InjL(ref sub) => Dag::InjL(Rc::clone(sub)),
+            CommitNodeInner::InjR(ref sub) => Dag::InjR(Rc::clone(sub)),
+            CommitNodeInner::Take(ref sub) => Dag::Take(Rc::clone(sub)),
+            CommitNodeInner::Drop(ref sub) => Dag::Drop(Rc::clone(sub)),
+            CommitNodeInner::Comp(ref left, ref right) => Dag::Comp(Rc::clone(left), Rc::clone(right)),
+            CommitNodeInner::Case(ref left, ref right) => Dag::Case(Rc::clone(left), Rc::clone(right)),
+            CommitNodeInner::AssertL(ref left, ref right) => Dag::Case(Rc::clone(left), Rc::clone(right)),
+            CommitNodeInner::AssertR(ref left, ref right) => Dag::Case(Rc::clone(left), Rc::clone(right)),
+            CommitNodeInner::Pair(ref left, ref right) => Dag::Pair(Rc::clone(left), Rc::clone(right)),
+            CommitNodeInner::Disconnect(ref left, ref right) => Dag::Disconnect(Rc::clone(left), Rc::clone(right)),
+            CommitNodeInner::Witness => Dag::Witness,
+            CommitNodeInner::Fail(..) => Dag::Fail,
+            CommitNodeInner::Hidden(..) => Dag::Hidden,
+            CommitNodeInner::Jet(..) => Dag::Jet,
+            CommitNodeInner::Word(..) => Dag::Word,
+        }
+    }
+}
+
+impl<'a, J: jet::Jet> DagLike for &'a RedeemNode<J> {
+    #[rustfmt::skip]
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self.inner {
+            RedeemNodeInner::Iden => Dag::Iden,
+            RedeemNodeInner::Unit => Dag::Unit,
+            RedeemNodeInner::InjL(ref sub) => Dag::InjL(sub),
+            RedeemNodeInner::InjR(ref sub) => Dag::InjR(sub),
+            RedeemNodeInner::Take(ref sub) => Dag::Take(sub),
+            RedeemNodeInner::Drop(ref sub) => Dag::Drop(sub),
+            RedeemNodeInner::Comp(ref left, ref right) => Dag::Comp(left, right),
+            RedeemNodeInner::Case(ref left, ref right) => Dag::Case(left, right),
+            RedeemNodeInner::AssertL(ref left, ref right) => Dag::Case(left, right),
+            RedeemNodeInner::AssertR(ref left, ref right) => Dag::Case(left, right),
+            RedeemNodeInner::Pair(ref left, ref right) => Dag::Pair(left, right),
+            RedeemNodeInner::Disconnect(ref left, ref right) => Dag::Disconnect(left, right),
+            RedeemNodeInner::Witness(..) => Dag::Witness,
+            RedeemNodeInner::Fail(..) => Dag::Fail,
+            RedeemNodeInner::Hidden(..) => Dag::Hidden,
+            RedeemNodeInner::Jet(..) => Dag::Jet,
+            RedeemNodeInner::Word(..) => Dag::Word,
+        }
+    }
+}
+
+impl<J: jet::Jet> DagLike for Rc<RedeemNode<J>> {
+    #[rustfmt::skip]
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self.inner {
+            RedeemNodeInner::Iden => Dag::Iden,
+            RedeemNodeInner::Unit => Dag::Unit,
+            RedeemNodeInner::InjL(ref sub) => Dag::InjL(Rc::clone(sub)),
+            RedeemNodeInner::InjR(ref sub) => Dag::InjR(Rc::clone(sub)),
+            RedeemNodeInner::Take(ref sub) => Dag::Take(Rc::clone(sub)),
+            RedeemNodeInner::Drop(ref sub) => Dag::Drop(Rc::clone(sub)),
+            RedeemNodeInner::Comp(ref left, ref right) => Dag::Comp(Rc::clone(left), Rc::clone(right)),
+            RedeemNodeInner::Case(ref left, ref right) => Dag::Case(Rc::clone(left), Rc::clone(right)),
+            RedeemNodeInner::AssertL(ref left, ref right) => Dag::Case(Rc::clone(left), Rc::clone(right)),
+            RedeemNodeInner::AssertR(ref left, ref right) => Dag::Case(Rc::clone(left), Rc::clone(right)),
+            RedeemNodeInner::Pair(ref left, ref right) => Dag::Pair(Rc::clone(left), Rc::clone(right)),
+            RedeemNodeInner::Disconnect(ref left, ref right) => Dag::Disconnect(Rc::clone(left), Rc::clone(right)),
+            RedeemNodeInner::Witness(..) => Dag::Witness,
+            RedeemNodeInner::Fail(..) => Dag::Fail,
+            RedeemNodeInner::Hidden(..) => Dag::Hidden,
+            RedeemNodeInner::Jet(..) => Dag::Jet,
+            RedeemNodeInner::Word(..) => Dag::Word,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod bit_machine;
 pub mod bititer;
 pub mod bitwriter;
 pub mod core;
+mod dag;
 mod decode;
 mod encode;
 pub mod jet;

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -291,8 +291,6 @@ impl<Pk: MiniscriptKey + PublicKey32 + ToPublicKey> Policy<Pk> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::iter::DagIterable;
-    use crate::core::{iter, redeem};
     use crate::exec::BitMachine;
     use bitcoin_hashes::{sha256, Hash};
     use std::convert::TryFrom;
@@ -328,7 +326,7 @@ mod tests {
     }
 
     fn to_witness(program: &RedeemNode<Elements>) -> Vec<&Value> {
-        iter::into_witness(redeem::RefWrapper(program).iter_post_order()).collect()
+        program.iter().into_deduped_witnesses().collect()
     }
 
     #[test]

--- a/src/sharing.rs
+++ b/src/sharing.rs
@@ -12,8 +12,8 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use crate::core::iter::PostOrderIter;
-use crate::core::redeem::{RedeemNodeInner, RefWrapper};
+use crate::core::redeem::{RedeemNode, RedeemNodeInner};
+use crate::dag::PostOrderIter;
 use crate::jet::Jet;
 use crate::Imr;
 use std::collections::{HashMap, HashSet};
@@ -24,19 +24,19 @@ use std::collections::{HashMap, HashSet};
 /// 1. For hidden nodes, their hash must be unique in the program.
 /// 2. For non-hidden nodes, the triple of their IMR, source type TMR and target type TMR
 ///    must be unique in the program.
-pub(crate) fn check_maximal_sharing<J: Jet>(program: PostOrderIter<RefWrapper<J>>) -> bool {
+pub(crate) fn check_maximal_sharing<J: Jet>(program: PostOrderIter<&RedeemNode<J>>) -> bool {
     let mut seen_hashes = HashSet::new();
     let mut seen_keys = HashSet::new();
 
     for node in program {
-        if let RedeemNodeInner::Hidden(h) = node.0.inner {
+        if let RedeemNodeInner::Hidden(h) = node.inner {
             if seen_hashes.contains(&h) {
                 return false;
             } else {
                 seen_hashes.insert(h);
             }
         } else {
-            let primary_key = node.0.imr;
+            let primary_key = node.imr;
 
             if seen_keys.contains(&primary_key) {
                 return false;
@@ -57,13 +57,13 @@ pub(crate) fn check_maximal_sharing<J: Jet>(program: PostOrderIter<RefWrapper<J>
 /// # See
 /// [`check_maximal_sharing()`]
 pub(crate) fn compute_maximal_sharing<J: Jet>(
-    program: PostOrderIter<RefWrapper<J>>,
+    program: PostOrderIter<&RedeemNode<J>>,
 ) -> (HashMap<Imr, usize>, usize) {
     let mut node_to_index = HashMap::new();
 
     let mut index = 0;
     for node in program {
-        node_to_index.entry(node.0.imr).or_insert_with(|| {
+        node_to_index.entry(node.imr).or_insert_with(|| {
             index += 1;
             index - 1
         });


### PR DESCRIPTION
Draft since we can't completely replace the existing iteration logic without messing with both sharing (which would conflict with #103) and finalization (which would conflict with #99). But this is mostly complete.

Basically, I was able to encapsulate all the weird pointer-comparison stuff into a new `dag` module which exposes a nice API that lets you iterate over commitnodes or redeemnodes, regardless of whether you want normal references or `Rc`s. As a user you never need to use types like `RefWrapper`.