### PR TITLE
Simplicity descriptors

### DIFF
--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -190,6 +190,18 @@ impl<J: Jet> RedeemNode<J> {
         w.flush_all()?;
         Ok(program_bits + witness_bits)
     }
+
+    /// Encode a Simplicity program to a vector of bytes, including the witness data.
+    pub fn encode_to_vec(&self) -> Vec<u8> {
+        let mut program_and_witness_bytes = Vec::<u8>::new();
+        let mut writer = BitWriter::new(&mut program_and_witness_bytes);
+        self.encode(&mut writer)
+            .expect("write to vector never fails");
+        writer.flush_all().expect("flushing vector never fails");
+        debug_assert!(!program_and_witness_bytes.is_empty());
+
+        program_and_witness_bytes
+    }
 }
 
 impl<J: Jet> fmt::Display for RedeemNode<J> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use bit_encoding::BitIter;
 pub use bit_encoding::BitWriter;
 
 #[cfg(feature = "elements")]
-pub use crate::policy::Policy;
+pub use crate::policy::{Descriptor, Policy};
 
 pub use crate::bit_machine::exec;
 pub use crate::context::Context;

--- a/src/policy/descriptor.rs
+++ b/src/policy/descriptor.rs
@@ -1,0 +1,173 @@
+use crate::policy::key::PublicKey32;
+use crate::policy::satisfy::PolicySatisfier;
+use crate::{policy, Cmr, Context, Policy};
+use elements::secp256k1_zkp;
+use elements::taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo};
+use elements_miniscript::{MiniscriptKey, ToPublicKey};
+use std::fmt;
+use std::str::FromStr;
+
+/// Bytes of x-only public key whose discrete logarithm (secret key) is unknown
+///
+/// Taken from BIP 341
+const UNSPENDABLE_PUBLIC_KEY: [u8; 32] = [
+    0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a, 0x5e,
+    0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
+];
+/// Version of Simplicity tap leaves
+pub const TAPROOT_LEAF_SIMPLICITY: u8 = 0xbe;
+
+/// Return the version of Simplicity tap leaves
+pub fn leaf_version() -> LeafVersion {
+    LeafVersion::from_u8(TAPROOT_LEAF_SIMPLICITY).expect("constant leaf version")
+}
+
+// TODO: Support multiple tap leaves
+/// Descriptor of Simplicity outputs.
+///
+/// Simplicity is embedded in Taproot outputs as tap leaves with version 0xbe.
+///
+/// The tap tree can include many leaves, be it version 0xc0 (standard Taproot) or 0xbe (Simplicity).
+/// Currently only trees with a single Simplicity leaf are supported.
+///
+/// On "top" of the tap tree sits the internal key which can be used as an alternative spending path
+/// if all parties that own the output agree to sign.
+///
+/// The internal key can be a normal public key (p2pk), a MuSig aggregate public key (multisig)
+/// or an unspendable public key in case this feature is undesirable.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Descriptor<Pk: MiniscriptKey> {
+    internal_key: Pk,
+    spend_info: TaprootSpendInfo,
+    policy: Policy<Pk>,
+    cmr: Cmr,
+}
+
+impl<Pk: PublicKey32 + ToPublicKey> Descriptor<Pk> {
+    /// Create a new descriptor from the given internal key and
+    /// policy which will become a single tap leaf
+    pub fn new(internal_key: Pk, policy: Policy<Pk>) -> Result<Self, crate::Error> {
+        let mut context = Context::default();
+        let commit = policy.compile(&mut context)?;
+        let cmr = commit.cmr();
+        let script = elements::Script::from(Vec::from(cmr.as_ref()));
+        let version = leaf_version();
+
+        let builder = TaprootBuilder::new()
+            .add_leaf_with_ver(0, script, version)
+            .expect("constant leaf");
+        let secp = secp256k1_zkp::Secp256k1::verification_only();
+        let spend_info = builder
+            .finalize(&secp, internal_key.to_x_only_pubkey())
+            .expect("constant tree");
+
+        Ok(Self {
+            internal_key,
+            spend_info,
+            policy,
+            cmr,
+        })
+    }
+
+    /// Create a new descriptor from the given policy which will become a single tap leaf
+    ///
+    /// The internal key is set to a constant that is provably not spendable
+    pub fn single_leaf(policy: Policy<Pk>) -> Result<Self, crate::Error> {
+        let bytes = Vec::<u8>::from(UNSPENDABLE_PUBLIC_KEY);
+        let internal_key = Pk::from_32_bytes(&bytes);
+        Self::new(internal_key, policy)
+    }
+
+    /// Return the internal key
+    pub fn internal_key(&self) -> &Pk {
+        &self.internal_key
+    }
+
+    /// Return the spend data
+    pub fn spend_info(&self) -> &TaprootSpendInfo {
+        &self.spend_info
+    }
+
+    /// Return the script pubkey
+    pub fn script_pubkey(&self) -> elements::Script {
+        let output_key = self.spend_info().output_key();
+        let builder = elements::script::Builder::new();
+        builder
+            .push_opcode(elements::opcodes::all::OP_PUSHNUM_1)
+            .push_slice(&output_key.as_inner().serialize())
+            .into_script()
+    }
+
+    /// Return the Elements address on the given network
+    pub fn address(&self, params: &'static elements::AddressParams) -> elements::Address {
+        let output_key = self.spend_info().output_key();
+        elements::Address::p2tr_tweaked(output_key, None, params)
+    }
+
+    /// Return the CMR of the program inside the single tap leaf
+    pub fn cmr(&self) -> Cmr {
+        self.cmr
+    }
+
+    /// Return the single tap leaf
+    pub fn leaf(&self) -> (elements::Script, LeafVersion) {
+        let script = elements::Script::from(Vec::from(self.cmr.as_ref()));
+        let version = leaf_version();
+        (script, version)
+    }
+
+    /// Return a satisfying non-malleable witness and script sig with minimum weight
+    /// to spend an output controlled by the given descriptor if it is possible to satisfy
+    /// given the `satisfier`
+    pub fn get_satisfaction(
+        &self,
+        satisfier: &PolicySatisfier<Pk>,
+    ) -> Result<(Vec<Vec<u8>>, elements::Script), policy::Error> {
+        let program = self
+            .policy
+            .satisfy(satisfier)
+            .ok_or(policy::Error::CouldNotSatisfy)?;
+
+        // Uncomment code below for sanity check
+        // that program successfully runs on Bit Machine
+        // let mut mac = crate::exec::BitMachine::for_program(&program);
+        // let _output = mac
+        //     .exec(&program, &satisfier.env)
+        //     .expect("sanity check");
+
+        let program_and_witness_bytes = program.encode_to_vec();
+        let cmr_bytes = Vec::from(program.cmr.as_ref());
+
+        // FIXME: Should env be public?
+        let control_block = satisfier.env.control_block();
+        let witness = vec![
+            program_and_witness_bytes,
+            cmr_bytes,
+            control_block.serialize(),
+        ];
+        let script_sig = elements::Script::new();
+
+        Ok((witness, script_sig))
+    }
+}
+
+impl<Pk: MiniscriptKey> fmt::Display for Descriptor<Pk> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.policy, f)
+    }
+}
+
+impl<Pk> FromStr for Descriptor<Pk>
+where
+    Pk: PublicKey32 + ToPublicKey + FromStr,
+    <Pk as MiniscriptKey>::Sha256: FromStr,
+    <Pk as FromStr>::Err: fmt::Display,
+    <<Pk as MiniscriptKey>::Sha256 as FromStr>::Err: fmt::Display,
+{
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let policy = Policy::from_str(s)?;
+        Self::single_leaf(policy)
+    }
+}

--- a/src/policy/error.rs
+++ b/src/policy/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     Ripemd160,
     Multisig,
     Extensions,
+    CouldNotSatisfy,
 }
 
 impl fmt::Debug for Error {
@@ -18,6 +19,7 @@ impl fmt::Debug for Error {
             Error::Ripemd160 => writeln!(f, "Ripemd160 is not supported"),
             Error::Multisig => writeln!(f, "Multisig is not supported"),
             Error::Extensions => writeln!(f, "Extensions are not supported"),
+            Error::CouldNotSatisfy => writeln!(f, "Could not satisfy the given policy"),
         }
     }
 }

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod ast;
 mod compiler;
+pub mod descriptor;
 mod embed;
 mod error;
 pub mod key;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -35,4 +35,5 @@ pub mod satisfy;
 // pub mod lift;
 
 pub use ast::Policy;
+pub use descriptor::Descriptor;
 pub use error::Error;


### PR DESCRIPTION
This PR adds descriptors of Simplicity outputs. This is the API that wallets will use to interact with rust-simplicity.

Currently the descriptors are very limited. We can only construct tap trees with a single leaf. Future PRs can add support for multiple leaves, non-Simplicity leaves, etc.