### PR TITLE
A few miscellaneous cleanups/bugfixes

### DIFF
--- a/fuzz/fuzz_targets/decode_natural.rs
+++ b/fuzz/fuzz_targets/decode_natural.rs
@@ -14,13 +14,13 @@
 
 use honggfuzz::fuzz;
 
-use simplicity::{decode_natural, encode_natural};
+use simplicity::encode_natural;
 use simplicity::{BitIter, BitWriter};
 
 fn do_test(data: &[u8]) {
     let mut iter = BitIter::new(data.iter().cloned());
 
-    if let Ok(natural) = decode_natural(&mut iter, None) {
+    if let Ok(natural) = iter.read_natural(None) {
         // println!("{:?}", natural);
         let bit_len = iter.n_total_read();
 

--- a/jets-bench/benches/elements/data_structures.rs
+++ b/jets-bench/benches/elements/data_structures.rs
@@ -59,7 +59,7 @@ pub fn var_len_buf_from_slice(v: &[u8], mut n: usize) -> Result<Value, Error> {
     while n > 0 {
         let v = if v.len() >= (1 << (n + 1)) {
             let ty = &types[n];
-            let val = simplicity::decode_value(&ty.final_data().unwrap(), &mut iter)?;
+            let val = iter.read_value(&ty.final_data().unwrap())?;
             Value::SumR(Box::new(val))
         } else {
             Value::SumL(Box::new(Value::Unit))

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -21,6 +21,25 @@
 //! `Iterator<Item=bool>`.
 //!
 
+use crate::Cmr;
+
+/// Attempted to read from a bit iterator, but there was no more data
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EarlyEndOfStreamError;
+
+/// Two-bit type used during decoding
+///
+/// Use of an enum rather than a numeric primitive type makes it easier to
+/// match on.
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum u2 {
+    _0,
+    _1,
+    _2,
+    _3,
+}
+
 /// Bitwise iterator formed from a wrapped bytewise iterator. Bytes are
 /// interpreted big-endian, i.e. MSB is returned first
 #[derive(Debug)]
@@ -91,45 +110,39 @@ impl<I: Iterator<Item = u8>> BitIter<I> {
         Self::from(iter)
     }
 
-    /// Reads up to 64 bits as a big-endian number
-    ///
-    /// `n` must be between 0 and 63 inclusive; the function will panic
-    /// otherwise.
-    ///
-    /// Returns `None` if the underlying byte iterator runs out
-    pub fn read_bits_be(&mut self, mut n: usize) -> Option<u64> {
-        assert!(n < 64);
-        if n == 0 {
-            return Some(0);
-        }
+    /// Reads a single bit from the iterator.
+    pub fn read_bit(&mut self) -> Result<bool, EarlyEndOfStreamError> {
+        self.next().ok_or(EarlyEndOfStreamError)
+    }
 
-        // 0 <= avail_bits <= 8
-        // 0 <= n < 64
-        let avail_bits = 8 - self.read_bits;
-        if avail_bits < n {
-            n -= avail_bits;
-            let mask = if avail_bits < 8 {
-                (1 << avail_bits) - 1
-            } else {
-                0xff
-            };
-            let pre_result = ((self.cached_byte & mask) as u64) << n;
-            self.cached_byte = self.iter.next()?;
-            self.read_bits = 0;
-
-            if let Some(read) = self.read_bits_be(n) {
-                self.total_read += avail_bits;
-                Some(pre_result + read)
-            } else {
-                None
-            }
-        } else {
-            // 0 <= n <= 8
-            self.read_bits += n;
-            self.total_read += n;
-            let mask = if n < 8 { (1 << n) - 1 } else { 0xff };
-            Some(((self.cached_byte >> (avail_bits - n)) & mask) as u64)
+    /// Reads two bits from the iterator.
+    pub fn read_u2(&mut self) -> Result<u2, EarlyEndOfStreamError> {
+        match (self.next(), self.next()) {
+            (Some(false), Some(false)) => Ok(u2::_0),
+            (Some(false), Some(true)) => Ok(u2::_1),
+            (Some(true), Some(false)) => Ok(u2::_2),
+            (Some(true), Some(true)) => Ok(u2::_3),
+            _ => Err(EarlyEndOfStreamError),
         }
+    }
+
+    /// Reads a byte from the iterator.
+    pub fn read_u8(&mut self) -> Result<u8, EarlyEndOfStreamError> {
+        debug_assert!(self.read_bits > 0);
+        let cached = self.cached_byte;
+        self.cached_byte = self.iter.next().ok_or(EarlyEndOfStreamError)?;
+
+        Ok(cached.checked_shl(self.read_bits as u32).unwrap_or(0)
+            + (self.cached_byte >> (8 - self.read_bits)))
+    }
+
+    /// Reads a 256-bit CMR from the iterator.
+    pub fn read_cmr(&mut self) -> Result<Cmr, EarlyEndOfStreamError> {
+        let mut ret = [0; 32];
+        for byte in &mut ret {
+            *byte = self.read_u8()?;
+        }
+        Ok(Cmr::from(ret))
     }
 
     /// Accessor for the number of bits which have been read,
@@ -147,20 +160,20 @@ mod tests {
     fn empty_iter() {
         let mut iter = BitIter::from([].iter().cloned());
         assert!(iter.next().is_none());
-        assert_eq!(iter.read_bits_be(0), Some(0));
-        assert_eq!(iter.read_bits_be(1), None);
-        assert_eq!(iter.read_bits_be(63), None);
+        assert_eq!(iter.read_bit(), Err(EarlyEndOfStreamError));
+        assert_eq!(iter.read_u2(), Err(EarlyEndOfStreamError));
+        assert_eq!(iter.read_u8(), Err(EarlyEndOfStreamError));
+        assert_eq!(iter.read_cmr(), Err(EarlyEndOfStreamError));
         assert_eq!(iter.n_total_read(), 0);
     }
 
     #[test]
     fn one_bit_iter() {
         let mut iter = BitIter::from([0x80].iter().cloned());
-        assert_eq!(iter.read_bits_be(0), Some(0));
-        assert_eq!(iter.read_bits_be(1), Some(1));
-        assert_eq!(iter.read_bits_be(7), Some(0));
-        assert_eq!(iter.read_bits_be(1), None);
-        assert_eq!(iter.n_total_read(), 8);
+        assert_eq!(iter.read_bit(), Ok(true));
+        assert_eq!(iter.read_bit(), Ok(false));
+        assert_eq!(iter.read_u8(), Err(EarlyEndOfStreamError));
+        assert_eq!(iter.n_total_read(), 2);
     }
 
     #[test]
@@ -180,24 +193,21 @@ mod tests {
     }
 
     #[test]
-    fn six_by_six() {
-        let mut iter = BitIter::from([0x0f, 0xaa, 0x00].iter().cloned());
-        assert_eq!(iter.read_bits_be(6), Some(0x03)); // 00 0011
-        assert_eq!(iter.read_bits_be(6), Some(0x3a)); // 11 1010
-        assert_eq!(iter.read_bits_be(6), Some(0x28)); // 10 1000
-        assert_eq!(iter.read_bits_be(6), Some(0x00)); // 00 0000
-        assert_eq!(iter.n_total_read(), 24);
+    fn byte_by_byte() {
+        let mut iter = BitIter::from([0x0f, 0xaa].iter().cloned());
+        assert_eq!(iter.read_u8(), Ok(0x0f));
+        assert_eq!(iter.read_u8(), Ok(0xaa));
         assert_eq!(iter.next(), None);
-        assert_eq!(iter.n_total_read(), 24);
     }
 
     #[test]
     fn regression_1() {
         let mut iter = BitIter::from([0x34, 0x90].iter().cloned());
-        assert_eq!(iter.read_bits_be(4), Some(0x03)); // 0011
+        assert_eq!(iter.read_u2(), Ok(u2::_0)); // 0011
+        assert_eq!(iter.read_u2(), Ok(u2::_3)); // 0011
         assert_eq!(iter.next(), Some(false)); // 0
-        assert_eq!(iter.read_bits_be(2), Some(0x02)); // 10
-        assert_eq!(iter.read_bits_be(2), Some(0x01)); // 01
+        assert_eq!(iter.read_u2(), Ok(u2::_2)); // 10
+        assert_eq!(iter.read_u2(), Ok(u2::_1)); // 01
         assert_eq!(iter.n_total_read(), 9);
     }
 }

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -22,8 +22,8 @@
 //!
 
 use crate::core::Value;
-use crate::types;
 use crate::Cmr;
+use crate::{decode, types};
 
 /// Attempted to read from a bit iterator, but there was no more data
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -229,6 +229,14 @@ impl<I: Iterator<Item = u8>> BitIter<I> {
         }
         assert_eq!(result_stack.len(), 1);
         Ok(result_stack.pop().unwrap())
+    }
+
+    /// Decode a natural number from bits.
+    ///
+    /// If a bound is specified, then the decoding terminates before trying to
+    /// decode a larger number.
+    pub fn read_natural(&mut self, bound: Option<usize>) -> Result<usize, decode::Error> {
+        decode::decode_natural(self, bound)
     }
 
     /// Accessor for the number of bits which have been read,

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -21,6 +21,8 @@
 //! `Iterator<Item=bool>`.
 //!
 
+use crate::core::Value;
+use crate::types;
 use crate::Cmr;
 
 /// Attempted to read from a bit iterator, but there was no more data
@@ -59,6 +61,8 @@ impl From<Vec<u8>> for BitIter<std::vec::IntoIter<u8>> {
         BitIter {
             iter: v.into_iter(),
             cached_byte: 0,
+            // Set to 8 to force next `Iterator::next` to read a new byte
+            // from the underlying iterator
             read_bits: 8,
             total_read: 0,
         }
@@ -70,6 +74,8 @@ impl<'a> From<&'a [u8]> for BitIter<std::iter::Copied<std::slice::Iter<'a, u8>>>
         BitIter {
             iter: sl.iter().copied(),
             cached_byte: 0,
+            // Set to 8 to force next `Iterator::next` to read a new byte
+            // from the underlying iterator
             read_bits: 8,
             total_read: 0,
         }
@@ -81,6 +87,8 @@ impl<I: Iterator<Item = u8>> From<I> for BitIter<I> {
         BitIter {
             iter,
             cached_byte: 0,
+            // Set to 8 to force next `Iterator::next` to read a new byte
+            // from the underlying iterator
             read_bits: 8,
             total_read: 0,
         }
@@ -99,6 +107,35 @@ impl<I: Iterator<Item = u8>> Iterator for BitIter<I> {
             self.cached_byte = self.iter.next()?;
             self.read_bits = 0;
             self.next()
+        }
+    }
+}
+
+impl<'a> BitIter<std::iter::Copied<std::slice::Iter<'a, u8>>> {
+    /// Creates a new bitwise iterator from a bytewise one. Equivalent
+    /// to using `From`
+    pub fn byte_slice_window(sl: &'a [u8], start: usize, end: usize) -> Self {
+        assert!(start <= end);
+        assert!(end <= sl.len() * 8);
+
+        let actual_sl = &sl[start / 8..(end + 7) / 8];
+        let mut iter = actual_sl.iter().copied();
+
+        let read_bits = start % 8;
+        if read_bits == 0 {
+            BitIter {
+                iter,
+                cached_byte: 0,
+                read_bits: 8,
+                total_read: 0,
+            }
+        } else {
+            BitIter {
+                cached_byte: iter.by_ref().next().unwrap(),
+                iter,
+                read_bits,
+                total_read: 0,
+            }
         }
     }
 }
@@ -143,6 +180,55 @@ impl<I: Iterator<Item = u8>> BitIter<I> {
             *byte = self.read_u8()?;
         }
         Ok(Cmr::from(ret))
+    }
+
+    /// Decode a value from bits, based on the given type.
+    pub fn read_value(&mut self, ty: &types::Final) -> Result<Value, EarlyEndOfStreamError> {
+        enum State<'a> {
+            ProcessType(&'a types::Final),
+            DoSumL,
+            DoSumR,
+            DoProduct,
+        }
+
+        let mut stack = vec![State::ProcessType(ty)];
+        let mut result_stack = vec![];
+        while let Some(state) = stack.pop() {
+            match state {
+                State::ProcessType(ty) => match ty.bound() {
+                    types::CompleteBound::Unit => result_stack.push(Value::Unit),
+                    types::CompleteBound::Sum(ref l, ref r) => {
+                        if self.read_bit()? {
+                            stack.push(State::DoSumR);
+                            stack.push(State::ProcessType(r));
+                        } else {
+                            stack.push(State::DoSumL);
+                            stack.push(State::ProcessType(l));
+                        }
+                    }
+                    types::CompleteBound::Product(ref l, ref r) => {
+                        stack.push(State::DoProduct);
+                        stack.push(State::ProcessType(r));
+                        stack.push(State::ProcessType(l));
+                    }
+                },
+                State::DoSumL => {
+                    let val = result_stack.pop().unwrap();
+                    result_stack.push(Value::SumL(Box::new(val)));
+                }
+                State::DoSumR => {
+                    let val = result_stack.pop().unwrap();
+                    result_stack.push(Value::SumR(Box::new(val)));
+                }
+                State::DoProduct => {
+                    let val_r = result_stack.pop().unwrap();
+                    let val_l = result_stack.pop().unwrap();
+                    result_stack.push(Value::Prod(Box::new(val_l), Box::new(val_r)));
+                }
+            }
+        }
+        assert_eq!(result_stack.len(), 1);
+        Ok(result_stack.pop().unwrap())
     }
 
     /// Accessor for the number of bits which have been read,
@@ -209,5 +295,35 @@ mod tests {
         assert_eq!(iter.read_u2(), Ok(u2::_2)); // 10
         assert_eq!(iter.read_u2(), Ok(u2::_1)); // 01
         assert_eq!(iter.n_total_read(), 9);
+    }
+
+    #[test]
+    fn byte_slice_window() {
+        let data = [0x12, 0x23, 0x34];
+
+        let mut full = BitIter::byte_slice_window(&data, 0, 24);
+        assert_eq!(full.read_u8(), Ok(0x12));
+        assert_eq!(full.read_u8(), Ok(0x23));
+        assert_eq!(full.read_u8(), Ok(0x34));
+        assert_eq!(full.read_u8(), Err(EarlyEndOfStreamError));
+
+        let mut mid = BitIter::byte_slice_window(&data, 8, 16);
+        assert_eq!(mid.read_u8(), Ok(0x23));
+        assert_eq!(mid.read_u8(), Err(EarlyEndOfStreamError));
+
+        let mut offs = BitIter::byte_slice_window(&data, 4, 20);
+        assert_eq!(offs.read_u8(), Ok(0x22));
+        assert_eq!(offs.read_u8(), Ok(0x33));
+        assert_eq!(offs.read_u8(), Err(EarlyEndOfStreamError));
+
+        let mut shift1 = BitIter::byte_slice_window(&data, 1, 24);
+        assert_eq!(shift1.read_u8(), Ok(0x24));
+        assert_eq!(shift1.read_u8(), Ok(0x46));
+        assert_eq!(shift1.read_u8(), Err(EarlyEndOfStreamError));
+
+        let mut shift7 = BitIter::byte_slice_window(&data, 7, 24);
+        assert_eq!(shift7.read_u8(), Ok(0x11));
+        assert_eq!(shift7.read_u8(), Ok(0x9a));
+        assert_eq!(shift7.read_u8(), Err(EarlyEndOfStreamError));
     }
 }

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -573,6 +573,24 @@ mod tests {
     }
 
     #[test]
+    fn shared_grandchild() {
+        // # This program repeats the node `cp2` three times; during iteration it will
+        // # be placed on the stack as part of the initial `comp` combinator, but by
+        // # the time we get to it, it will have already been yielded. Makes sure this
+        // # does not confuse the iteration logic and break the decoded program structure.
+        // id1 = iden
+        // cp2 = comp id1 id1
+        // cp3 = comp cp2 cp2
+        // main = comp cp3 cp2
+        assert_program_deserializable::<Core>(
+            &[0xc1, 0x00, 0x00, 0x01, 0x00],
+            "c2c86be0081a9c75af49098f359c7efdfa7ccbd0459adb11bcf676b80c8644b1",
+            Some("e053520f0c3219d1cabd705b4523ccd05c8d703a70f6f3994a20774a42b5ccfc"),
+            Some("7b0ad0514279280d5c2ac1da729222936b8768d9f465c6c6ade3b0ed7dc97263"),
+        );
+    }
+
+    #[test]
     #[rustfmt::skip]
     fn assert_lr() {
         // asst = assertl unit deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -178,7 +178,7 @@ pub fn decode_program<I: Iterator<Item = u8>, J: Jet>(
 pub fn decode_expression<I: Iterator<Item = u8>, J: Jet>(
     bits: &mut BitIter<I>,
 ) -> Result<Rc<CommitNode<J>>, Error> {
-    let len = decode_natural(bits, None)?;
+    let len = bits.read_natural(None)?;
 
     if len == 0 {
         return Err(Error::EmptyProgram);
@@ -293,7 +293,7 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
                 Ok(jet) => Ok(DecodeNode::Jet(jet)),
             }
         } else {
-            let depth = decode_natural(bits, Some(32))?;
+            let depth = bits.read_natural(Some(32))?;
             let word = decode_power_of_2(bits, 1 << (depth - 1))?;
             Ok(DecodeNode::Word(cell::RefCell::new(word)))
         }
@@ -302,8 +302,8 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
         match bits.read_u2()? {
             u2::_0 => {
                 let subcode = bits.read_u2()?;
-                let i_abs = index - decode_natural(bits, Some(index))?;
-                let j_abs = index - decode_natural(bits, Some(index))?;
+                let i_abs = index - bits.read_natural(Some(index))?;
+                let j_abs = index - bits.read_natural(Some(index))?;
 
                 // Bits 4 and 5: subcode
                 match subcode {
@@ -315,7 +315,7 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
             }
             u2::_1 => {
                 let subcode = bits.read_u2()?;
-                let i_abs = index - decode_natural(bits, Some(index))?;
+                let i_abs = index - bits.read_natural(Some(index))?;
                 // Bits 4 and 5: subcode
                 match subcode {
                     u2::_0 => Ok(DecodeNode::InjL(i_abs)),
@@ -361,7 +361,7 @@ impl<'a, I: Iterator<Item = u8>> WitnessDecoder<'a, I> {
     pub fn new(bits: &'a mut BitIter<I>) -> Result<Self, Error> {
         let bit_len = match bits.next() {
             Some(false) => 0,
-            Some(true) => decode_natural(bits, None)?,
+            Some(true) => bits.read_natural(None)?,
             None => return Err(Error::EndOfStream),
         };
         let n_start = bits.n_total_read();

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -20,10 +20,10 @@
 
 use super::frame::Frame;
 use crate::core::redeem::RedeemNodeInner;
-use crate::core::{RedeemNode, Value};
+use crate::core::Value;
 use crate::jet::{Jet, JetFailed};
-use crate::merkle::cmr::Cmr;
-use crate::{analysis, decode, types};
+use crate::{analysis, types};
+use crate::{Cmr, RedeemNode};
 use std::fmt;
 use std::{cmp, error};
 
@@ -447,9 +447,10 @@ impl BitMachine {
         if output_width > 0 {
             let out_frame = self.write.last_mut().unwrap();
             out_frame.reset_cursor();
-            let value =
-                decode::decode_value(&program.ty.target, &mut out_frame.to_frame_data(&self.data))
-                    .expect("Decode value of output frame");
+            let value = out_frame
+                .as_bit_iter(&self.data)
+                .read_value(&program.ty.target)
+                .expect("Decode value of output frame");
 
             Ok(value)
         } else {

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -257,6 +257,19 @@ mod tests {
     }
 
     #[test]
+    fn unshared_child() {
+        // # id1 and id2 should be shared, but are not!
+        // id1 = iden          :: A -> A # cmr dbfefcfc...
+        // id2 = iden          :: A -> A # cmr dbfefcfc...
+        // cp3 = comp id1 id2  :: A -> A # cmr c1ae55b5...
+        // main = comp cp3 cp3 :: A -> A # cmr 314e2879...
+        let bad = [0xc1, 0x08, 0x04, 0x00, 0x00, 0x74, 0x74, 0x74];
+        let mut iter = BitIter::from(&bad[..]);
+        let err = RedeemNode::<crate::jet::Core>::decode(&mut iter).unwrap_err();
+        assert!(matches!(err, crate::Error::SharingNotMaximal));
+    }
+
+    #[test]
     fn witness_consumed() {
         // "main = unit", but with a witness attached. Found by fuzzer.
         let badwit = vec![0x27, 0x00];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub use crate::bit_machine::exec;
 pub use crate::core::commit::CommitNodeInner;
 pub use crate::core::redeem::RedeemNodeInner;
 pub use crate::core::{CommitNode, Context, RedeemNode};
-pub use crate::decode::{decode_natural, decode_program, WitnessDecoder};
+pub use crate::decode::{decode_program, WitnessDecoder};
 pub use crate::encode::{encode_natural, encode_value, encode_witness};
 pub use crate::merkle::{amr::Amr, cmr::Cmr, imr::Imr, tmr::Tmr};
 pub use simplicity_sys as ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod types;
 mod util;
 
 use bit_encoding::bititer; // FIXME used by autogenerator jet code
+pub use bit_encoding::bititer::EarlyEndOfStreamError;
 use bit_encoding::bitwriter; // FIXME used by autogenerator jet code
 use bit_encoding::decode;
 use bit_encoding::encode;
@@ -61,7 +62,7 @@ pub use crate::bit_machine::exec;
 pub use crate::core::commit::CommitNodeInner;
 pub use crate::core::redeem::RedeemNodeInner;
 pub use crate::core::{CommitNode, Context, RedeemNode};
-pub use crate::decode::{decode_natural, decode_program, decode_value, WitnessDecoder};
+pub use crate::decode::{decode_natural, decode_program, WitnessDecoder};
 pub use crate::encode::{encode_natural, encode_value, encode_witness};
 pub use crate::merkle::{amr::Amr, cmr::Cmr, imr::Imr, tmr::Tmr};
 pub use simplicity_sys as ffi;
@@ -127,6 +128,12 @@ impl std::error::Error for Error {
 impl From<crate::decode::Error> for Error {
     fn from(e: crate::decode::Error) -> Error {
         Error::Decode(e)
+    }
+}
+
+impl From<EarlyEndOfStreamError> for Error {
+    fn from(e: EarlyEndOfStreamError) -> Error {
+        Error::Decode(e.into())
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,23 +44,3 @@ macro_rules! define_be_to_array {
 
 define_slice_to_be!(slice_to_u64_be, u64);
 define_be_to_array!(u64_to_array_be, u64, 8);
-
-// handy function for converting bit vector to vec[u8]
-// # PANIC:
-// panics when bitvec length is not a multiple of 8.
-#[cfg(test)]
-pub(crate) fn bitvec_to_bytevec(bitvec: &[bool]) -> Vec<u8> {
-    let mut ret = vec![];
-    assert!(bitvec.len() % 8 == 0, "Bitvec len must be multiple of 8");
-    let mut start = 0;
-    while start < bitvec.len() {
-        //read a byte
-        let mut byte: u8 = 0;
-        for i in 0..8 {
-            byte += (bitvec[start + i] as u8) * (1u8 << (7 - i));
-        }
-        ret.push(byte);
-        start += 8;
-    }
-    ret
-}


### PR DESCRIPTION
These commits didn't fit into the other `decode` PRs, but I'd like to get them in if possible before shifting gears to clean up and bugfix the Merkle roots (which are the last thing we need to get the fuzztests going, other than upstream fixes).

The first two commits are just refactors. We continue to move away from the `Iterator<Item=bool>` model to putting things as methods on `BitIter`; while we are at it, we replace the recursive `Value`-decoding algorithm with an iterative one.

The third commit fixes a bug found by the fuzzer, where a program with a complicated sharing pattern causes a node to be yielded twice by the post-order iterator. Fixing this replaces the "repeated children" logic with something a little bit (IMHO) conceptually simpler.

Finally, the last two commits replace some `Hashmap` indices with flat `Vec`s, fixing a bug that was causing us not to recognize improperly-shared programs as being improperly shared.

Again, this PR does multiple things and I'm happy to split it into multiple PRs if you want. But each commit should be independent at least.