### PR TITLE
Node overhaul 1: introduce new *`Node` types

### DIFF
--- a/fuzz/fuzz_targets/c_rust_merkle.rs
+++ b/fuzz/fuzz_targets/c_rust_merkle.rs
@@ -15,7 +15,7 @@
 use honggfuzz::fuzz;
 
 use simplicity::bitcoin_hashes::sha256::Midstate;
-use simplicity::ffi::{tests, ffi::SimplicityErr};
+use simplicity::ffi::{ffi::SimplicityErr, tests};
 use simplicity::jet::Elements;
 use simplicity::{BitIter, RedeemNode};
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -51,7 +51,7 @@ fn compute_extra_cells_bound<J: Jet>(
     match untyped_node.inner() {
         CommitNodeInner::Iden
         | CommitNodeInner::Unit
-        | CommitNodeInner::Fail(_, _)
+        | CommitNodeInner::Fail(_)
         | CommitNodeInner::Jet(_)
         | CommitNodeInner::Word(_) => 0,
         CommitNodeInner::InjL(_)
@@ -90,7 +90,7 @@ fn compute_extra_frames_bound<J: Jet>(
         CommitNodeInner::Iden
         | CommitNodeInner::Unit
         | CommitNodeInner::Witness
-        | CommitNodeInner::Fail(_, _)
+        | CommitNodeInner::Fail(_)
         | CommitNodeInner::Jet(_)
         | CommitNodeInner::Word(_) => 0,
         CommitNodeInner::InjL(_)

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -13,12 +13,137 @@
 //
 
 use crate::core::commit::CommitNodeInner;
-use crate::core::redeem::NodeBounds;
-use crate::core::{CommitNode, RedeemNode};
 use crate::jet::Jet;
 use crate::types::arrow::FinalArrow;
+use crate::{CommitNode, RedeemNode};
 use std::cmp;
 use std::rc::Rc;
+
+/// Bounds on the resources required by a node during execution on the Bit Machine
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeBounds {
+    /// Upper bound on the required number of cells (bits).
+    /// The root additionally requires the bit width of its source and target type (input, output)
+    pub extra_cells: usize,
+    /// Upper bound on the required number of frames (sum of read and write frames).
+    /// The root additionally requires two frames (input, output)
+    pub extra_frames: usize,
+}
+
+impl NodeBounds {
+    const ZERO: Self = NodeBounds {
+        extra_cells: 0,
+        extra_frames: 0,
+    };
+
+    /// Node bounds for an `iden` node
+    pub const fn iden() -> NodeBounds {
+        NodeBounds::ZERO
+    }
+
+    /// Node bounds for a `unit` node
+    pub const fn unit() -> NodeBounds {
+        NodeBounds::ZERO
+    }
+
+    /// Node bounds for an `injl` node
+    pub const fn injl(child: Self) -> NodeBounds {
+        child
+    }
+
+    /// Node bounds for an `injr` node
+    pub const fn injr(child: Self) -> NodeBounds {
+        child
+    }
+
+    /// Node bounds for a `take` node
+    pub const fn take(child: Self) -> NodeBounds {
+        child
+    }
+
+    /// Node bounds for a `drop` node
+    pub const fn drop(child: Self) -> NodeBounds {
+        child
+    }
+
+    /// Node bounds for a `comp` node
+    pub fn comp(left: Self, right: Self, mid_ty_bit_width: usize) -> NodeBounds {
+        NodeBounds {
+            extra_cells: mid_ty_bit_width + cmp::max(left.extra_cells, right.extra_cells),
+            extra_frames: 1 + cmp::max(left.extra_frames, right.extra_frames),
+        }
+    }
+
+    /// Node bounds for a `case` node
+    pub fn case(left: Self, right: Self) -> NodeBounds {
+        NodeBounds {
+            extra_cells: cmp::max(left.extra_cells, right.extra_cells),
+            extra_frames: cmp::max(left.extra_frames, right.extra_frames),
+        }
+    }
+
+    /// Node bounds for a `assertl` node
+    pub const fn assertl(child: Self) -> NodeBounds {
+        child
+    }
+
+    /// Node bounds for a `assertr` node
+    pub const fn assertr(child: Self) -> NodeBounds {
+        child
+    }
+
+    /// Node bounds for a `pair` node
+    pub fn pair(left: Self, right: Self) -> NodeBounds {
+        NodeBounds {
+            extra_cells: cmp::max(left.extra_cells, right.extra_cells),
+            extra_frames: cmp::max(left.extra_frames, right.extra_frames),
+        }
+    }
+
+    // disconnect, jet, witness, word
+    /// Node bounds for a `disconnect` node
+    pub fn disconnect(
+        left: Self,
+        right: Self,
+        left_source_bit_width: usize,
+        left_target_bit_width: usize,
+    ) -> NodeBounds {
+        NodeBounds {
+            extra_cells: left_source_bit_width
+                + left_target_bit_width
+                + cmp::max(left.extra_cells, right.extra_cells),
+            extra_frames: 2 + cmp::max(left.extra_frames, right.extra_frames),
+        }
+    }
+
+    /// Node bounds for an arbitrary jet node
+    pub fn witness(target_ty_bit_width: usize) -> NodeBounds {
+        NodeBounds {
+            extra_cells: target_ty_bit_width,
+            extra_frames: 0,
+        }
+    }
+
+    /// Node bounds for an arbitrary jet node
+    pub const fn jet() -> NodeBounds {
+        NodeBounds::ZERO
+    }
+
+    /// Node bounds for an arbitrary constant word node
+    pub const fn const_word() -> NodeBounds {
+        NodeBounds::ZERO
+    }
+
+    /// Node bounds for a `fail` node.
+    ///
+    /// This is a bit of a silly constructor because if a `fail` node is actually
+    /// executed in the bit machine, it will fail instantly, while if it *isn't*
+    /// executed, it will fail the "no unexecuted nodes" check. But to analyze
+    /// arbitrary programs, we need it.
+    pub const fn fail() -> NodeBounds {
+        NodeBounds::ZERO
+    }
+}
 
 /// Number of frames required for the input and output of a Simplicity expression
 pub(crate) const IO_EXTRA_FRAMES: usize = 2;

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -22,7 +22,7 @@
 //!
 
 use crate::{decode, types};
-use crate::{Cmr, Value};
+use crate::{Cmr, FailEntropy, Value};
 
 /// Attempted to read from a bit iterator, but there was no more data
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -179,6 +179,15 @@ impl<I: Iterator<Item = u8>> BitIter<I> {
             *byte = self.read_u8()?;
         }
         Ok(Cmr::from_byte_array(ret))
+    }
+
+    /// Reads a 512-bit fail-combinator entropy from the iterator.
+    pub fn read_fail_entropy(&mut self) -> Result<FailEntropy, EarlyEndOfStreamError> {
+        let mut ret = [0; 64];
+        for byte in &mut ret {
+            *byte = self.read_u8()?;
+        }
+        Ok(FailEntropy::from_byte_array(ret))
     }
 
     /// Decode a value from bits, based on the given type.

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -137,21 +137,21 @@ impl<'d, J: Jet> DagLike for (usize, &'d [DecodeNode<J>]) {
     fn as_dag_node(&self) -> Dag<Self> {
         let nodes = &self.1;
         match self.1[self.0] {
-            DecodeNode::Iden => Dag::Iden,
-            DecodeNode::Unit => Dag::Unit,
-            DecodeNode::InjL(i) => Dag::InjL((i, nodes)),
-            DecodeNode::InjR(i) => Dag::InjR((i, nodes)),
-            DecodeNode::Take(i) => Dag::Take((i, nodes)),
-            DecodeNode::Drop(i) => Dag::Drop((i, nodes)),
-            DecodeNode::Comp(li, ri) => Dag::Comp((li, nodes), (ri, nodes)),
-            DecodeNode::Case(li, ri) => Dag::Case((li, nodes), (ri, nodes)),
-            DecodeNode::Pair(li, ri) => Dag::Pair((li, nodes), (ri, nodes)),
+            DecodeNode::Iden
+            | DecodeNode::Unit
+            | DecodeNode::Fail(..)
+            | DecodeNode::Hidden(..)
+            | DecodeNode::Jet(..)
+            | DecodeNode::Word(..) => Dag::Nullary,
+            DecodeNode::InjL(i)
+            | DecodeNode::InjR(i)
+            | DecodeNode::Take(i)
+            | DecodeNode::Drop(i) => Dag::Unary((i, nodes)),
+            DecodeNode::Comp(li, ri) | DecodeNode::Case(li, ri) | DecodeNode::Pair(li, ri) => {
+                Dag::Binary((li, nodes), (ri, nodes))
+            }
             DecodeNode::Disconnect(li, ri) => Dag::Disconnect((li, nodes), (ri, nodes)),
             DecodeNode::Witness => Dag::Witness,
-            DecodeNode::Fail(..) => Dag::Fail,
-            DecodeNode::Hidden(..) => Dag::Hidden,
-            DecodeNode::Jet(..) => Dag::Jet,
-            DecodeNode::Word(..) => Dag::Word,
         }
     }
 }

--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -41,37 +41,33 @@ impl<'n, J: Jet> DagLike for EncodeNode<'n, J> {
     fn as_dag_node(&self) -> Dag<Self> {
         let node = match *self {
             EncodeNode::Node(node) => node,
-            EncodeNode::Hidden(..) => return Dag::Hidden,
+            EncodeNode::Hidden(..) => return Dag::Nullary,
         };
         match &node.inner {
-            RedeemNodeInner::Unit => Dag::Unit,
-            RedeemNodeInner::Iden => Dag::Iden,
-            RedeemNodeInner::InjL(sub) => Dag::InjL(EncodeNode::Node(sub)),
-            RedeemNodeInner::InjR(sub) => Dag::InjR(EncodeNode::Node(sub)),
-            RedeemNodeInner::Take(sub) => Dag::Take(EncodeNode::Node(sub)),
-            RedeemNodeInner::Drop(sub) => Dag::Drop(EncodeNode::Node(sub)),
-            RedeemNodeInner::Comp(left, right) => {
-                Dag::Comp(EncodeNode::Node(left), EncodeNode::Node(right))
-            }
-            RedeemNodeInner::Case(left, right) => {
-                Dag::Case(EncodeNode::Node(left), EncodeNode::Node(right))
+            RedeemNodeInner::Unit
+            | RedeemNodeInner::Iden
+            | RedeemNodeInner::Fail(..)
+            | RedeemNodeInner::Jet(..)
+            | RedeemNodeInner::Word(..) => Dag::Nullary,
+            RedeemNodeInner::InjL(sub)
+            | RedeemNodeInner::InjR(sub)
+            | RedeemNodeInner::Take(sub)
+            | RedeemNodeInner::Drop(sub) => Dag::Unary(EncodeNode::Node(sub)),
+            RedeemNodeInner::Comp(left, right)
+            | RedeemNodeInner::Case(left, right)
+            | RedeemNodeInner::Pair(left, right) => {
+                Dag::Binary(EncodeNode::Node(left), EncodeNode::Node(right))
             }
             RedeemNodeInner::AssertL(left, rcmr) => {
-                Dag::Case(EncodeNode::Node(left), EncodeNode::Hidden(*rcmr))
+                Dag::Binary(EncodeNode::Node(left), EncodeNode::Hidden(*rcmr))
             }
             RedeemNodeInner::AssertR(lcmr, right) => {
-                Dag::Case(EncodeNode::Hidden(*lcmr), EncodeNode::Node(right))
-            }
-            RedeemNodeInner::Pair(left, right) => {
-                Dag::Pair(EncodeNode::Node(left), EncodeNode::Node(right))
+                Dag::Binary(EncodeNode::Hidden(*lcmr), EncodeNode::Node(right))
             }
             RedeemNodeInner::Disconnect(left, right) => {
                 Dag::Disconnect(EncodeNode::Node(left), EncodeNode::Node(right))
             }
             RedeemNodeInner::Witness(..) => Dag::Witness,
-            RedeemNodeInner::Fail(..) => Dag::Fail,
-            RedeemNodeInner::Jet(..) => Dag::Jet,
-            RedeemNodeInner::Word(..) => Dag::Word,
         }
     }
 }

--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -203,10 +203,9 @@ fn encode_node<W: io::Write, J: Jet>(
             RedeemNodeInner::Unit => {
                 w.write_bits_be(0b01001, 5)?;
             }
-            RedeemNodeInner::Fail(hl, hr) => {
+            RedeemNodeInner::Fail(entropy) => {
                 w.write_bits_be(0b01010, 5)?;
-                encode_hash(hl.as_ref(), w)?;
-                encode_hash(hr.as_ref(), w)?;
+                encode_hash(entropy.as_ref(), w)?;
             }
             RedeemNodeInner::Witness(_) => {
                 w.write_bits_be(0b0111, 4)?;

--- a/src/bit_machine/exec.rs
+++ b/src/bit_machine/exec.rs
@@ -22,7 +22,7 @@ use super::frame::Frame;
 use crate::core::redeem::RedeemNodeInner;
 use crate::jet::{Jet, JetFailed};
 use crate::{analysis, types};
-use crate::{Cmr, RedeemNode, Value};
+use crate::{Cmr, FailEntropy, RedeemNode, Value};
 use std::fmt;
 use std::{cmp, error};
 
@@ -423,8 +423,8 @@ impl BitMachine {
                 RedeemNodeInner::Witness(value) => self.write_value(value),
                 RedeemNodeInner::Jet(jet) => jet.exec(self, env)?,
                 RedeemNodeInner::Word(value) => self.write_value(value),
-                RedeemNodeInner::Fail(left, right) => {
-                    return Err(ExecutionError::ReachedFailNode(*left, *right))
+                RedeemNodeInner::Fail(entropy) => {
+                    return Err(ExecutionError::ReachedFailNode(*entropy))
                 }
             }
 
@@ -462,7 +462,7 @@ impl BitMachine {
 #[derive(Debug)]
 pub enum ExecutionError {
     /// Reached a fail node
-    ReachedFailNode(Cmr, Cmr),
+    ReachedFailNode(FailEntropy),
     /// Reached a pruned branch
     ReachedPrunedBranch(Cmr),
     /// Jet failed during execution
@@ -472,8 +472,8 @@ pub enum ExecutionError {
 impl fmt::Display for ExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ExecutionError::ReachedFailNode(left, right) => {
-                write!(f, "Execution reached a fail node: {} {}", left, right)
+            ExecutionError::ReachedFailNode(entropy) => {
+                write!(f, "Execution reached a fail node: {}", entropy)
             }
             ExecutionError::ReachedPrunedBranch(hash) => {
                 write!(f, "Execution reached a pruned branch: {}", hash)

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -22,7 +22,7 @@ use crate::merkle::cmr::Cmr;
 use crate::merkle::imr::{FirstPassImr, Imr};
 use crate::types::{self, arrow::Arrow};
 use crate::{analysis, Error};
-use crate::{BitIter, BitWriter, Context, RedeemNode, Value};
+use crate::{BitIter, BitWriter, Context, FailEntropy, RedeemNode, Value};
 use std::rc::Rc;
 use std::{fmt, io};
 
@@ -57,7 +57,7 @@ pub enum CommitNodeInner<J: Jet> {
     /// Witness data (missing during commitment, inserted during redemption)
     Witness,
     /// Universal fail
-    Fail(Cmr, Cmr),
+    Fail(FailEntropy),
     /// Application jet
     Jet(J),
     /// Constant word
@@ -384,8 +384,8 @@ impl<J: Jet> CommitNode<J> {
     /// The given `left` and `right` hashes form a block for the CMR computation.
     ///
     /// _Overall type: A → B_
-    pub fn fail(context: &mut Context<J>, left: Cmr, right: Cmr) -> Rc<Self> {
-        let inner = CommitNodeInner::Fail(left, right);
+    pub fn fail(context: &mut Context<J>, entropy: FailEntropy) -> Rc<Self> {
+        let inner = CommitNodeInner::Fail(entropy);
         Rc::new(CommitNode {
             cmr: Cmr::compute(&inner),
             inner,
@@ -649,7 +649,7 @@ impl<J: Jet> CommitNode<J> {
                     RedeemNodeInner::Disconnect(left.unwrap(), right.unwrap())
                 }
                 CommitNodeInner::Witness => RedeemNodeInner::Witness(value.unwrap()),
-                CommitNodeInner::Fail(hl, hr) => RedeemNodeInner::Fail(hl, hr),
+                CommitNodeInner::Fail(entropy) => RedeemNodeInner::Fail(entropy),
                 CommitNodeInner::Jet(jet) => RedeemNodeInner::Jet(jet),
                 CommitNodeInner::Word(ref w) => RedeemNodeInner::Word(w.clone()),
             };

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -397,7 +397,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Overall type: A → B where jet: A → B_
     pub fn jet(context: &mut Context<J>, jet: J) -> Rc<Self> {
-        let arrow = Arrow::for_jet(context, &jet);
+        let arrow = Arrow::for_jet(context, jet);
         let inner = CommitNodeInner::Jet(jet);
         Rc::new(CommitNode {
             cmr: Cmr::compute(&inner),

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -20,7 +20,7 @@ use crate::merkle::cmr::Cmr;
 use crate::merkle::imr::Imr;
 use crate::types::{self, arrow::FinalArrow};
 use crate::{encode, Error};
-use crate::{BitIter, BitWriter, Value};
+use crate::{BitIter, BitWriter, FailEntropy, Value};
 use std::rc::Rc;
 use std::{fmt, io};
 
@@ -57,7 +57,7 @@ pub enum RedeemNodeInner<J: Jet> {
     /// Witness data
     Witness(Value),
     /// Universal fail
-    Fail(Cmr, Cmr),
+    Fail(FailEntropy),
     /// Application jet
     Jet(J),
     /// Constant word

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -12,6 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use crate::analysis::NodeBounds;
 use crate::dag::{DagLike, FullSharing, InternalSharing, NoSharing, PostOrderIter};
 use crate::decode::WitnessDecoder;
 use crate::jet::Jet;
@@ -85,17 +86,6 @@ impl<J: Jet> fmt::Display for RedeemNodeInner<J> {
             RedeemNodeInner::Word(w) => write!(f, "word({})", w),
         }
     }
-}
-
-/// Bounds on the resources required by a node during execution on the Bit Machine
-#[derive(Debug)]
-pub struct NodeBounds {
-    /// Upper bound on the required number of cells (bits).
-    /// The root additionally requires the bit width of its source and target type (input, output)
-    pub extra_cells: usize,
-    /// Upper bound on the required number of frames (sum of read and write frames).
-    /// The root additionally requires two frames (input, output)
-    pub extra_frames: usize,
 }
 
 /// Root node of a Simplicity DAG for some application.

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -16,11 +16,13 @@
 
 use std::collections::{hash_map::Entry, HashMap};
 use std::rc::Rc;
+use std::sync::Arc;
 use std::{fmt, marker};
 
 use crate::core::commit::{CommitNode, CommitNodeInner};
 use crate::core::redeem::{RedeemNode, RedeemNodeInner};
 use crate::jet;
+use crate::node::{self, Node, NodeData};
 use crate::{Imr, Value};
 
 /// Generic container for Simplicity DAGs
@@ -459,6 +461,66 @@ impl<J: jet::Jet> DagLike for Rc<RedeemNode<J>> {
             RedeemNodeInner::Fail(..) => Dag::Fail,
             RedeemNodeInner::Jet(..) => Dag::Jet,
             RedeemNodeInner::Word(..) => Dag::Word,
+        }
+    }
+}
+
+impl<'a, N: NodeData<J>, J: jet::Jet> DagLike for &'a Node<N, J> {
+    type Node = Node<N, J>;
+
+    fn data(&self) -> &Node<N, J> {
+        self
+    }
+
+    #[rustfmt::skip]
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self.inner() {
+            node::Inner::Iden => Dag::Iden,
+            node::Inner::Unit => Dag::Unit,
+            node::Inner::InjL(ref sub) => Dag::InjL(sub),
+            node::Inner::InjR(ref sub) => Dag::InjR(sub),
+            node::Inner::Take(ref sub) => Dag::Take(sub),
+            node::Inner::Drop(ref sub) => Dag::Drop(sub),
+            node::Inner::Comp(ref left, ref right) => Dag::Comp(left, right),
+            node::Inner::Case(ref left, ref right) => Dag::Case(left, right),
+            node::Inner::AssertL(ref left, _) => Dag::AssertL(left),
+            node::Inner::AssertR(_, ref right) => Dag::AssertR(right),
+            node::Inner::Pair(ref left, ref right) => Dag::Pair(left, right),
+            node::Inner::Disconnect(ref left, ref right) => Dag::Disconnect(left, right),
+            node::Inner::Witness(..) => Dag::Witness,
+            node::Inner::Fail(..) => Dag::Fail,
+            node::Inner::Jet(..) => Dag::Jet,
+            node::Inner::Word(..) => Dag::Word,
+        }
+    }
+}
+
+impl<N: NodeData<J>, J: jet::Jet> DagLike for Arc<Node<N, J>> {
+    type Node = Node<N, J>;
+
+    fn data(&self) -> &Node<N, J> {
+        self
+    }
+
+    #[rustfmt::skip]
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self.inner() {
+            node::Inner::Iden => Dag::Iden,
+            node::Inner::Unit => Dag::Unit,
+            node::Inner::InjL(ref sub) => Dag::InjL(Arc::clone(sub)),
+            node::Inner::InjR(ref sub) => Dag::InjR(Arc::clone(sub)),
+            node::Inner::Take(ref sub) => Dag::Take(Arc::clone(sub)),
+            node::Inner::Drop(ref sub) => Dag::Drop(Arc::clone(sub)),
+            node::Inner::Comp(ref left, ref right) => Dag::Comp(Arc::clone(left), Arc::clone(right)),
+            node::Inner::Case(ref left, ref right) => Dag::Case(Arc::clone(left), Arc::clone(right)),
+            node::Inner::AssertL(ref left, _) => Dag::AssertL(Arc::clone(left)),
+            node::Inner::AssertR(_, ref right) => Dag::AssertR(Arc::clone(right)),
+            node::Inner::Pair(ref left, ref right) => Dag::Pair(Arc::clone(left), Arc::clone(right)),
+            node::Inner::Disconnect(ref left, ref right) => Dag::Disconnect(Arc::clone(left), Arc::clone(right)),
+            node::Inner::Witness(..) => Dag::Witness,
+            node::Inner::Fail(..) => Dag::Fail,
+            node::Inner::Jet(..) => Dag::Jet,
+            node::Inner::Word(..) => Dag::Word,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub use crate::merkle::{
     cmr::Cmr,
     imr::{FirstPassImr, Imr},
     tmr::Tmr,
+    FailEntropy,
 };
 pub use crate::value::Value;
 pub use simplicity_sys as ffi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod core;
 pub mod dag;
 pub mod jet;
 mod merkle;
+pub mod node;
 #[cfg(feature = "elements")]
 pub mod policy;
 pub mod types;

--- a/src/merkle/amr.rs
+++ b/src/merkle/amr.rs
@@ -21,6 +21,8 @@ use crate::{Cmr, RedeemNode, Tmr, Value};
 use bitcoin_hashes::sha256::Midstate;
 use std::rc::Rc;
 
+use super::FailEntropy;
+
 /// Annotated Merkle root
 ///
 /// A Merkle root that commits to a node's combinator, its source and target type,
@@ -165,9 +167,9 @@ impl Amr {
             .update(b.tmr().into(), Amr::from_byte_array(compact_value(value)))
     }
 
-    /// Produce a CMR for a fail combinator
-    pub fn fail(left: Amr, right: Amr) -> Self {
-        Self::FAIL_IV.update(left, right)
+    /// Produce an AMR for a fail combinator
+    pub fn fail(entropy: FailEntropy) -> Self {
+        Self::FAIL_IV.update_fail_entropy(entropy)
     }
 
     /// Produce a CMR for a jet
@@ -342,7 +344,7 @@ impl Amr {
                 right.as_ref().unwrap().amr,
             ),
             CommitNodeInner::Witness => Self::witness(ty, value.unwrap()),
-            CommitNodeInner::Fail(left, right) => Self::fail(left.into(), right.into()),
+            CommitNodeInner::Fail(entropy) => Self::fail(entropy),
             CommitNodeInner::Jet(j) => Self::jet(j),
             CommitNodeInner::Word(ref w) => Self::const_word(w),
         }

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -15,7 +15,7 @@
 use crate::core::commit::CommitNodeInner;
 use crate::impl_midstate_wrapper;
 use crate::jet::Jet;
-use crate::{Tmr, Value};
+use crate::{FailEntropy, Tmr, Value};
 use bitcoin_hashes::sha256::Midstate;
 
 use super::bip340_iv;
@@ -96,8 +96,8 @@ impl Cmr {
     }
 
     /// Produce a CMR for a fail combinator
-    pub fn fail(left: Cmr, right: Cmr) -> Self {
-        Self::FAIL_IV.update(left, right)
+    pub fn fail(entropy: FailEntropy) -> Self {
+        Self::FAIL_IV.update_fail_entropy(entropy)
     }
 
     /// Produce a CMR for a jet
@@ -275,7 +275,7 @@ impl Cmr {
             CommitNodeInner::Pair(left, right) => Self::pair(left.cmr(), right.cmr()),
             CommitNodeInner::Disconnect(left, _) => Self::disconnect(left.cmr()),
             CommitNodeInner::Witness => Self::witness(),
-            CommitNodeInner::Fail(left, right) => Self::fail(*left, *right),
+            CommitNodeInner::Fail(entropy) => Self::fail(*entropy),
             CommitNodeInner::Jet(j) => Self::jet(*j),
             CommitNodeInner::Word(w) => Self::const_word(w),
         }

--- a/src/merkle/imr.rs
+++ b/src/merkle/imr.rs
@@ -19,7 +19,7 @@ use crate::types::arrow::FinalArrow;
 use crate::{Cmr, Tmr, Value};
 use bitcoin_hashes::sha256::Midstate;
 
-use super::{bip340_iv, compact_value};
+use super::{bip340_iv, compact_value, FailEntropy};
 
 /// Identity Merkle root (first pass)
 ///
@@ -124,9 +124,9 @@ impl FirstPassImr {
         FirstPassImr(engine.midstate())
     }
 
-    /// Produce a CMR for a fail combinator
-    pub fn fail(left: FirstPassImr, right: FirstPassImr) -> Self {
-        Self::FAIL_IV.update(left, right)
+    /// Produce an IMR for a fail combinator
+    pub fn fail(entropy: FailEntropy) -> Self {
+        Self::FAIL_IV.update_fail_entropy(entropy)
     }
 
     /// Produce a CMR for a jet
@@ -264,7 +264,7 @@ impl FirstPassImr {
             CommitNodeInner::Pair(..) => Self::pair(left.unwrap(), right.unwrap()),
             CommitNodeInner::Disconnect(..) => Self::disconnect(left.unwrap(), right.unwrap()),
             CommitNodeInner::Witness => Self::witness(ty, value.unwrap()),
-            CommitNodeInner::Fail(left, right) => Self::fail(left.into(), right.into()),
+            CommitNodeInner::Fail(entropy) => Self::fail(entropy),
             CommitNodeInner::Jet(j) => Self::jet(j),
             CommitNodeInner::Word(ref w) => Self::const_word(w),
         }

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -1,0 +1,191 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use crate::dag::MaxSharing;
+use crate::jet::Jet;
+use crate::types;
+use crate::types::arrow::{Arrow, FinalArrow};
+use crate::{Cmr, Context, FirstPassImr, Imr};
+
+use super::{
+    Construct, ConstructData, ConstructNode, Constructible, Inner, NoWitness, Node, NodeData,
+};
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Commit {}
+
+impl<J: Jet> NodeData<J> for Commit {
+    type CachedData = Arc<CommitData<J>>;
+    type Witness = NoWitness;
+    type SharingId = Imr;
+
+    fn compute_sharing_id(_: Cmr, cached_data: &Arc<CommitData<J>>) -> Option<Imr> {
+        cached_data.imr
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CommitData<J: Jet> {
+    /// The source and target types of the node
+    arrow: FinalArrow,
+    /// The first-pass IMR of the node if it exists.
+    first_pass_imr: Option<FirstPassImr>,
+    /// The IMR of the node if it exists, meaning, if it is not (an ancestor of)
+    /// a witness or disconnect node.
+    imr: Option<Imr>,
+    /// This isn't really necessary, but it helps type inference if every
+    /// struct has a <J> parameter, since it forces the choice of jets to
+    /// be consistent without the user needing to specify it too many times.
+    phantom: PhantomData<J>,
+}
+
+impl<J: Jet> PartialEq for CommitData<J> {
+    // Two nodes are equal if they both have IMRs and those IMRs are equal.
+    fn eq(&self, other: &Self) -> bool {
+        self.imr
+            .zip(other.imr)
+            .map(|(a, b)| a == b)
+            .unwrap_or(false)
+    }
+}
+
+impl<J: Jet> CommitData<J> {
+    /// Accessor for the node's arrow
+    pub fn arrow(&self) -> &FinalArrow {
+        &self.arrow
+    }
+
+    /// Helper function to compute a cached first-pass IMR
+    fn first_pass_imr(inner: Inner<&Arc<Self>, J, NoWitness>) -> Option<FirstPassImr> {
+        match inner {
+            Inner::Iden => Some(FirstPassImr::iden()),
+            Inner::Unit => Some(FirstPassImr::unit()),
+            Inner::InjL(child) => child.first_pass_imr.map(FirstPassImr::injl),
+            Inner::InjR(child) => child.first_pass_imr.map(FirstPassImr::injr),
+            Inner::Take(child) => child.first_pass_imr.map(FirstPassImr::take),
+            Inner::Drop(child) => child.first_pass_imr.map(FirstPassImr::drop),
+            Inner::Comp(left, right) => left
+                .first_pass_imr
+                .zip(right.first_pass_imr)
+                .map(|(a, b)| FirstPassImr::comp(a, b)),
+            Inner::Case(left, right) => left
+                .first_pass_imr
+                .zip(right.first_pass_imr)
+                .map(|(a, b)| FirstPassImr::case(a, b)),
+            Inner::AssertL(left, r_cmr) => left
+                .first_pass_imr
+                .map(|l_imr| FirstPassImr::case(l_imr, r_cmr.into())),
+            Inner::AssertR(l_cmr, right) => right
+                .first_pass_imr
+                .map(|r_imr| FirstPassImr::case(l_cmr.into(), r_imr)),
+            Inner::Pair(left, right) => left
+                .first_pass_imr
+                .zip(right.first_pass_imr)
+                .map(|(a, b)| FirstPassImr::pair(a, b)),
+            Inner::Disconnect(..) => None,
+            Inner::Witness(..) => None,
+            Inner::Fail(entropy) => Some(FirstPassImr::fail(entropy)),
+            Inner::Jet(jet) => Some(FirstPassImr::jet(jet)),
+            Inner::Word(ref val) => Some(FirstPassImr::const_word(val)),
+        }
+    }
+
+    pub fn new(
+        arrow: &Arrow,
+        inner: Inner<&Arc<Self>, J, NoWitness>,
+    ) -> Result<Self, types::Error> {
+        let final_arrow = arrow.finalize()?;
+        let first_pass_imr = Self::first_pass_imr(inner);
+        Ok(CommitData {
+            first_pass_imr,
+            imr: first_pass_imr.map(|imr| Imr::compute_pass2(imr, &final_arrow)),
+            arrow: final_arrow,
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn from_final(arrow: FinalArrow, inner: Inner<&Arc<Self>, J, NoWitness>) -> Self {
+        let first_pass_imr = Self::first_pass_imr(inner);
+        CommitData {
+            first_pass_imr,
+            imr: first_pass_imr.map(|imr| Imr::compute_pass2(imr, &arrow)),
+            arrow,
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub type CommitNode<J> = Node<Commit, J>;
+
+impl<J: Jet> CommitNode<J> {
+    /// Accessor for the node's arrow
+    pub fn arrow(&self) -> &FinalArrow {
+        &self.data.arrow
+    }
+
+    /// Accessor for the node's IMR, if known
+    pub fn imr(&self) -> Option<Imr> {
+        self.data.imr
+    }
+
+    /// Convert a [`CommitNode`] back to a [`ConstructNode`] by redoing type inference
+    pub fn unfinalize_types(
+        &self,
+        ctx: &mut Context<J>,
+    ) -> Result<Arc<ConstructNode<J>>, types::Error> {
+        // Writing e.g. Ok(ConstructData::new(Arrow::iden(ctx))) is a little wordy.
+        macro_rules! ok_new {
+            ($fn:ident($($arg:tt)*)$($question_mark:tt)*) => {
+                Ok(ConstructData::new(Arrow::$fn($($arg)*)$($question_mark)*))
+            }
+        }
+
+        self.convert::<MaxSharing<Commit, J>, _, _, Construct, _>(
+            |_, inner| match inner {
+                Inner::Iden => ok_new!(iden(ctx)),
+                Inner::Unit => ok_new!(unit(ctx)),
+                Inner::InjL(child) => ok_new!(injl(ctx, child.arrow())),
+                Inner::InjR(child) => ok_new!(injr(ctx, child.arrow())),
+                Inner::Take(child) => ok_new!(take(ctx, child.arrow())),
+                Inner::Drop(child) => ok_new!(drop_(ctx, child.arrow())),
+                Inner::Comp(left, right) => {
+                    ok_new!(comp(ctx, left.arrow(), right.arrow())?)
+                }
+                Inner::Case(left, right) => {
+                    ok_new!(case(ctx, left.arrow(), right.arrow())?)
+                }
+                Inner::AssertL(left, r_cmr) => {
+                    ok_new!(assertl(ctx, left.arrow(), r_cmr)?)
+                }
+                Inner::AssertR(l_cmr, right) => {
+                    ok_new!(assertr(ctx, l_cmr, right.arrow())?)
+                }
+                Inner::Pair(left, right) => {
+                    ok_new!(pair(ctx, left.arrow(), right.arrow())?)
+                }
+                Inner::Disconnect(left, right) => {
+                    ok_new!(disconnect(ctx, left.arrow(), right.arrow())?)
+                }
+                Inner::Witness(..) => ok_new!(witness(ctx, NoWitness)),
+                Inner::Fail(entropy) => ok_new!(fail(ctx, entropy)),
+                Inner::Jet(jet) => ok_new!(jet(ctx, jet)),
+                Inner::Word(ref value) => ok_new!(const_word(ctx, Arc::clone(value))),
+            },
+            |_, _| Ok(NoWitness),
+        )
+    }
+}

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -1,0 +1,184 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use crate::jet::Jet;
+use crate::types::{self, arrow::Arrow};
+use crate::{Cmr, Context, FailEntropy, Value};
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use super::{Constructible, NoWitness, Node, NodeData};
+
+/// ID used to share [`ConstructNode`]s.
+///
+/// This is impossible to construct, which is a promise that it is impossible
+/// to share [`ConstructNode`]s.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum ConstructId {}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Construct {}
+
+impl<J: Jet> NodeData<J> for Construct {
+    type CachedData = ConstructData<J>;
+    type Witness = NoWitness;
+    type SharingId = ConstructId;
+
+    fn compute_sharing_id(_: Cmr, _: &ConstructData<J>) -> Option<ConstructId> {
+        None
+    }
+}
+
+pub type ConstructNode<J> = Node<Construct, J>;
+
+impl<J: Jet> ConstructNode<J> {
+    /// Accessor for the node's arrow
+    pub fn arrow(&self) -> &Arrow {
+        &self.data.arrow
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConstructData<J: Jet> {
+    arrow: Arrow,
+    /// This isn't really necessary, but it helps type inference if every
+    /// struct has a <J> parameter, since it forces the choice of jets to
+    /// be consistent without the user needing to specify it too many times.
+    phantom: PhantomData<J>,
+}
+
+impl<J: Jet> ConstructData<J> {
+    /// Constructs a new [`ConstructData`] from an (unfinalized) type arrow
+    pub fn new(arrow: Arrow) -> Self {
+        ConstructData {
+            arrow,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, J: Jet> Constructible<&'a NoWitness, J> for ConstructData<J> {
+    fn iden(ctx: &mut Context<J>) -> Self {
+        ConstructData {
+            arrow: Arrow::iden(ctx),
+            phantom: PhantomData,
+        }
+    }
+
+    fn unit(ctx: &mut Context<J>) -> Self {
+        ConstructData {
+            arrow: Arrow::unit(ctx),
+            phantom: PhantomData,
+        }
+    }
+
+    fn injl(ctx: &mut Context<J>, child: &Self) -> Self {
+        ConstructData {
+            arrow: Arrow::injl(ctx, &child.arrow),
+            phantom: PhantomData,
+        }
+    }
+
+    fn injr(ctx: &mut Context<J>, child: &Self) -> Self {
+        ConstructData {
+            arrow: Arrow::injr(ctx, &child.arrow),
+            phantom: PhantomData,
+        }
+    }
+
+    fn take(ctx: &mut Context<J>, child: &Self) -> Self {
+        ConstructData {
+            arrow: Arrow::take(ctx, &child.arrow),
+            phantom: PhantomData,
+        }
+    }
+
+    fn drop_(ctx: &mut Context<J>, child: &Self) -> Self {
+        ConstructData {
+            arrow: Arrow::drop_(ctx, &child.arrow),
+            phantom: PhantomData,
+        }
+    }
+
+    fn comp(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        Ok(ConstructData {
+            arrow: Arrow::comp(ctx, &left.arrow, &right.arrow)?,
+            phantom: PhantomData,
+        })
+    }
+
+    fn case(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        Ok(ConstructData {
+            arrow: Arrow::case(ctx, &left.arrow, &right.arrow)?,
+            phantom: PhantomData,
+        })
+    }
+
+    fn assertl(ctx: &mut Context<J>, left: &Self, right: Cmr) -> Result<Self, types::Error> {
+        Ok(ConstructData {
+            arrow: Arrow::assertl(ctx, &left.arrow, right)?,
+            phantom: PhantomData,
+        })
+    }
+
+    fn assertr(ctx: &mut Context<J>, left: Cmr, right: &Self) -> Result<Self, types::Error> {
+        Ok(ConstructData {
+            arrow: Arrow::assertr(ctx, left, &right.arrow)?,
+            phantom: PhantomData,
+        })
+    }
+
+    fn pair(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        Ok(ConstructData {
+            arrow: Arrow::pair(ctx, &left.arrow, &right.arrow)?,
+            phantom: PhantomData,
+        })
+    }
+
+    fn disconnect(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        Ok(ConstructData {
+            arrow: Arrow::disconnect(ctx, &left.arrow, &right.arrow)?,
+            phantom: PhantomData,
+        })
+    }
+
+    fn witness(ctx: &mut Context<J>, witness: &NoWitness) -> Self {
+        ConstructData {
+            arrow: Arrow::witness(ctx, *witness),
+            phantom: PhantomData,
+        }
+    }
+
+    fn fail(ctx: &mut Context<J>, entropy: FailEntropy) -> Self {
+        ConstructData {
+            arrow: Arrow::fail(ctx, entropy),
+            phantom: PhantomData,
+        }
+    }
+
+    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
+        ConstructData {
+            arrow: Arrow::jet(ctx, jet),
+            phantom: PhantomData,
+        }
+    }
+
+    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
+        ConstructData {
+            arrow: Arrow::const_word(ctx, word),
+            phantom: PhantomData,
+        }
+    }
+}

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -1,0 +1,280 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use super::FailEntropy;
+use crate::jet::Jet;
+use crate::{Cmr, Value};
+
+use std::fmt;
+use std::sync::Arc;
+
+/// Internal "Simplicity DAG" structure.
+///
+/// This structure is used to indicate the type of a node and provide
+/// pointers or references to its children, if any.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Inner<C, J: Jet, W> {
+    /// Identity
+    Iden,
+    /// Unit constant
+    Unit,
+    /// Left injection of some child
+    InjL(C),
+    /// Right injection of some child
+    InjR(C),
+    /// Take of some child
+    Take(C),
+    /// Drop of some child
+    Drop(C),
+    /// Composition of a left and right child
+    Comp(C, C),
+    /// Case of a left and right child
+    Case(C, C),
+    /// Left assertion of a left and right child.
+    AssertL(C, Cmr),
+    /// Right assertion of a left and right child.
+    AssertR(Cmr, C),
+    /// Pair of a left and right child
+    Pair(C, C),
+    /// Disconnect of a left and right child
+    Disconnect(C, C),
+    /// Witness data (missing during commitment, inserted during redemption)
+    Witness(W),
+    /// Universal fail
+    Fail(FailEntropy),
+    /// Application jet
+    Jet(J),
+    /// Constant word
+    Word(Arc<Value>),
+}
+
+impl<C, J: Jet, W> Inner<C, J, W> {
+    /// Convert a node's combinator data to a different type.
+    pub fn map<D, F: FnMut(C) -> D>(self, mut f: F) -> Inner<D, J, W> {
+        match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(f(c)),
+            Inner::InjR(c) => Inner::InjR(f(c)),
+            Inner::Take(c) => Inner::Take(f(c)),
+            Inner::Drop(c) => Inner::Drop(f(c)),
+            Inner::Comp(cl, cr) => Inner::Comp(f(cl), f(cr)),
+            Inner::Case(cl, cr) => Inner::Case(f(cl), f(cr)),
+            Inner::AssertL(c, cmr) => Inner::AssertL(f(c), cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, f(c)),
+            Inner::Pair(cl, cr) => Inner::Pair(f(cl), f(cr)),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(f(cl), f(cr)),
+            Inner::Witness(w) => Inner::Witness(w),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        }
+    }
+
+    /// Convert a node's combinator data to a different type.
+    pub fn map_result<D, E, F: FnMut(C) -> Result<D, E>>(
+        self,
+        mut f: F,
+    ) -> Result<Inner<D, J, W>, E> {
+        Ok(match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(f(c)?),
+            Inner::InjR(c) => Inner::InjR(f(c)?),
+            Inner::Take(c) => Inner::Take(f(c)?),
+            Inner::Drop(c) => Inner::Drop(f(c)?),
+            Inner::Comp(cl, cr) => Inner::Comp(f(cl)?, f(cr)?),
+            Inner::Case(cl, cr) => Inner::Case(f(cl)?, f(cr)?),
+            Inner::AssertL(c, cmr) => Inner::AssertL(f(c)?, cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, f(c)?),
+            Inner::Pair(cl, cr) => Inner::Pair(f(cl)?, f(cr)?),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(f(cl)?, f(cr)?),
+            Inner::Witness(w) => Inner::Witness(w),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        })
+    }
+
+    /// Convert a node's combinator data to a different type, mapping each
+    /// child separately.
+    ///
+    /// Importantly, the child of an `AssertR` node is considered the left
+    /// child, because as a DAG node, this is the sole (left) child, even
+    /// though as a combinator, it is a right child.
+    pub fn map_left_right<D, FL, FR>(self, fl: FL, fr: FR) -> Inner<D, J, W>
+    where
+        FL: FnOnce(C) -> D,
+        FR: FnOnce(C) -> D,
+    {
+        match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(fl(c)),
+            Inner::InjR(c) => Inner::InjR(fl(c)),
+            Inner::Take(c) => Inner::Take(fl(c)),
+            Inner::Drop(c) => Inner::Drop(fl(c)),
+            Inner::Comp(cl, cr) => Inner::Comp(fl(cl), fr(cr)),
+            Inner::Case(cl, cr) => Inner::Case(fl(cl), fr(cr)),
+            Inner::AssertL(c, cmr) => Inner::AssertL(fl(c), cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, fl(c)),
+            Inner::Pair(cl, cr) => Inner::Pair(fl(cl), fr(cr)),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(fl(cl), fr(cr)),
+            Inner::Witness(w) => Inner::Witness(w),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        }
+    }
+
+    /// Take references to all contained data.
+    pub fn as_ref(&self) -> Inner<&C, J, &W> {
+        match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(c),
+            Inner::InjR(c) => Inner::InjR(c),
+            Inner::Take(c) => Inner::Take(c),
+            Inner::Drop(c) => Inner::Drop(c),
+            Inner::Comp(cl, cr) => Inner::Comp(cl, cr),
+            Inner::Case(cl, cr) => Inner::Case(cl, cr),
+            Inner::AssertL(c, cmr) => Inner::AssertL(c, *cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(*cmr, c),
+            Inner::Pair(cl, cr) => Inner::Pair(cl, cr),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(cl, cr),
+            Inner::Witness(w) => Inner::Witness(w),
+            Inner::Fail(entropy) => Inner::Fail(*entropy),
+            Inner::Jet(j) => Inner::Jet(*j),
+            Inner::Word(w) => Inner::Word(Arc::clone(w)),
+        }
+    }
+
+    /// Convert a node's witness data to a different type.
+    pub fn map_witness<V, F: FnOnce(W) -> V>(self, f: F) -> Inner<C, J, V> {
+        match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(c),
+            Inner::InjR(c) => Inner::InjR(c),
+            Inner::Take(c) => Inner::Take(c),
+            Inner::Drop(c) => Inner::Drop(c),
+            Inner::Comp(cl, cr) => Inner::Comp(cl, cr),
+            Inner::Case(cl, cr) => Inner::Case(cl, cr),
+            Inner::AssertL(c, cmr) => Inner::AssertL(c, cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, c),
+            Inner::Pair(cl, cr) => Inner::Pair(cl, cr),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(cl, cr),
+            Inner::Witness(w) => Inner::Witness(f(w)),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        }
+    }
+
+    /// Convert a node's witness data to a different type.
+    pub fn map_witness_result<V, E, F: FnOnce(W) -> Result<V, E>>(
+        self,
+        f: F,
+    ) -> Result<Inner<C, J, V>, E> {
+        Ok(match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(c),
+            Inner::InjR(c) => Inner::InjR(c),
+            Inner::Take(c) => Inner::Take(c),
+            Inner::Drop(c) => Inner::Drop(c),
+            Inner::Comp(cl, cr) => Inner::Comp(cl, cr),
+            Inner::Case(cl, cr) => Inner::Case(cl, cr),
+            Inner::AssertL(c, cmr) => Inner::AssertL(c, cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, c),
+            Inner::Pair(cl, cr) => Inner::Pair(cl, cr),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(cl, cr),
+            Inner::Witness(w) => Inner::Witness(f(w)?),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        })
+    }
+}
+
+impl<C, J: Jet, W> Inner<Option<C>, J, W> {
+    /// Convert an `Inner<Option<C>, J, W>` to an `Option<Inner<C, J, W>>`.
+    pub fn transpose(self) -> Option<Inner<C, J, W>> {
+        Some(match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(c?),
+            Inner::InjR(c) => Inner::InjR(c?),
+            Inner::Take(c) => Inner::Take(c?),
+            Inner::Drop(c) => Inner::Drop(c?),
+            Inner::Comp(cl, cr) => Inner::Comp(cl?, cr?),
+            Inner::Case(cl, cr) => Inner::Case(cl?, cr?),
+            Inner::AssertL(c, cmr) => Inner::AssertL(c?, cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, c?),
+            Inner::Pair(cl, cr) => Inner::Pair(cl?, cr?),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(cl?, cr?),
+            Inner::Witness(w) => Inner::Witness(w),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        })
+    }
+}
+
+impl<C, J: Jet, W> Inner<C, J, Option<W>> {
+    /// Convert an `Inner<C, J, Option<W>>` to an `Option<Inner<C, J, W>>`.
+    pub fn transpose_witness(self) -> Option<Inner<C, J, W>> {
+        Some(match self {
+            Inner::Iden => Inner::Iden,
+            Inner::Unit => Inner::Unit,
+            Inner::InjL(c) => Inner::InjL(c),
+            Inner::InjR(c) => Inner::InjR(c),
+            Inner::Take(c) => Inner::Take(c),
+            Inner::Drop(c) => Inner::Drop(c),
+            Inner::Comp(cl, cr) => Inner::Comp(cl, cr),
+            Inner::Case(cl, cr) => Inner::Case(cl, cr),
+            Inner::AssertL(c, cmr) => Inner::AssertL(c, cmr),
+            Inner::AssertR(cmr, c) => Inner::AssertR(cmr, c),
+            Inner::Pair(cl, cr) => Inner::Pair(cl, cr),
+            Inner::Disconnect(cl, cr) => Inner::Disconnect(cl, cr),
+            Inner::Witness(w) => Inner::Witness(w?),
+            Inner::Fail(entropy) => Inner::Fail(entropy),
+            Inner::Jet(j) => Inner::Jet(j),
+            Inner::Word(w) => Inner::Word(w),
+        })
+    }
+}
+
+impl<C, J: Jet, W> fmt::Display for Inner<C, J, W> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Inner::Iden => f.write_str("iden"),
+            Inner::Unit => f.write_str("unit"),
+            Inner::InjL(_) => f.write_str("injl"),
+            Inner::InjR(_) => f.write_str("injr"),
+            Inner::Take(_) => f.write_str("take"),
+            Inner::Drop(_) => f.write_str("drop"),
+            Inner::Comp(_, _) => f.write_str("comp"),
+            Inner::Case(_, _) => f.write_str("case"),
+            Inner::AssertL(_, _) => f.write_str("assertl"),
+            Inner::AssertR(_, _) => f.write_str("assertr"),
+            Inner::Pair(_, _) => f.write_str("pair"),
+            Inner::Disconnect(_, _) => f.write_str("disconnect"),
+            Inner::Witness(..) => f.write_str("witness"),
+            Inner::Fail(..) => f.write_str("fail"),
+            Inner::Jet(jet) => write!(f, "jet({})", jet),
+            Inner::Word(w) => write!(f, "word({})", w),
+        }
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -92,10 +92,12 @@ use std::{fmt, hash};
 mod commit;
 mod construct;
 mod inner;
+mod redeem;
 
 pub use commit::{Commit, CommitData, CommitNode};
 pub use construct::{Construct, ConstructData, ConstructNode};
 pub use inner::Inner;
+pub use redeem::{Redeem, RedeemData, RedeemNode};
 
 // This trait should only be implemented on empty types, so we can demand
 // every trait bound under the sun. Doing so will make #[derive]s easier

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -89,9 +89,11 @@ use crate::{types, Cmr, Context, FailEntropy, Value};
 use std::sync::Arc;
 use std::{fmt, hash};
 
+mod commit;
 mod construct;
 mod inner;
 
+pub use commit::{Commit, CommitData, CommitNode};
 pub use construct::{Construct, ConstructData, ConstructNode};
 pub use inner::Inner;
 

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,0 +1,233 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use crate::dag::{DagLike, InternalSharing};
+use crate::jet::Jet;
+use crate::{types, Cmr, Context, FailEntropy, Value};
+
+use std::sync::Arc;
+use std::{fmt, hash};
+
+mod inner;
+
+pub use inner::Inner;
+
+// This trait should only be implemented on empty types, so we can demand
+// every trait bound under the sun. Doing so will make #[derive]s easier
+// for downstream users.
+pub trait NodeData<J: Jet>:
+    Copy + Clone + PartialEq + Eq + PartialOrd + Ord + fmt::Debug + hash::Hash
+{
+    type CachedData: Clone;
+    type Witness: Clone;
+}
+
+/// Null data type used as dummy for [`NodeData::Witness`]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct NoWitness;
+
+pub trait Constructible<W, J: Jet>: Sized {
+    fn iden(ctx: &mut Context<J>) -> Self;
+    fn unit(ctx: &mut Context<J>) -> Self;
+    fn injl(ctx: &mut Context<J>, child: &Self) -> Self;
+    fn injr(ctx: &mut Context<J>, child: &Self) -> Self;
+    fn take(ctx: &mut Context<J>, child: &Self) -> Self;
+    fn drop_(ctx: &mut Context<J>, child: &Self) -> Self;
+    fn comp(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error>;
+    fn case(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error>;
+    fn assertl(ctx: &mut Context<J>, left: &Self, right: Cmr) -> Result<Self, types::Error>;
+    fn assertr(ctx: &mut Context<J>, left: Cmr, right: &Self) -> Result<Self, types::Error>;
+    fn pair(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error>;
+    fn disconnect(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error>;
+    fn witness(ctx: &mut Context<J>, witness: W) -> Self;
+    fn fail(ctx: &mut Context<J>, entropy: FailEntropy) -> Self;
+    fn jet(ctx: &mut Context<J>, jet: J) -> Self;
+    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self;
+
+    /// Create a DAG that takes any input and returns `value` as constant output.
+    ///
+    /// _Overall type: A → B where value: B_
+    fn scribe(context: &mut Context<J>, value: &Value) -> Self {
+        match value {
+            Value::Unit => Self::unit(context),
+            Value::SumL(l) => {
+                let l = Self::scribe(context, l);
+                Self::injl(context, &l)
+            }
+            Value::SumR(r) => {
+                let r = Self::scribe(context, r);
+                Self::injr(context, &r)
+            }
+            Value::Prod(l, r) => {
+                let l = Self::scribe(context, l);
+                let r = Self::scribe(context, r);
+                Self::pair(context, &l, &r).expect("source of scribe has no constraints")
+            }
+        }
+    }
+
+    /// Create a DAG that takes any input and returns bit `0` as constant output.
+    ///
+    /// _Overall type: A → 2_
+    fn bit_false(context: &mut Context<J>) -> Self {
+        let unit = Self::unit(context);
+        Self::injl(context, &unit)
+    }
+
+    /// Create a DAG that takes any input and returns bit `1` as constant output.
+    ///
+    /// _Overall type: A → 2_
+    fn bit_true(context: &mut Context<J>) -> Self {
+        let unit = Self::unit(context);
+        Self::injr(context, &unit)
+    }
+
+    /// Create a DAG that takes a bit and an input,
+    /// such that the `left` child is evaluated on the input if the bit is `1` _(if branch)_
+    /// and the `right` child is evaluated on the input otherwise _(else branch)_.
+    ///
+    /// _Overall type: 2 × A → B where `left`: A → B and `right`: A → B_
+    ///
+    /// _Type inference will fail if children are not of the correct type._
+    fn cond(context: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        let drop_left = Self::drop_(context, left);
+        let drop_right = Self::drop_(context, right);
+        Self::case(context, &drop_right, &drop_left)
+    }
+
+    /// Create a DAG that asserts that its child returns `true`, and fails otherwise.
+    /// The `hash` identifies the assertion and is returned upon failure.
+    ///
+    /// _Overall type: A → 1 where `child`: A → 2_
+    ///
+    /// _Type inference will fail if children are not of the correct type._
+    fn assert(context: &mut Context<J>, child: &Self, hash: Cmr) -> Result<Self, types::Error> {
+        let unit = Self::unit(context);
+        let pair_child_unit = Self::pair(context, child, &unit)?;
+        let assertr_hidden_unit = Self::assertr(context, hash, &unit)?;
+
+        Self::comp(context, &pair_child_unit, &assertr_hidden_unit)
+    }
+
+    /// Create a DAG that computes Boolean _NOT_ of the `child`.
+    ///
+    /// _Overall type: A → 2 where `child`: A → 2_
+    ///
+    /// _Type inference will fail if children are not of the correct type._
+    #[allow(clippy::should_implement_trait)]
+    fn not(context: &mut Context<J>, child: &Self) -> Result<Self, types::Error> {
+        let unit = Self::unit(context);
+        let pair_child_unit = Self::pair(context, child, &unit)?;
+        let bit_true = Self::bit_true(context);
+        let bit_false = Self::bit_false(context);
+        let case_true_false = Self::case(context, &bit_true, &bit_false)?;
+
+        Self::comp(context, &pair_child_unit, &case_true_false)
+    }
+
+    /// Create a DAG that computes Boolean _AND_ of the `left` and `right` child.
+    ///
+    /// _Overall type: A → 2 where `left`: A → 2 and `right`: A → 2_
+    ///
+    /// _Type inference will fail if children are not of the correct type._
+    fn and(context: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        let iden = Self::iden(context);
+        let pair_left_iden = Self::pair(context, left, &iden)?;
+        let bit_false = Self::bit_false(context);
+        let drop_right = Self::drop_(context, right);
+        let case_false_right = Self::case(context, &bit_false, &drop_right)?;
+
+        Self::comp(context, &pair_left_iden, &case_false_right)
+    }
+
+    /// Create a DAG that computes Boolean _OR_ of the `left` and `right`.
+    ///
+    /// _Overall type: A → 2 where `left`: A → 2 and `right`: A → 2_
+    ///
+    /// _Type inference will fail if children are not of the correct type._
+    fn or(context: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+        let iden = Self::iden(context);
+        let pair_left_iden = Self::pair(context, left, &iden)?;
+        let drop_right = Self::drop_(context, right);
+        let bit_true = Self::bit_true(context);
+        let case_right_true = Self::case(context, &drop_right, &bit_true)?;
+
+        Self::comp(context, &pair_left_iden, &case_right_true)
+    }
+}
+
+/// A node in a Simplicity expression.
+///
+/// There are three node types provided by this library: `ConstructNode`, `CommitNode`,
+/// and `RedeemNode`, which represent Simplicty programs during construction, at
+/// commitment time, and at redemption time, respectively.
+///
+/// This generic structure is used to define conversions and mapping functions over
+/// nodes and DAGs, and allows users to define their own custom node types.
+///
+/// For equality and hashing purposes, nodes are characterized entirely by their
+/// CMR and cached data. Users who create custom nodes should define a custom type
+/// for [`NodeData::CachedData`] and think carefully about whether and how to
+/// implement the [`std::hash::Hash`] or equality traits.
+#[derive(Debug)]
+pub struct Node<N: NodeData<J>, J: Jet> {
+    inner: Inner<Arc<Node<N, J>>, J, N::Witness>,
+    cmr: Cmr,
+    data: N::CachedData,
+}
+
+impl<N: NodeData<J>, J: Jet> PartialEq for Node<N, J>
+where
+    N::CachedData: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.cmr == other.cmr && self.data == other.data
+    }
+}
+impl<N: NodeData<J>, J: Jet> Eq for Node<N, J> where N::CachedData: Eq {}
+
+impl<N: NodeData<J>, J: Jet> hash::Hash for Node<N, J>
+where
+    N::CachedData: hash::Hash,
+{
+    fn hash<H: hash::Hasher>(&self, h: &mut H) {
+        self.cmr.hash(h);
+        self.data.hash(h);
+    }
+}
+
+impl<N: NodeData<J>, J: Jet> fmt::Display for Node<N, J>
+where
+    for<'a> &'a Node<N, J>: DagLike,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.post_order_iter::<InternalSharing>().into_display(
+            f,
+            |node, f| fmt::Display::fmt(&node.inner, f),
+            |_, _| Ok(()),
+        )
+    }
+}
+
+impl<N: NodeData<J>, J: Jet> Node<N, J> {
+    /// Accessor for the node's "inner value", i.e. its combinator
+    pub fn inner(&self) -> &Inner<Arc<Node<N, J>>, J, N::Witness> {
+        &self.inner
+    }
+
+    /// Accessor for the node's CMR
+    pub fn cmr(&self) -> Cmr {
+        self.cmr
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -89,8 +89,10 @@ use crate::{types, Cmr, Context, FailEntropy, Value};
 use std::sync::Arc;
 use std::{fmt, hash};
 
+mod construct;
 mod inner;
 
+pub use construct::{Construct, ConstructData, ConstructNode};
 pub use inner::Inner;
 
 // This trait should only be implemented on empty types, so we can demand

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -1,0 +1,191 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use crate::analysis::NodeBounds;
+use crate::dag::MaxSharing;
+use crate::jet::Jet;
+use crate::types::{self, arrow::FinalArrow};
+use crate::{Amr, Cmr, FirstPassImr, Imr, Value};
+
+use super::{CommitData, CommitNode, Inner, NoWitness, Node, NodeData};
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Redeem {}
+
+impl<J: Jet> NodeData<J> for Redeem {
+    type CachedData = Arc<RedeemData<J>>;
+    type Witness = Arc<Value>;
+    type SharingId = Imr;
+
+    fn compute_sharing_id(_: Cmr, cached_data: &Arc<RedeemData<J>>) -> Option<Imr> {
+        Some(cached_data.imr)
+    }
+}
+
+pub type RedeemNode<J> = Node<Redeem, J>;
+
+#[derive(Clone, Debug)]
+pub struct RedeemData<J: Jet> {
+    amr: Amr,
+    first_pass_imr: FirstPassImr,
+    imr: Imr,
+    arrow: FinalArrow,
+    bounds: NodeBounds,
+    /// This isn't really necessary, but it helps type inference if every
+    /// struct has a <J> parameter, since it forces the choice of jets to
+    /// be consistent without the user needing to specify it too many times.
+    phantom: PhantomData<J>,
+}
+
+impl<J: Jet> PartialEq for RedeemData<J> {
+    fn eq(&self, other: &Self) -> bool {
+        self.imr == other.imr
+    }
+}
+impl<J: Jet> Eq for RedeemData<J> {}
+
+impl<J: Jet> std::hash::Hash for RedeemData<J> {
+    fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
+        self.imr.hash(hasher)
+    }
+}
+
+impl<J: Jet> RedeemData<J> {
+    pub fn new(arrow: FinalArrow, inner: Inner<&Arc<Self>, J, Arc<Value>>) -> Self {
+        let (amr, first_pass_imr, bounds) = match inner {
+            Inner::Iden => (Amr::iden(&arrow), FirstPassImr::iden(), NodeBounds::iden()),
+            Inner::Unit => (Amr::unit(&arrow), FirstPassImr::unit(), NodeBounds::unit()),
+            Inner::InjL(child) => (
+                Amr::injl(&arrow, child.amr),
+                FirstPassImr::injl(child.first_pass_imr),
+                NodeBounds::injl(child.bounds),
+            ),
+            Inner::InjR(child) => (
+                Amr::injr(&arrow, child.amr),
+                FirstPassImr::injr(child.first_pass_imr),
+                NodeBounds::injr(child.bounds),
+            ),
+            Inner::Take(child) => (
+                Amr::take(&arrow, child.amr),
+                FirstPassImr::take(child.first_pass_imr),
+                NodeBounds::take(child.bounds),
+            ),
+            Inner::Drop(child) => (
+                Amr::drop(&arrow, child.amr),
+                FirstPassImr::drop(child.first_pass_imr),
+                NodeBounds::drop(child.bounds),
+            ),
+            Inner::Comp(left, right) => (
+                Amr::comp(&arrow, &left.arrow, left.amr, right.amr),
+                FirstPassImr::comp(left.first_pass_imr, right.first_pass_imr),
+                NodeBounds::comp(left.bounds, right.bounds, left.arrow.target.bit_width()),
+            ),
+            Inner::Case(left, right) => (
+                Amr::case(&arrow, left.amr, right.amr),
+                FirstPassImr::case(left.first_pass_imr, right.first_pass_imr),
+                NodeBounds::case(left.bounds, right.bounds),
+            ),
+            Inner::AssertL(left, r_cmr) => (
+                Amr::assertl(&arrow, left.amr, r_cmr.into()),
+                FirstPassImr::case(left.first_pass_imr, r_cmr.into()),
+                NodeBounds::assertl(left.bounds),
+            ),
+            Inner::AssertR(l_cmr, right) => (
+                Amr::assertr(&arrow, l_cmr.into(), right.amr),
+                FirstPassImr::case(l_cmr.into(), right.first_pass_imr),
+                NodeBounds::assertr(right.bounds),
+            ),
+            Inner::Pair(left, right) => (
+                Amr::pair(&arrow, &left.arrow, &right.arrow, left.amr, right.amr),
+                FirstPassImr::pair(left.first_pass_imr, right.first_pass_imr),
+                NodeBounds::pair(left.bounds, right.bounds),
+            ),
+            Inner::Disconnect(left, right) => (
+                Amr::disconnect(&arrow, &left.arrow, left.amr, right.amr),
+                FirstPassImr::disconnect(left.first_pass_imr, right.first_pass_imr),
+                NodeBounds::disconnect(
+                    left.bounds,
+                    right.bounds,
+                    left.arrow.source.bit_width(),
+                    left.arrow.target.bit_width(),
+                ),
+            ),
+            Inner::Witness(ref value) => (
+                Amr::witness(&arrow, value),
+                FirstPassImr::witness(&arrow, value),
+                NodeBounds::witness(arrow.target.bit_width()),
+            ),
+            Inner::Fail(entropy) => (
+                Amr::fail(entropy),
+                FirstPassImr::fail(entropy),
+                NodeBounds::fail(),
+            ),
+            Inner::Jet(jet) => (Amr::jet(jet), FirstPassImr::jet(jet), NodeBounds::jet()),
+            Inner::Word(ref val) => (
+                Amr::const_word(val),
+                FirstPassImr::const_word(val),
+                NodeBounds::const_word(),
+            ),
+        };
+
+        RedeemData {
+            amr,
+            first_pass_imr,
+            imr: Imr::compute_pass2(first_pass_imr, &arrow),
+            arrow,
+            bounds,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<J: Jet> RedeemNode<J> {
+    /// Accessor for the node's AMR
+    pub fn amr(&self) -> Amr {
+        self.data.amr
+    }
+
+    /// Accessor for the node's IMR
+    pub fn imr(&self) -> Imr {
+        self.data.imr
+    }
+
+    /// Accessor for the node's type arrow
+    pub fn arrow(&self) -> &FinalArrow {
+        &self.data.arrow
+    }
+
+    /// Accessor for the node's bit machine bounds
+    pub fn bounds(&self) -> NodeBounds {
+        self.data.bounds
+    }
+
+    /// Convert a [`RedeemNode`] back to a [`CommitNode`] by forgetting witnesses
+    /// and cached data.
+    pub fn unfinalize(&self) -> Result<Arc<CommitNode<J>>, types::Error> {
+        self.convert::<MaxSharing<Redeem, J>, _, _, _, _>(
+            |data, converted| {
+                let converted_data = converted.map(|node| node.cached_data());
+                Ok(Arc::new(CommitData::from_final(
+                    data.node.data.arrow.shallow_clone(),
+                    converted_data,
+                )))
+            },
+            |_, _| Ok(NoWitness),
+        )
+    }
+}

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -22,7 +22,7 @@ use crate::jet::Elements;
 use crate::miniscript::MiniscriptKey;
 use crate::policy::key::PublicKey32;
 use crate::types::Error;
-use crate::{Cmr, Context, Value};
+use crate::{Context, FailEntropy, Value};
 use std::rc::Rc;
 
 impl<Pk: MiniscriptKey + PublicKey32> Policy<Pk> {
@@ -64,11 +64,7 @@ fn compile<Pk: MiniscriptKey + PublicKey32>(
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
     match policy {
         // TODO: Choose specific Merkle roots for unsatisfiable policies
-        Policy::Unsatisfiable => Ok(CommitNode::fail(
-            context,
-            Cmr::from_byte_array([0; 32]),
-            Cmr::from_byte_array([0; 32]),
-        )),
+        Policy::Unsatisfiable => Ok(CommitNode::fail(context, FailEntropy::ZERO)),
         Policy::Trivial => Ok(CommitNode::unit(context)),
         Policy::Key(key) => {
             let key_value = Value::u256_from_slice(&key.to_32_bytes());

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -61,6 +61,16 @@ impl fmt::Display for FinalArrow {
     }
 }
 
+impl FinalArrow {
+    /// Same as [`Self::clone`] but named to make it clearer that this is cheap
+    pub fn shallow_clone(&self) -> Self {
+        FinalArrow {
+            source: Arc::clone(&self.source),
+            target: Arc::clone(&self.target),
+        }
+    }
+}
+
 impl Arrow {
     /// Finalize the source and target types in the arrow
     pub fn finalize(&self) -> Result<FinalArrow, Error> {
@@ -109,7 +119,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh jet combinator
-    pub fn for_jet<J: Jet>(context: &mut Context<J>, jet: &J) -> Self {
+    pub fn for_jet<J: Jet>(context: &mut Context<J>, jet: J) -> Self {
         Arrow {
             source: jet.source_ty().to_type(|n| context.nth_power_of_2(n)),
             target: jet.target_ty().to_type(|n| context.nth_power_of_2(n)),
@@ -283,5 +293,13 @@ impl Arrow {
             source: a,
             target: prod_b_d,
         })
+    }
+
+    /// Same as [`Self::clone`] but named to make it clearer that this is cheap
+    pub fn shallow_clone(&self) -> Self {
+        Arrow {
+            source: self.source.shallow_clone(),
+            target: self.target.shallow_clone(),
+        }
     }
 }

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -26,6 +26,7 @@
 use std::fmt;
 use std::sync::Arc;
 
+use crate::node::{Constructible, NoWitness};
 use crate::types::{Bound, Error, Final, Type};
 use crate::{jet::Jet, Context, Value};
 
@@ -301,5 +302,71 @@ impl Arrow {
             source: self.source.shallow_clone(),
             target: self.target.shallow_clone(),
         }
+    }
+}
+
+impl<J: Jet> Constructible<NoWitness, J> for Arrow {
+    fn iden(ctx: &mut Context<J>) -> Self {
+        Self::for_iden(ctx)
+    }
+
+    fn unit(ctx: &mut Context<J>) -> Self {
+        Self::for_unit(ctx)
+    }
+
+    fn injl(ctx: &mut Context<J>, child: &Self) -> Self {
+        Self::for_injl(ctx, child)
+    }
+
+    fn injr(ctx: &mut Context<J>, child: &Self) -> Self {
+        Self::for_injr(ctx, child)
+    }
+
+    fn take(ctx: &mut Context<J>, child: &Self) -> Self {
+        Self::for_take(ctx, child)
+    }
+
+    fn drop_(ctx: &mut Context<J>, child: &Self) -> Self {
+        Self::for_drop(ctx, child)
+    }
+
+    fn comp(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+        Self::for_comp(ctx, left, right)
+    }
+
+    fn case(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+        Self::for_case(ctx, Some(left), Some(right))
+    }
+
+    fn assertl(ctx: &mut Context<J>, left: &Self, _: crate::Cmr) -> Result<Self, Error> {
+        Self::for_case(ctx, Some(left), None)
+    }
+
+    fn assertr(ctx: &mut Context<J>, _: crate::Cmr, right: &Self) -> Result<Self, Error> {
+        Self::for_case(ctx, None, Some(right))
+    }
+
+    fn pair(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+        Self::for_pair(ctx, left, right)
+    }
+
+    fn disconnect(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+        Self::for_disconnect(ctx, left, right)
+    }
+
+    fn witness(ctx: &mut Context<J>, _: NoWitness) -> Self {
+        Self::for_witness(ctx)
+    }
+
+    fn fail(ctx: &mut Context<J>, _: crate::FailEntropy) -> Self {
+        Self::for_fail(ctx)
+    }
+
+    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
+        Self::for_jet(ctx, jet)
+    }
+
+    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
+        Self::for_const_word(ctx, &word)
     }
 }


### PR DESCRIPTION
This is part of another multi-PR project to replace `RedeemNode` and `CommitNode` with three new node types, `ConstructNode` (roughly the same as our current `CommitNode`), `CommitNode` (which will have complete types and be immediately usable for e.g. address computation), and `RedeemNode` (pretty-much the same as our current `RedeemNode`).

The idea is that when building a node programmatically, you would use `ConstructNode`s, which have no way to be de/serialized and generally have pretty limited functionality. Then you'd convert to `CommitNode`s, which have a canoncial bit-encoding as well as a human-readable encoding, and represent a complete program, up to witnesses and disconnects. Though for now the code continues to treat `Disconnect` as always-populated and basically a version of `Comp` with a weird CMR. We can revisit `disconnect` once we start writing nontrivial code using it.

This PR does a couple cleanups then introduces some new data structures. It does not actually use them anywhere or replace any existing code, which it turns out is fairly invasive and needs to happen across many more commits (and probably multiple PRs). But it does include basic conversions between the new node types so you can see how that'll work.

Happy to shrink or re-arrange this PR if that would make review easier.