### PR TITLE
Node overhaul 2: transition decoder logic to use the new node types

### DIFF
--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -512,7 +512,7 @@ mod tests {
             }
         }
 
-        let prog = crate::CommitNode::from_node(&prog);
+        let prog = crate::CommitNode::from_node(prog.as_ref());
         let mut reser_sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut reser_sink);
         prog.encode(&mut w)

--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -333,7 +333,7 @@ mod test {
 
     #[test]
     fn encode_decode_witness() {
-        let context = crate::Context::<crate::jet::Core>::new();
+        let context = crate::Context::new();
 
         for n in 1..1000 {
             let witness = vec![Value::u64(n)];

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,6 @@ use crate::types;
 /// Context for constructing a Simplicity program
 #[allow(dead_code)]
 pub struct Context {
-    pub(crate) naming: types::variable::Factory,
     pow2: Vec<types::Type>,
     unit_ty: types::Type,
 }
@@ -25,7 +24,6 @@ impl Context {
         .collect();
 
         Self {
-            naming: types::variable::Factory::new(),
             pow2,
             unit_ty: types::Type::unit(),
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,19 +1,16 @@
-use std::marker::PhantomData;
 use std::sync::Arc;
 
-use crate::jet::Jet;
 use crate::types;
 
 /// Context for constructing a Simplicity program
 #[allow(dead_code)]
-pub struct Context<J: Jet> {
+pub struct Context {
     pub(crate) naming: types::variable::Factory,
     pow2: Vec<types::Type>,
     unit_ty: types::Type,
-    _jet: PhantomData<J>,
 }
 
-impl<J: Jet> Context<J> {
+impl Context {
     /// Create a new context.
     pub fn new() -> Self {
         let one = types::Type::unit();
@@ -31,7 +28,6 @@ impl<J: Jet> Context<J> {
             naming: types::variable::Factory::new(),
             pow2,
             unit_ty: types::Type::unit(),
-            _jet: PhantomData,
         }
     }
 
@@ -66,7 +62,7 @@ impl<J: Jet> Context<J> {
     }
 }
 
-impl<J: Jet> Default for Context<J> {
+impl Default for Context {
     fn default() -> Self {
         Self::new()
     }

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -165,7 +165,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that computes the identity function.
     ///
     /// _Overall type: A → A_
-    pub fn iden(context: &mut Context<J>) -> Rc<Self> {
+    pub fn iden(context: &mut Context) -> Rc<Self> {
         let inner = CommitNodeInner::Iden;
         Rc::new(CommitNode {
             cmr: Cmr::compute(&inner),
@@ -177,7 +177,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that returns the unit constant.
     ///
     /// _Overall type: A → 1_
-    pub fn unit(context: &mut Context<J>) -> Rc<Self> {
+    pub fn unit(context: &mut Context) -> Rc<Self> {
         let inner = CommitNodeInner::Unit;
         Rc::new(CommitNode {
             cmr: Cmr::compute(&inner),
@@ -189,7 +189,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that computes the left injection of the given `child`.
     ///
     /// _Overall type: A → B + C where `child`: A → B_
-    pub fn injl(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+    pub fn injl(context: &mut Context, child: Rc<Self>) -> Rc<Self> {
         let arrow = Arrow::for_injl(context, &child.arrow);
         let inner = CommitNodeInner::InjL(child);
         Rc::new(CommitNode {
@@ -202,7 +202,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that computes the right injection of the given `child`.
     ///
     /// _Overall type: A → B + C where `child`: A → C_
-    pub fn injr(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+    pub fn injr(context: &mut Context, child: Rc<Self>) -> Rc<Self> {
         let arrow = Arrow::for_injr(context, &child.arrow);
         let inner = CommitNodeInner::InjR(child);
         Rc::new(CommitNode {
@@ -215,7 +215,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG with that computes _take_ of the given `child`.
     ///
     /// _Overall type: A × B → C where `child`: A → C_
-    pub fn take(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+    pub fn take(context: &mut Context, child: Rc<Self>) -> Rc<Self> {
         let arrow = Arrow::for_take(context, &child.arrow);
         let inner = CommitNodeInner::Take(child);
         Rc::new(CommitNode {
@@ -228,7 +228,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG with that computes _drop_ of the given `child`.
     ///
     /// _Overall type: A × B → C where `child`: B → C_
-    pub fn drop(context: &mut Context<J>, child: Rc<Self>) -> Rc<Self> {
+    pub fn drop(context: &mut Context, child: Rc<Self>) -> Rc<Self> {
         let arrow = Arrow::for_drop(context, &child.arrow);
         let inner = CommitNodeInner::Drop(child);
         Rc::new(CommitNode {
@@ -244,7 +244,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn comp(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -263,7 +263,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn case(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -283,7 +283,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn assertl(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Cmr,
     ) -> Result<Rc<Self>, types::Error> {
@@ -303,7 +303,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn assertr(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Cmr,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -317,7 +317,7 @@ impl<J: Jet> CommitNode<J> {
     }
 
     pub fn case_branch(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
         branch: UsedCaseBranch,
@@ -335,7 +335,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn pair(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -354,7 +354,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn disconnect(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -371,7 +371,7 @@ impl<J: Jet> CommitNode<J> {
     /// The value is missing during commitment and inserted during redemption.
     ///
     /// _Overall type: A → B_
-    pub fn witness(context: &mut Context<J>) -> Rc<Self> {
+    pub fn witness(context: &mut Context) -> Rc<Self> {
         let inner = CommitNodeInner::Witness;
         Rc::new(CommitNode {
             cmr: Cmr::compute(&inner),
@@ -384,7 +384,7 @@ impl<J: Jet> CommitNode<J> {
     /// The given `left` and `right` hashes form a block for the CMR computation.
     ///
     /// _Overall type: A → B_
-    pub fn fail(context: &mut Context<J>, entropy: FailEntropy) -> Rc<Self> {
+    pub fn fail(context: &mut Context, entropy: FailEntropy) -> Rc<Self> {
         let inner = CommitNodeInner::Fail(entropy);
         Rc::new(CommitNode {
             cmr: Cmr::compute(&inner),
@@ -396,7 +396,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that computes some black-box function that is associated with the given `jet`.
     ///
     /// _Overall type: A → B where jet: A → B_
-    pub fn jet(context: &mut Context<J>, jet: J) -> Rc<Self> {
+    pub fn jet(context: &mut Context, jet: J) -> Rc<Self> {
         let arrow = Arrow::for_jet(context, jet);
         let inner = CommitNodeInner::Jet(jet);
         Rc::new(CommitNode {
@@ -411,7 +411,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Overall type: () → 2^n for some n between 1 and 32.
     // FIXME if the `word` is not of the correct form we should error out here.
-    pub fn const_word(context: &mut Context<J>, word: Value) -> Rc<Self> {
+    pub fn const_word(context: &mut Context, word: Value) -> Rc<Self> {
         let arrow = Arrow::for_const_word(context, &word);
         let inner = CommitNodeInner::Word(word);
         Rc::new(CommitNode {
@@ -424,7 +424,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that takes any input and returns `value` as constant output.
     ///
     /// _Overall type: A → B where value: B_
-    pub fn scribe(context: &mut Context<J>, value: &Value) -> Rc<CommitNode<J>> {
+    pub fn scribe(context: &mut Context, value: &Value) -> Rc<CommitNode<J>> {
         match value {
             Value::Unit => CommitNode::unit(context),
             Value::SumL(l) => {
@@ -446,7 +446,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that takes any input and returns bit `0` as constant output.
     ///
     /// _Overall type: A → 2_
-    pub fn bit_false(context: &mut Context<J>) -> Rc<Self> {
+    pub fn bit_false(context: &mut Context) -> Rc<Self> {
         let unit = Self::unit(context);
         Self::injl(context, unit)
     }
@@ -454,7 +454,7 @@ impl<J: Jet> CommitNode<J> {
     /// Create a DAG that takes any input and returns bit `1` as constant output.
     ///
     /// _Overall type: A → 2_
-    pub fn bit_true(context: &mut Context<J>) -> Rc<Self> {
+    pub fn bit_true(context: &mut Context) -> Rc<Self> {
         let unit = Self::unit(context);
         Self::injr(context, unit)
     }
@@ -467,7 +467,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn cond(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -477,7 +477,7 @@ impl<J: Jet> CommitNode<J> {
     }
 
     pub fn cond_branch(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
         branch: UsedCaseBranch,
@@ -499,7 +499,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn assert(
-        context: &mut Context<J>,
+        context: &mut Context,
         child: Rc<Self>,
         hash: Cmr,
     ) -> Result<Rc<Self>, types::Error> {
@@ -517,7 +517,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     #[allow(clippy::should_implement_trait)]
-    pub fn not(context: &mut Context<J>, child: Rc<Self>) -> Result<Rc<Self>, types::Error> {
+    pub fn not(context: &mut Context, child: Rc<Self>) -> Result<Rc<Self>, types::Error> {
         let unit = Self::unit(context);
         let pair_child_unit = Self::pair(context, child, unit)?;
         let bit_true = Self::bit_true(context);
@@ -533,7 +533,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn and(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -552,7 +552,7 @@ impl<J: Jet> CommitNode<J> {
     ///
     /// _Type inference will fail if children are not of the correct type._
     pub fn or(
-        context: &mut Context<J>,
+        context: &mut Context,
         left: Rc<Self>,
         right: Rc<Self>,
     ) -> Result<Rc<Self>, types::Error> {
@@ -711,9 +711,9 @@ mod tests {
 
     #[test]
     fn occurs_check_error() {
-        let mut context = Context::<Core>::new();
-        let iden = CommitNode::iden(&mut context);
-        let node = CommitNode::disconnect(&mut context, iden.clone(), iden).unwrap();
+        let mut context = Context::new();
+        let iden = CommitNode::<Core>::iden(&mut context);
+        let node = CommitNode::<Core>::disconnect(&mut context, iden.clone(), iden).unwrap();
 
         if let Err(Error::Type(types::Error::OccursCheck { .. })) =
             node.finalize(std::iter::empty(), false)
@@ -725,9 +725,9 @@ mod tests {
 
     #[test]
     fn type_check_error() {
-        let mut context = Context::<Core>::new();
-        let unit = CommitNode::unit(&mut context);
-        let case = CommitNode::case(&mut context, unit.clone(), unit.clone()).unwrap();
+        let mut context = Context::new();
+        let unit = CommitNode::<Core>::unit(&mut context);
+        let case = CommitNode::<Core>::case(&mut context, unit.clone(), unit.clone()).unwrap();
 
         if let Err(types::Error::Bind { .. }) = CommitNode::disconnect(&mut context, case, unit) {
         } else {

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -20,6 +20,7 @@ use crate::jet::Jet;
 use crate::merkle::amr::Amr;
 use crate::merkle::cmr::Cmr;
 use crate::merkle::imr::{FirstPassImr, Imr};
+use crate::node;
 use crate::types::{self, arrow::Arrow};
 use crate::{analysis, Error};
 use crate::{BitIter, BitWriter, Context, FailEntropy, RedeemNode, Value};
@@ -128,6 +129,41 @@ pub enum UsedCaseBranch {
 }
 
 impl<J: Jet> CommitNode<J> {
+    /// [will be removed] create a CommitNode from a newfangled `node::ConstructNode`
+    pub fn from_node(node: &node::ConstructNode<J>) -> Rc<Self> {
+        let mut converted = vec![];
+        for data in node.post_order_iter::<InternalSharing>() {
+            let left = data.left_index.map(|idx| Rc::clone(&converted[idx]));
+            let right = data.right_index.map(|idx| Rc::clone(&converted[idx]));
+            let new_node = Rc::new(CommitNode {
+                inner: match data.node.inner() {
+                    node::Inner::Iden => CommitNodeInner::Iden,
+                    node::Inner::Unit => CommitNodeInner::Unit,
+                    node::Inner::InjL(..) => CommitNodeInner::InjL(left.unwrap()),
+                    node::Inner::InjR(..) => CommitNodeInner::InjR(left.unwrap()),
+                    node::Inner::Take(..) => CommitNodeInner::Take(left.unwrap()),
+                    node::Inner::Drop(..) => CommitNodeInner::Drop(left.unwrap()),
+                    node::Inner::Comp(..) => CommitNodeInner::Comp(left.unwrap(), right.unwrap()),
+                    node::Inner::Case(..) => CommitNodeInner::Case(left.unwrap(), right.unwrap()),
+                    node::Inner::AssertL(_, cmr) => CommitNodeInner::AssertL(left.unwrap(), *cmr),
+                    node::Inner::AssertR(cmr, _) => CommitNodeInner::AssertR(*cmr, left.unwrap()),
+                    node::Inner::Pair(..) => CommitNodeInner::Pair(left.unwrap(), right.unwrap()),
+                    node::Inner::Disconnect(..) => {
+                        CommitNodeInner::Disconnect(left.unwrap(), right.unwrap())
+                    }
+                    node::Inner::Witness(..) => CommitNodeInner::Witness,
+                    node::Inner::Jet(j) => CommitNodeInner::Jet(*j),
+                    node::Inner::Word(w) => CommitNodeInner::Word(w.as_ref().clone()),
+                    node::Inner::Fail(entropy) => CommitNodeInner::Fail(*entropy),
+                },
+                cmr: data.node.cmr(),
+                arrow: data.node.arrow().shallow_clone(),
+            });
+            converted.push(new_node);
+        }
+        converted.pop().unwrap()
+    }
+
     /// Accessor for the node's "inner value", i.e. its combinator
     pub fn inner(&self) -> &CommitNodeInner<J> {
         &self.inner
@@ -678,7 +714,8 @@ impl<J: Jet> CommitNode<J> {
     pub fn decode<I: Iterator<Item = u8>>(
         bits: &mut BitIter<I>,
     ) -> Result<Rc<Self>, crate::decode::Error> {
-        crate::decode::decode_expression(bits)
+        let node = crate::decode::decode_expression(bits)?;
+        Ok(Self::from_node(&node))
     }
 
     /// Encode a Simplicity program to bits, without witness data.

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -714,8 +714,7 @@ impl<J: Jet> CommitNode<J> {
     pub fn decode<I: Iterator<Item = u8>>(
         bits: &mut BitIter<I>,
     ) -> Result<Rc<Self>, crate::decode::Error> {
-        let node = crate::decode::decode_expression(bits)?;
-        Ok(Self::from_node(&node))
+        Ok(Self::from_node(node::ConstructNode::decode(bits)?.as_ref()))
     }
 
     /// Encode a Simplicity program to bits, without witness data.

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -152,7 +152,8 @@ impl<J: Jet> RedeemNode<J> {
 
     /// Decode a Simplicity program from bits, including the witness data.
     pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Rc<Self>, Error> {
-        let commit = crate::bit_encoding::decode::decode_program(bits)?;
+        let commit = crate::bit_encoding::decode::decode_expression(bits)?;
+        let commit = crate::CommitNode::from_node(&commit);
         let witness = WitnessDecoder::new(bits)?;
         let program = commit.finalize(witness, false)?;
 
@@ -210,7 +211,7 @@ mod tests {
 
     use super::*;
 
-    use crate::bit_encoding::decode::decode_program;
+    use crate::bit_encoding::decode::decode_expression;
     use crate::jet::Core;
 
     #[test]
@@ -223,7 +224,8 @@ mod tests {
         // main = comp wits_are_equal jet_verify            :: 1 -> 1
         let eqwits = vec![0xc9, 0xc4, 0x6d, 0xb8, 0x82, 0x30, 0x10];
         let mut iter = BitIter::from(&eqwits[..]);
-        let eqwits_prog = decode_program::<_, Core>(&mut iter).unwrap();
+        let eqwits_prog = decode_expression::<_, Core>(&mut iter).unwrap();
+        let eqwits_prog = crate::CommitNode::from_node(&eqwits_prog);
 
         let mut witness_iter = iter::repeat(Value::u32(0xDEADBEEF));
         // Generally when we are manually adding witnesses we want to unshare them so that

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -152,7 +152,7 @@ impl<J: Jet> RedeemNode<J> {
 
     /// Decode a Simplicity program from bits, including the witness data.
     pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Rc<Self>, Error> {
-        let commit = crate::decode_program(bits)?;
+        let commit = crate::bit_encoding::decode::decode_program(bits)?;
         let witness = WitnessDecoder::new(bits)?;
         let program = commit.finalize(witness, false)?;
 
@@ -210,6 +210,7 @@ mod tests {
 
     use super::*;
 
+    use crate::bit_encoding::decode::decode_program;
     use crate::jet::Core;
 
     #[test]
@@ -222,7 +223,7 @@ mod tests {
         // main = comp wits_are_equal jet_verify            :: 1 -> 1
         let eqwits = vec![0xc9, 0xc4, 0x6d, 0xb8, 0x82, 0x30, 0x10];
         let mut iter = BitIter::from(&eqwits[..]);
-        let eqwits_prog = crate::decode_program::<_, Core>(&mut iter).unwrap();
+        let eqwits_prog = decode_program::<_, Core>(&mut iter).unwrap();
 
         let mut witness_iter = iter::repeat(Value::u32(0xDEADBEEF));
         // Generally when we are manually adding witnesses we want to unshare them so that

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -800,29 +800,20 @@ impl<D: DagLike, S: SharingTracker<D>> PostOrderIter<D, S> {
         F: FnMut(&D, &mut fmt::Formatter<'_>) -> fmt::Result,
         G: FnMut(&D, &mut fmt::Formatter<'_>) -> fmt::Result,
     {
-        let mut node_to_index = HashMap::new();
+        for data in self {
+            write!(f, "{}: ", data.index)?;
+            display_body(&data.node, f)?;
 
-        for (index, node) in self.map(|data| data.node).enumerate() {
-            write!(f, "{}: ", index)?;
-            display_body(&node, f)?;
-
-            if let Some(left) = node.left_child() {
-                let i_abs = node_to_index.get(&PointerId::from(&left)).unwrap();
-
-                if let Some(right) = node.right_child() {
-                    let j_abs = node_to_index.get(&PointerId::from(&right)).unwrap();
-
+            if let Some(i_abs) = data.left_index {
+                if let Some(j_abs) = data.right_index {
                     write!(f, "({}, {})", i_abs, j_abs)?;
                 } else {
                     write!(f, "({})", i_abs)?;
                 }
             }
-
-            display_aux(&node, f)?;
+            display_aux(&data.node, f)?;
             f.write_str("\n")?;
-            node_to_index.insert(PointerId::from(&node), index);
         }
-
         Ok(())
     }
 }

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -331,6 +331,23 @@ pub trait DagLike: Sized {
         }
     }
 
+    /// Checks whether a DAG's internal sharing (as expressed by shared pointers)
+    /// matches the given target sharing.
+    #[allow(clippy::wrong_self_convention)] // clippy doesn't like is_* taking a pointer by value
+    fn is_shared_as<S: SharingTracker<Self> + Default>(self) -> bool
+    where
+        Self: Clone,
+    {
+        let iter_is = self.clone().post_order_iter::<InternalSharing>();
+        let iter_ought = self.post_order_iter::<S>();
+        for (data_is, data_ought) in iter_is.zip(iter_ought) {
+            if PointerId::from(&data_is.node) != PointerId::from(&data_ought.node) {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Obtains an post-order iterator of all the nodes rooted at DAG, using the
     /// given tracker.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use crate::context::Context;
 pub use crate::core::commit::CommitNodeInner;
 pub use crate::core::redeem::RedeemNodeInner;
 pub use crate::core::{CommitNode, RedeemNode};
-pub use crate::decode::{decode_program, WitnessDecoder};
+pub use crate::decode::WitnessDecoder;
 pub use crate::encode::{encode_natural, encode_value, encode_witness};
 pub use crate::merkle::{
     amr::Amr,

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -291,8 +291,8 @@ mod tests {
 
     #[test]
     fn cmr_display_unit() {
-        let mut ctx = crate::Context::<crate::jet::Core>::new();
-        let c = crate::CommitNode::unit(&mut ctx);
+        let mut ctx = crate::Context::new();
+        let c = crate::CommitNode::<crate::jet::Core>::unit(&mut ctx);
 
         assert_eq!(
             c.cmr().to_string(),
@@ -324,8 +324,8 @@ mod tests {
 
     #[test]
     fn bit_cmr() {
-        let mut ctx = Context::<crate::jet::Core>::new();
-        let unit = CommitNode::unit(&mut ctx);
+        let mut ctx = Context::new();
+        let unit = CommitNode::<crate::jet::Core>::unit(&mut ctx);
         let bit0 = CommitNode::injl(&mut ctx, unit.clone());
         assert_eq!(bit0.cmr(), Cmr::BITS[0]);
 

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -145,7 +145,7 @@ impl<J: Jet> CommitNode<J> {
     /// Convert a [`CommitNode`] back to a [`ConstructNode`] by redoing type inference
     pub fn unfinalize_types(
         &self,
-        ctx: &mut Context<J>,
+        ctx: &mut Context,
     ) -> Result<Arc<ConstructNode<J>>, types::Error> {
         self.convert::<MaxSharing<Commit, J>, _, _, Construct, _>(
             |_, inner| {

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -16,10 +16,11 @@ use crate::dag::MaxSharing;
 use crate::jet::Jet;
 use crate::types;
 use crate::types::arrow::{Arrow, FinalArrow};
-use crate::{Cmr, Context, FirstPassImr, Imr};
+use crate::{Cmr, Context, Error, FirstPassImr, Imr, Value};
 
 use super::{
     Construct, ConstructData, ConstructNode, Constructible, Inner, NoWitness, Node, NodeData,
+    RedeemData, RedeemNode,
 };
 
 use std::marker::PhantomData;
@@ -140,6 +141,31 @@ impl<J: Jet> CommitNode<J> {
     /// Accessor for the node's IMR, if known
     pub fn imr(&self) -> Option<Imr> {
         self.data.imr
+    }
+
+    /// Finalize the [`CommitNode`], assuming it has no witnesses. Does not do any
+    /// pruning.
+    ///
+    /// It will populate unit witnesses, to make this method a bit more useful for
+    /// testing purposes. But for any other witness nodes, it will error out with
+    /// [`Error::NoMoreWitnesses`].
+    pub fn finalize_no_witnesses(&self) -> Result<Arc<RedeemNode<J>>, Error> {
+        self.convert::<MaxSharing<Commit, J>, _, _, _, _>(
+            |data, converted| {
+                let converted_data = converted.map(|node| node.cached_data());
+                Ok(Arc::new(RedeemData::new(
+                    data.node.data.arrow.shallow_clone(),
+                    converted_data,
+                )))
+            },
+            |data, _| {
+                if data.node.arrow().target.is_unit() {
+                    Ok(Arc::new(Value::Unit))
+                } else {
+                    Err(Error::NoMoreWitnesses)
+                }
+            },
+        )
     }
 
     /// Convert a [`CommitNode`] back to a [`ConstructNode`] by redoing type inference

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -18,9 +18,8 @@ use crate::types;
 use crate::types::arrow::{Arrow, FinalArrow};
 use crate::{Cmr, Context, FirstPassImr, Imr};
 
-use super::{
-    Construct, ConstructData, ConstructNode, Constructible, Inner, NoWitness, Node, NodeData,
-};
+use super::{Construct, ConstructData, ConstructNode, Inner, NoWitness, Node, NodeData};
+use super::{CoreConstructible, JetConstructible, WitnessConstructible};
 
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -18,8 +18,9 @@ use crate::types;
 use crate::types::arrow::{Arrow, FinalArrow};
 use crate::{Cmr, Context, FirstPassImr, Imr};
 
-use super::{Construct, ConstructData, ConstructNode, Inner, NoWitness, Node, NodeData};
-use super::{CoreConstructible, JetConstructible, WitnessConstructible};
+use super::{
+    Construct, ConstructData, ConstructNode, Constructible, Inner, NoWitness, Node, NodeData,
+};
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -146,43 +147,10 @@ impl<J: Jet> CommitNode<J> {
         &self,
         ctx: &mut Context<J>,
     ) -> Result<Arc<ConstructNode<J>>, types::Error> {
-        // Writing e.g. Ok(ConstructData::new(Arrow::iden(ctx))) is a little wordy.
-        macro_rules! ok_new {
-            ($fn:ident($($arg:tt)*)$($question_mark:tt)*) => {
-                Ok(ConstructData::new(Arrow::$fn($($arg)*)$($question_mark)*))
-            }
-        }
-
         self.convert::<MaxSharing<Commit, J>, _, _, Construct, _>(
-            |_, inner| match inner {
-                Inner::Iden => ok_new!(iden(ctx)),
-                Inner::Unit => ok_new!(unit(ctx)),
-                Inner::InjL(child) => ok_new!(injl(ctx, child.arrow())),
-                Inner::InjR(child) => ok_new!(injr(ctx, child.arrow())),
-                Inner::Take(child) => ok_new!(take(ctx, child.arrow())),
-                Inner::Drop(child) => ok_new!(drop_(ctx, child.arrow())),
-                Inner::Comp(left, right) => {
-                    ok_new!(comp(ctx, left.arrow(), right.arrow())?)
-                }
-                Inner::Case(left, right) => {
-                    ok_new!(case(ctx, left.arrow(), right.arrow())?)
-                }
-                Inner::AssertL(left, r_cmr) => {
-                    ok_new!(assertl(ctx, left.arrow(), r_cmr)?)
-                }
-                Inner::AssertR(l_cmr, right) => {
-                    ok_new!(assertr(ctx, l_cmr, right.arrow())?)
-                }
-                Inner::Pair(left, right) => {
-                    ok_new!(pair(ctx, left.arrow(), right.arrow())?)
-                }
-                Inner::Disconnect(left, right) => {
-                    ok_new!(disconnect(ctx, left.arrow(), right.arrow())?)
-                }
-                Inner::Witness(..) => ok_new!(witness(ctx, NoWitness)),
-                Inner::Fail(entropy) => ok_new!(fail(ctx, entropy)),
-                Inner::Jet(jet) => ok_new!(jet(ctx, jet)),
-                Inner::Word(ref value) => ok_new!(const_word(ctx, Arc::clone(value))),
+            |_, inner| {
+                let inner = inner.map(|node| node.arrow());
+                Ok(ConstructData::new(Arrow::from_inner(ctx, inner)?))
             },
             |_, _| Ok(NoWitness),
         )

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -15,7 +15,7 @@
 use crate::dag::InternalSharing;
 use crate::jet::Jet;
 use crate::types::{self, arrow::Arrow};
-use crate::{Cmr, Context, FailEntropy, Value};
+use crate::{BitIter, Cmr, Context, FailEntropy, Value};
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -85,6 +85,21 @@ impl<J: Jet> ConstructNode<J> {
             },
             |_, _| Ok(NoWitness),
         )
+    }
+
+    /// Decode a Simplicity expression from bits, without witness data.
+    ///
+    /// # Usage
+    ///
+    /// Use this method only if the serialization **does not** include the witness data.
+    /// This means, the program simply has no witness during commitment,
+    /// or the witness is provided by other means.
+    ///
+    /// If the serialization contains the witness data, then use [`RedeemNode::decode()`].
+    pub fn decode<I: Iterator<Item = u8>>(
+        bits: &mut BitIter<I>,
+    ) -> Result<Arc<Self>, crate::decode::Error> {
+        crate::decode::decode_expression(bits)
     }
 }
 

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -20,7 +20,8 @@ use crate::{Cmr, Context, FailEntropy, Value};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use super::{CommitData, CommitNode, Constructible, NoWitness, Node, NodeData};
+use super::{CommitData, CommitNode, NoWitness, Node, NodeData};
+use super::{CoreConstructible, JetConstructible, WitnessConstructible};
 
 /// ID used to share [`ConstructNode`]s.
 ///
@@ -106,7 +107,7 @@ impl<J: Jet> ConstructData<J> {
     }
 }
 
-impl<'a, J: Jet> Constructible<&'a NoWitness, J> for ConstructData<J> {
+impl<J: Jet> CoreConstructible<J> for ConstructData<J> {
     fn iden(ctx: &mut Context<J>) -> Self {
         ConstructData {
             arrow: Arrow::iden(ctx),
@@ -191,13 +192,6 @@ impl<'a, J: Jet> Constructible<&'a NoWitness, J> for ConstructData<J> {
         })
     }
 
-    fn witness(ctx: &mut Context<J>, witness: &NoWitness) -> Self {
-        ConstructData {
-            arrow: Arrow::witness(ctx, *witness),
-            phantom: PhantomData,
-        }
-    }
-
     fn fail(ctx: &mut Context<J>, entropy: FailEntropy) -> Self {
         ConstructData {
             arrow: Arrow::fail(ctx, entropy),
@@ -205,16 +199,27 @@ impl<'a, J: Jet> Constructible<&'a NoWitness, J> for ConstructData<J> {
         }
     }
 
-    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
-        ConstructData {
-            arrow: Arrow::jet(ctx, jet),
-            phantom: PhantomData,
-        }
-    }
-
     fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
         ConstructData {
             arrow: Arrow::const_word(ctx, word),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, J: Jet> WitnessConstructible<&'a NoWitness, J> for ConstructData<J> {
+    fn witness(ctx: &mut Context<J>, witness: &NoWitness) -> Self {
+        ConstructData {
+            arrow: Arrow::witness(ctx, *witness),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<J: Jet> JetConstructible<J> for ConstructData<J> {
+    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
+        ConstructData {
+            arrow: Arrow::jet(ctx, jet),
             phantom: PhantomData,
         }
     }

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -107,99 +107,99 @@ impl<J: Jet> ConstructData<J> {
     }
 }
 
-impl<J: Jet> CoreConstructible<J> for ConstructData<J> {
-    fn iden(ctx: &mut Context<J>) -> Self {
+impl<J: Jet> CoreConstructible for ConstructData<J> {
+    fn iden(ctx: &mut Context) -> Self {
         ConstructData {
             arrow: Arrow::iden(ctx),
             phantom: PhantomData,
         }
     }
 
-    fn unit(ctx: &mut Context<J>) -> Self {
+    fn unit(ctx: &mut Context) -> Self {
         ConstructData {
             arrow: Arrow::unit(ctx),
             phantom: PhantomData,
         }
     }
 
-    fn injl(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn injl(ctx: &mut Context, child: &Self) -> Self {
         ConstructData {
             arrow: Arrow::injl(ctx, &child.arrow),
             phantom: PhantomData,
         }
     }
 
-    fn injr(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn injr(ctx: &mut Context, child: &Self) -> Self {
         ConstructData {
             arrow: Arrow::injr(ctx, &child.arrow),
             phantom: PhantomData,
         }
     }
 
-    fn take(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn take(ctx: &mut Context, child: &Self) -> Self {
         ConstructData {
             arrow: Arrow::take(ctx, &child.arrow),
             phantom: PhantomData,
         }
     }
 
-    fn drop_(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn drop_(ctx: &mut Context, child: &Self) -> Self {
         ConstructData {
             arrow: Arrow::drop_(ctx, &child.arrow),
             phantom: PhantomData,
         }
     }
 
-    fn comp(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+    fn comp(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, types::Error> {
         Ok(ConstructData {
             arrow: Arrow::comp(ctx, &left.arrow, &right.arrow)?,
             phantom: PhantomData,
         })
     }
 
-    fn case(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+    fn case(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, types::Error> {
         Ok(ConstructData {
             arrow: Arrow::case(ctx, &left.arrow, &right.arrow)?,
             phantom: PhantomData,
         })
     }
 
-    fn assertl(ctx: &mut Context<J>, left: &Self, right: Cmr) -> Result<Self, types::Error> {
+    fn assertl(ctx: &mut Context, left: &Self, right: Cmr) -> Result<Self, types::Error> {
         Ok(ConstructData {
             arrow: Arrow::assertl(ctx, &left.arrow, right)?,
             phantom: PhantomData,
         })
     }
 
-    fn assertr(ctx: &mut Context<J>, left: Cmr, right: &Self) -> Result<Self, types::Error> {
+    fn assertr(ctx: &mut Context, left: Cmr, right: &Self) -> Result<Self, types::Error> {
         Ok(ConstructData {
             arrow: Arrow::assertr(ctx, left, &right.arrow)?,
             phantom: PhantomData,
         })
     }
 
-    fn pair(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+    fn pair(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, types::Error> {
         Ok(ConstructData {
             arrow: Arrow::pair(ctx, &left.arrow, &right.arrow)?,
             phantom: PhantomData,
         })
     }
 
-    fn disconnect(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error> {
+    fn disconnect(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, types::Error> {
         Ok(ConstructData {
             arrow: Arrow::disconnect(ctx, &left.arrow, &right.arrow)?,
             phantom: PhantomData,
         })
     }
 
-    fn fail(ctx: &mut Context<J>, entropy: FailEntropy) -> Self {
+    fn fail(ctx: &mut Context, entropy: FailEntropy) -> Self {
         ConstructData {
             arrow: Arrow::fail(ctx, entropy),
             phantom: PhantomData,
         }
     }
 
-    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
+    fn const_word(ctx: &mut Context, word: Arc<Value>) -> Self {
         ConstructData {
             arrow: Arrow::const_word(ctx, word),
             phantom: PhantomData,
@@ -207,8 +207,8 @@ impl<J: Jet> CoreConstructible<J> for ConstructData<J> {
     }
 }
 
-impl<'a, J: Jet> WitnessConstructible<&'a NoWitness, J> for ConstructData<J> {
-    fn witness(ctx: &mut Context<J>, witness: &NoWitness) -> Self {
+impl<'a, J: Jet> WitnessConstructible<&'a NoWitness> for ConstructData<J> {
+    fn witness(ctx: &mut Context, witness: &NoWitness) -> Self {
         ConstructData {
             arrow: Arrow::witness(ctx, *witness),
             phantom: PhantomData,
@@ -217,7 +217,7 @@ impl<'a, J: Jet> WitnessConstructible<&'a NoWitness, J> for ConstructData<J> {
 }
 
 impl<J: Jet> JetConstructible<J> for ConstructData<J> {
-    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
+    fn jet(ctx: &mut Context, jet: J) -> Self {
         ConstructData {
             arrow: Arrow::jet(ctx, jet),
             phantom: PhantomData,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -131,6 +131,26 @@ pub struct NoWitness;
 pub trait Constructible<W, J: Jet>:
     JetConstructible<J> + WitnessConstructible<W, J> + CoreConstructible<J> + Sized
 {
+    fn from_inner(ctx: &mut Context<J>, inner: Inner<&Self, J, W>) -> Result<Self, types::Error> {
+        match inner {
+            Inner::Iden => Ok(Self::iden(ctx)),
+            Inner::Unit => Ok(Self::unit(ctx)),
+            Inner::InjL(child) => Ok(Self::injl(ctx, child)),
+            Inner::InjR(child) => Ok(Self::injr(ctx, child)),
+            Inner::Take(child) => Ok(Self::take(ctx, child)),
+            Inner::Drop(child) => Ok(Self::drop_(ctx, child)),
+            Inner::Comp(left, right) => Self::comp(ctx, left, right),
+            Inner::Case(left, right) => Self::case(ctx, left, right),
+            Inner::AssertL(left, r_cmr) => Self::assertl(ctx, left, r_cmr),
+            Inner::AssertR(l_cmr, right) => Self::assertr(ctx, l_cmr, right),
+            Inner::Pair(left, right) => Self::pair(ctx, left, right),
+            Inner::Disconnect(left, right) => Self::disconnect(ctx, left, right),
+            Inner::Fail(entropy) => Ok(Self::fail(ctx, entropy)),
+            Inner::Word(ref w) => Ok(Self::const_word(ctx, Arc::clone(w))),
+            Inner::Jet(j) => Ok(Self::jet(ctx, j)),
+            Inner::Witness(w) => Ok(Self::witness(ctx, w)),
+        }
+    }
 }
 
 impl<W, J: Jet, T> Constructible<W, J> for T where

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -128,7 +128,17 @@ pub trait NodeData<J: Jet>:
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct NoWitness;
 
-pub trait Constructible<W, J: Jet>: Sized {
+pub trait Constructible<W, J: Jet>:
+    JetConstructible<J> + WitnessConstructible<W, J> + CoreConstructible<J> + Sized
+{
+}
+
+impl<W, J: Jet, T> Constructible<W, J> for T where
+    T: JetConstructible<J> + WitnessConstructible<W, J> + CoreConstructible<J> + Sized
+{
+}
+
+pub trait CoreConstructible<J: Jet>: Sized {
     fn iden(ctx: &mut Context<J>) -> Self;
     fn unit(ctx: &mut Context<J>) -> Self;
     fn injl(ctx: &mut Context<J>, child: &Self) -> Self;
@@ -141,9 +151,7 @@ pub trait Constructible<W, J: Jet>: Sized {
     fn assertr(ctx: &mut Context<J>, left: Cmr, right: &Self) -> Result<Self, types::Error>;
     fn pair(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error>;
     fn disconnect(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, types::Error>;
-    fn witness(ctx: &mut Context<J>, witness: W) -> Self;
     fn fail(ctx: &mut Context<J>, entropy: FailEntropy) -> Self;
-    fn jet(ctx: &mut Context<J>, jet: J) -> Self;
     fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self;
 
     /// Create a DAG that takes any input and returns `value` as constant output.
@@ -258,6 +266,14 @@ pub trait Constructible<W, J: Jet>: Sized {
     }
 }
 
+pub trait JetConstructible<J: Jet>: Sized {
+    fn jet(ctx: &mut Context<J>, jet: J) -> Self;
+}
+
+pub trait WitnessConstructible<W, J: Jet>: Sized {
+    fn witness(ctx: &mut Context<J>, witness: W) -> Self;
+}
+
 /// A node in a Simplicity expression.
 ///
 /// There are three node types provided by this library: `ConstructNode`, `CommitNode`,
@@ -311,7 +327,7 @@ where
     }
 }
 
-impl<N, J> Constructible<N::Witness, J> for Arc<Node<N, J>>
+impl<N, J> CoreConstructible<J> for Arc<Node<N, J>>
 where
     N: NodeData<J>,
     N::CachedData: for<'a> Constructible<&'a N::Witness, J>,
@@ -413,14 +429,6 @@ where
         }))
     }
 
-    fn witness(ctx: &mut Context<J>, value: N::Witness) -> Self {
-        Arc::new(Node {
-            cmr: Cmr::witness(),
-            data: N::CachedData::witness(ctx, &value),
-            inner: Inner::Witness(value),
-        })
-    }
-
     fn fail(ctx: &mut Context<J>, entropy: FailEntropy) -> Self {
         Arc::new(Node {
             cmr: Cmr::fail(entropy),
@@ -429,19 +437,41 @@ where
         })
     }
 
-    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
-        Arc::new(Node {
-            cmr: Cmr::jet(jet),
-            data: N::CachedData::jet(ctx, jet),
-            inner: Inner::Jet(jet),
-        })
-    }
-
     fn const_word(ctx: &mut Context<J>, value: Arc<Value>) -> Self {
         Arc::new(Node {
             cmr: Cmr::const_word(&value),
             data: N::CachedData::const_word(ctx, Arc::clone(&value)),
             inner: Inner::Word(value),
+        })
+    }
+}
+
+impl<N, J> WitnessConstructible<N::Witness, J> for Arc<Node<N, J>>
+where
+    N: NodeData<J>,
+    N::CachedData: for<'a> Constructible<&'a N::Witness, J>,
+    J: Jet,
+{
+    fn witness(ctx: &mut Context<J>, value: N::Witness) -> Self {
+        Arc::new(Node {
+            cmr: Cmr::witness(),
+            data: N::CachedData::witness(ctx, &value),
+            inner: Inner::Witness(value),
+        })
+    }
+}
+
+impl<N, J> JetConstructible<J> for Arc<Node<N, J>>
+where
+    N: NodeData<J>,
+    N::CachedData: for<'a> Constructible<&'a N::Witness, J>,
+    J: Jet,
+{
+    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
+        Arc::new(Node {
+            cmr: Cmr::jet(jet),
+            data: N::CachedData::jet(ctx, jet),
+            inner: Inner::Jet(jet),
         })
     }
 }

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -13,13 +13,14 @@
 //
 
 use crate::analysis::NodeBounds;
-use crate::dag::MaxSharing;
+use crate::dag::{DagLike, InternalSharing, MaxSharing};
 use crate::jet::Jet;
 use crate::types::{self, arrow::FinalArrow};
-use crate::{Amr, Cmr, FirstPassImr, Imr, Value};
+use crate::{Amr, BitIter, Cmr, Error, FirstPassImr, Imr, Value};
 
 use super::{CommitData, CommitNode, Inner, NoWitness, Node, NodeData};
 
+use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -187,5 +188,52 @@ impl<J: Jet> RedeemNode<J> {
             },
             |_, _| Ok(NoWitness),
         )
+    }
+
+    /// Decode a Simplicity program from bits, including the witness data.
+    pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Arc<Self>, Error> {
+        // 1. Decode program without witnesses as CommitNode
+        let commit = crate::decode::decode_program(bits)?;
+
+        // 2. Convert to RedeemNode, reading witnesses as we go
+        let witness_len = if bits.read_bit()? {
+            bits.read_natural(None)?
+        } else {
+            0
+        };
+        let witness_start = bits.n_total_read();
+
+        // Importantly, we do this directly using convert() rather than calling
+        // `.finalize()` because we need to use `InternalSharing` to make sure
+        // that we respect the sharing choices that were actually encoded in the
+        // bitstream.
+        let program: Arc<Self> = commit.convert::<InternalSharing, _, _, _, _>(
+            |data, converted| {
+                let converted_data = converted.map(|node| node.cached_data());
+                Ok(Arc::new(RedeemData::new(
+                    data.node.arrow().shallow_clone(),
+                    converted_data,
+                )))
+            },
+            |data, _| {
+                bits.read_value(&data.node.data.arrow().target)
+                    .map(Arc::new)
+            },
+        )?;
+
+        // 3. Check that we read exactly as much witness data as we expected
+        if bits.n_total_read() != witness_start + witness_len {
+            return Err(Error::InconsistentWitnessLength);
+        }
+
+        // 4. Check sharing
+        let mut imrs: HashSet<Imr> = HashSet::new();
+        for data in program.as_ref().post_order_iter::<InternalSharing>() {
+            if !imrs.insert(data.node.imr()) {
+                return Err(Error::SharingNotMaximal);
+            }
+        }
+
+        Ok(program)
     }
 }

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -27,16 +27,13 @@ use std::rc::Rc;
 
 impl<Pk: MiniscriptKey + PublicKey32> Policy<Pk> {
     /// Compile the policy into a Simplicity program
-    pub fn compile(
-        &self,
-        context: &mut Context<Elements>,
-    ) -> Result<Rc<CommitNode<Elements>>, Error> {
+    pub fn compile(&self, context: &mut Context) -> Result<Rc<CommitNode<Elements>>, Error> {
         compile(context, self)
     }
 }
 
 fn compute_sha256(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     witness256: Rc<CommitNode<Elements>>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
     let ctx = CommitNode::jet(context, Elements::Sha256Ctx8Init);
@@ -48,7 +45,7 @@ fn compute_sha256(
 }
 
 fn verify_bexp(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     input: Rc<CommitNode<Elements>>,
     bexp: Rc<CommitNode<Elements>>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
@@ -59,7 +56,7 @@ fn verify_bexp(
 
 /// Compile the given policy into a Simplicity program.
 fn compile<Pk: MiniscriptKey + PublicKey32>(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     policy: &Policy<Pk>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
     match policy {
@@ -145,14 +142,14 @@ fn compile<Pk: MiniscriptKey + PublicKey32>(
     }
 }
 
-fn selector(context: &mut Context<Elements>) -> Result<Rc<CommitNode<Elements>>, Error> {
+fn selector(context: &mut Context) -> Result<Rc<CommitNode<Elements>>, Error> {
     let witness = CommitNode::witness(context);
     let unit = CommitNode::unit(context);
     CommitNode::pair(context, witness, unit)
 }
 
 pub(crate) fn and(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     left: Rc<CommitNode<Elements>>,
     right: Rc<CommitNode<Elements>>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
@@ -167,7 +164,7 @@ pub(crate) fn and(
 }
 
 pub(crate) fn or(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     left: Rc<CommitNode<Elements>>,
     right: Rc<CommitNode<Elements>>,
     branch: UsedCaseBranch,
@@ -184,7 +181,7 @@ pub(crate) fn or(
 ///
 /// summand(child): 1 → 2^32
 pub(crate) fn thresh_summand(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     child: Rc<CommitNode<Elements>>,
     branch: UsedCaseBranch,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
@@ -208,7 +205,7 @@ pub(crate) fn thresh_summand(
 ///
 /// add(sum, summand): 1 → 2^32
 pub(crate) fn thresh_add(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     sum: Rc<CommitNode<Elements>>,
     summand: Rc<CommitNode<Elements>>,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {
@@ -231,7 +228,7 @@ pub(crate) fn thresh_add(
 
 /// verify(sum): 1 → 1
 pub(crate) fn thresh_verify(
-    context: &mut Context<Elements>,
+    context: &mut Context,
     sum: Rc<CommitNode<Elements>>,
     k: u32,
 ) -> Result<Rc<CommitNode<Elements>>, Error> {

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -60,7 +60,7 @@ impl<Pk: MiniscriptKey + PublicKey32 + ToPublicKey> Policy<Pk> {
         Some(program)
     }
 
-    fn compile_no_witness(&self, context: &mut Context<Elements>) -> SatisfierExtData {
+    fn compile_no_witness(&self, context: &mut Context) -> SatisfierExtData {
         SatisfierExtData {
             witness: VecDeque::new(),
             witness_cost: 0,
@@ -69,11 +69,7 @@ impl<Pk: MiniscriptKey + PublicKey32 + ToPublicKey> Policy<Pk> {
         }
     }
 
-    fn compile_witness_bytes(
-        &self,
-        context: &mut Context<Elements>,
-        witness: &[u8],
-    ) -> SatisfierExtData {
+    fn compile_witness_bytes(&self, context: &mut Context, witness: &[u8]) -> SatisfierExtData {
         let value = match witness.len() {
             32 => Value::u256_from_slice(witness),
             64 => Value::u512_from_slice(witness),
@@ -94,7 +90,7 @@ impl<Pk: MiniscriptKey + PublicKey32 + ToPublicKey> Policy<Pk> {
     fn satisfy_helper<S: Satisfier<Pk>>(
         &self,
         satisfier: &S,
-        context: &mut Context<Elements>,
+        context: &mut Context,
     ) -> Option<SatisfierExtData> {
         match self {
             Policy::Unsatisfiable => None,
@@ -213,7 +209,7 @@ impl<Pk: MiniscriptKey + PublicKey32 + ToPublicKey> Policy<Pk> {
                 /// Return satisfaction for `i`th child, if it exists, or return dummy instead
                 fn get_sat_or_default<Pk: MiniscriptKey + PublicKey32>(
                     i: usize,
-                    context: &mut Context<Elements>,
+                    context: &mut Context,
                     satisfiable_children: &mut Vec<(SatisfierExtData, usize)>,
                     sub_policies: &[Policy<Pk>],
                 ) -> SatisfierExtData {
@@ -234,7 +230,7 @@ impl<Pk: MiniscriptKey + PublicKey32 + ToPublicKey> Policy<Pk> {
                 /// Return summand program for `i`th child
                 fn get_summand<Pk: MiniscriptKey + PublicKey32>(
                     i: usize,
-                    context: &mut Context<Elements>,
+                    context: &mut Context,
                     satisfiable_children: &mut Vec<(SatisfierExtData, usize)>,
                     sub_policies: &[Policy<Pk>],
                 ) -> SatisfierExtData {

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -26,7 +26,7 @@
 use std::fmt;
 use std::sync::Arc;
 
-use crate::node::{Constructible, NoWitness};
+use crate::node::{CoreConstructible, JetConstructible, WitnessConstructible};
 use crate::types::{Bound, Error, Final, Type};
 use crate::{jet::Jet, Context, Value};
 
@@ -305,7 +305,7 @@ impl Arrow {
     }
 }
 
-impl<J: Jet> Constructible<NoWitness, J> for Arrow {
+impl<J: Jet> CoreConstructible<J> for Arrow {
     fn iden(ctx: &mut Context<J>) -> Self {
         Self::for_iden(ctx)
     }
@@ -354,19 +354,23 @@ impl<J: Jet> Constructible<NoWitness, J> for Arrow {
         Self::for_disconnect(ctx, left, right)
     }
 
-    fn witness(ctx: &mut Context<J>, _: NoWitness) -> Self {
-        Self::for_witness(ctx)
-    }
-
     fn fail(ctx: &mut Context<J>, _: crate::FailEntropy) -> Self {
         Self::for_fail(ctx)
     }
 
+    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
+        Self::for_const_word(ctx, &word)
+    }
+}
+
+impl<J: Jet> JetConstructible<J> for Arrow {
     fn jet(ctx: &mut Context<J>, jet: J) -> Self {
         Self::for_jet(ctx, jet)
     }
+}
 
-    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
-        Self::for_const_word(ctx, &word)
+impl<W, J: Jet> WitnessConstructible<W, J> for Arrow {
+    fn witness(ctx: &mut Context<J>, _: W) -> Self {
+        Self::for_witness(ctx)
     }
 }

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -30,6 +30,8 @@ use crate::node::{CoreConstructible, JetConstructible, WitnessConstructible};
 use crate::types::{Bound, Error, Final, Type};
 use crate::{jet::Jet, Context, Value};
 
+use super::variable::new_name;
+
 /// A container for an expression's source and target types, whether or not
 /// these types are complete.
 #[derive(Clone, Debug)]
@@ -84,19 +86,19 @@ impl Arrow {
     /// Create a unification arrow for a fresh `unit` combinator
     pub fn for_unit(context: &mut Context) -> Self {
         Arrow {
-            source: Type::free(context.naming.new_name()),
+            source: Type::free(new_name("unit_src_")),
             target: context.unit_ty(),
         }
     }
 
     /// Create a unification arrow for a fresh `iden` combinator
-    pub fn for_iden(context: &mut Context) -> Self {
+    pub fn for_iden(_context: &mut Context) -> Self {
         // Throughout this module, when two types are the same, we reuse a
         // pointer to them rather than creating distinct types and unifying
         // them. This theoretically could lead to more confusing errors for
         // the user during type inference, but in practice type inference
         // is completely opaque and there's no harm in making it moreso.
-        let new = Type::free(context.naming.new_name());
+        let new = Type::free(new_name("iden_src_"));
         Arrow {
             source: new.shallow_clone(),
             target: new,
@@ -104,18 +106,18 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `witness` combinator
-    pub fn for_witness(context: &mut Context) -> Self {
+    pub fn for_witness(_context: &mut Context) -> Self {
         Arrow {
-            source: Type::free(context.naming.new_name()),
-            target: Type::free(context.naming.new_name()),
+            source: Type::free(new_name("witness_src_")),
+            target: Type::free(new_name("witness_tgt_")),
         }
     }
 
     /// Create a unification arrow for a fresh `fail` combinator
-    pub fn for_fail(context: &mut Context) -> Self {
+    pub fn for_fail(_context: &mut Context) -> Self {
         Arrow {
-            source: Type::free(context.naming.new_name()),
-            target: Type::free(context.naming.new_name()),
+            source: Type::free(new_name("fail_src_")),
+            target: Type::free(new_name("fail_tgt_")),
         }
     }
 
@@ -139,43 +141,43 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `injl` combinator
-    pub fn for_injl(context: &mut Context, child_arrow: &Arrow) -> Self {
+    pub fn for_injl(_context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: child_arrow.source.shallow_clone(),
             target: Type::sum(
                 child_arrow.target.shallow_clone(),
-                Type::free(context.naming.new_name()),
+                Type::free(new_name("injl_tgt_")),
             ),
         }
     }
 
     /// Create a unification arrow for a fresh `injr` combinator
-    pub fn for_injr(context: &mut Context, child_arrow: &Arrow) -> Self {
+    pub fn for_injr(_context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: child_arrow.source.shallow_clone(),
             target: Type::sum(
-                Type::free(context.naming.new_name()),
+                Type::free(new_name("injr_tgt_")),
                 child_arrow.target.shallow_clone(),
             ),
         }
     }
 
     /// Create a unification arrow for a fresh `take` combinator
-    pub fn for_take(context: &mut Context, child_arrow: &Arrow) -> Self {
+    pub fn for_take(_context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: Type::product(
                 child_arrow.source.shallow_clone(),
-                Type::free(context.naming.new_name()),
+                Type::free(new_name("take_src_")),
             ),
             target: child_arrow.target.shallow_clone(),
         }
     }
 
     /// Create a unification arrow for a fresh `drop` combinator
-    pub fn for_drop(context: &mut Context, child_arrow: &Arrow) -> Self {
+    pub fn for_drop(_context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: Type::product(
-                Type::free(context.naming.new_name()),
+                Type::free(new_name("drop_src_")),
                 child_arrow.source.shallow_clone(),
             ),
             target: child_arrow.target.shallow_clone(),
@@ -226,13 +228,13 @@ impl Arrow {
     /// If neither child is provided, this function will not raise an error; it
     /// is the responsibility of the caller to detect this case and error elsewhere.
     pub fn for_case(
-        context: &mut Context,
+        _context: &mut Context,
         lchild_arrow: Option<&Arrow>,
         rchild_arrow: Option<&Arrow>,
     ) -> Result<Self, Error> {
-        let a = Type::free(context.naming.new_name());
-        let b = Type::free(context.naming.new_name());
-        let c = Type::free(context.naming.new_name());
+        let a = Type::free(new_name("case_a_"));
+        let b = Type::free(new_name("case_b_"));
+        let c = Type::free(new_name("case_c_"));
 
         let sum_a_b = Type::sum(a.shallow_clone(), b.shallow_clone());
         let prod_sum_a_b_c = Type::product(sum_a_b, c.shallow_clone());
@@ -270,8 +272,8 @@ impl Arrow {
         lchild_arrow: &Arrow,
         rchild_arrow: &Arrow,
     ) -> Result<Self, Error> {
-        let a = Type::free(context.naming.new_name());
-        let b = Type::free(context.naming.new_name());
+        let a = Type::free(new_name("disconnect_a_"));
+        let b = Type::free(new_name("disconnect_b_"));
         let c = rchild_arrow.source.shallow_clone();
         let d = rchild_arrow.target.shallow_clone();
 

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -82,7 +82,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `unit` combinator
-    pub fn for_unit<J: Jet>(context: &mut Context<J>) -> Self {
+    pub fn for_unit(context: &mut Context) -> Self {
         Arrow {
             source: Type::free(context.naming.new_name()),
             target: context.unit_ty(),
@@ -90,7 +90,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `iden` combinator
-    pub fn for_iden<J: Jet>(context: &mut Context<J>) -> Self {
+    pub fn for_iden(context: &mut Context) -> Self {
         // Throughout this module, when two types are the same, we reuse a
         // pointer to them rather than creating distinct types and unifying
         // them. This theoretically could lead to more confusing errors for
@@ -104,7 +104,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `witness` combinator
-    pub fn for_witness<J: Jet>(context: &mut Context<J>) -> Self {
+    pub fn for_witness(context: &mut Context) -> Self {
         Arrow {
             source: Type::free(context.naming.new_name()),
             target: Type::free(context.naming.new_name()),
@@ -112,7 +112,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `fail` combinator
-    pub fn for_fail<J: Jet>(context: &mut Context<J>) -> Self {
+    pub fn for_fail(context: &mut Context) -> Self {
         Arrow {
             source: Type::free(context.naming.new_name()),
             target: Type::free(context.naming.new_name()),
@@ -120,7 +120,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh jet combinator
-    pub fn for_jet<J: Jet>(context: &mut Context<J>, jet: J) -> Self {
+    pub fn for_jet<J: Jet>(context: &mut Context, jet: J) -> Self {
         Arrow {
             source: jet.source_ty().to_type(|n| context.nth_power_of_2(n)),
             target: jet.target_ty().to_type(|n| context.nth_power_of_2(n)),
@@ -128,7 +128,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh const-word combinator
-    pub fn for_const_word<J: Jet>(context: &mut Context<J>, word: &Value) -> Self {
+    pub fn for_const_word(context: &mut Context, word: &Value) -> Self {
         let len = word.len();
         assert_eq!(len.count_ones(), 1);
         let depth = word.len().trailing_zeros();
@@ -139,7 +139,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `injl` combinator
-    pub fn for_injl<J: Jet>(context: &mut Context<J>, child_arrow: &Arrow) -> Self {
+    pub fn for_injl(context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: child_arrow.source.shallow_clone(),
             target: Type::sum(
@@ -150,7 +150,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `injr` combinator
-    pub fn for_injr<J: Jet>(context: &mut Context<J>, child_arrow: &Arrow) -> Self {
+    pub fn for_injr(context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: child_arrow.source.shallow_clone(),
             target: Type::sum(
@@ -161,7 +161,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `take` combinator
-    pub fn for_take<J: Jet>(context: &mut Context<J>, child_arrow: &Arrow) -> Self {
+    pub fn for_take(context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: Type::product(
                 child_arrow.source.shallow_clone(),
@@ -172,7 +172,7 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `drop` combinator
-    pub fn for_drop<J: Jet>(context: &mut Context<J>, child_arrow: &Arrow) -> Self {
+    pub fn for_drop(context: &mut Context, child_arrow: &Arrow) -> Self {
         Arrow {
             source: Type::product(
                 Type::free(context.naming.new_name()),
@@ -183,8 +183,8 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `pair` combinator
-    pub fn for_pair<J: Jet>(
-        _: &mut Context<J>,
+    pub fn for_pair(
+        _: &mut Context,
         lchild_arrow: &Arrow,
         rchild_arrow: &Arrow,
     ) -> Result<Self, Error> {
@@ -202,8 +202,8 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `comp` combinator
-    pub fn for_comp<J: Jet>(
-        _: &mut Context<J>,
+    pub fn for_comp(
+        _: &mut Context,
         lchild_arrow: &Arrow,
         rchild_arrow: &Arrow,
     ) -> Result<Self, Error> {
@@ -225,8 +225,8 @@ impl Arrow {
     ///
     /// If neither child is provided, this function will not raise an error; it
     /// is the responsibility of the caller to detect this case and error elsewhere.
-    pub fn for_case<J: Jet>(
-        context: &mut Context<J>,
+    pub fn for_case(
+        context: &mut Context,
         lchild_arrow: Option<&Arrow>,
         rchild_arrow: Option<&Arrow>,
     ) -> Result<Self, Error> {
@@ -265,8 +265,8 @@ impl Arrow {
     }
 
     /// Create a unification arrow for a fresh `comp` combinator
-    pub fn for_disconnect<J: Jet>(
-        context: &mut Context<J>,
+    pub fn for_disconnect(
+        context: &mut Context,
         lchild_arrow: &Arrow,
         rchild_arrow: &Arrow,
     ) -> Result<Self, Error> {
@@ -305,72 +305,72 @@ impl Arrow {
     }
 }
 
-impl<J: Jet> CoreConstructible<J> for Arrow {
-    fn iden(ctx: &mut Context<J>) -> Self {
+impl CoreConstructible for Arrow {
+    fn iden(ctx: &mut Context) -> Self {
         Self::for_iden(ctx)
     }
 
-    fn unit(ctx: &mut Context<J>) -> Self {
+    fn unit(ctx: &mut Context) -> Self {
         Self::for_unit(ctx)
     }
 
-    fn injl(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn injl(ctx: &mut Context, child: &Self) -> Self {
         Self::for_injl(ctx, child)
     }
 
-    fn injr(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn injr(ctx: &mut Context, child: &Self) -> Self {
         Self::for_injr(ctx, child)
     }
 
-    fn take(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn take(ctx: &mut Context, child: &Self) -> Self {
         Self::for_take(ctx, child)
     }
 
-    fn drop_(ctx: &mut Context<J>, child: &Self) -> Self {
+    fn drop_(ctx: &mut Context, child: &Self) -> Self {
         Self::for_drop(ctx, child)
     }
 
-    fn comp(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+    fn comp(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, Error> {
         Self::for_comp(ctx, left, right)
     }
 
-    fn case(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+    fn case(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, Error> {
         Self::for_case(ctx, Some(left), Some(right))
     }
 
-    fn assertl(ctx: &mut Context<J>, left: &Self, _: crate::Cmr) -> Result<Self, Error> {
+    fn assertl(ctx: &mut Context, left: &Self, _: crate::Cmr) -> Result<Self, Error> {
         Self::for_case(ctx, Some(left), None)
     }
 
-    fn assertr(ctx: &mut Context<J>, _: crate::Cmr, right: &Self) -> Result<Self, Error> {
+    fn assertr(ctx: &mut Context, _: crate::Cmr, right: &Self) -> Result<Self, Error> {
         Self::for_case(ctx, None, Some(right))
     }
 
-    fn pair(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+    fn pair(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, Error> {
         Self::for_pair(ctx, left, right)
     }
 
-    fn disconnect(ctx: &mut Context<J>, left: &Self, right: &Self) -> Result<Self, Error> {
+    fn disconnect(ctx: &mut Context, left: &Self, right: &Self) -> Result<Self, Error> {
         Self::for_disconnect(ctx, left, right)
     }
 
-    fn fail(ctx: &mut Context<J>, _: crate::FailEntropy) -> Self {
+    fn fail(ctx: &mut Context, _: crate::FailEntropy) -> Self {
         Self::for_fail(ctx)
     }
 
-    fn const_word(ctx: &mut Context<J>, word: Arc<Value>) -> Self {
+    fn const_word(ctx: &mut Context, word: Arc<Value>) -> Self {
         Self::for_const_word(ctx, &word)
     }
 }
 
 impl<J: Jet> JetConstructible<J> for Arrow {
-    fn jet(ctx: &mut Context<J>, jet: J) -> Self {
+    fn jet(ctx: &mut Context, jet: J) -> Self {
         Self::for_jet(ctx, jet)
     }
 }
 
-impl<W, J: Jet> WitnessConstructible<W, J> for Arrow {
-    fn witness(ctx: &mut Context<J>, _: W) -> Self {
+impl<W> WitnessConstructible<W> for Arrow {
+    fn witness(ctx: &mut Context, _: W) -> Self {
         Self::for_witness(ctx)
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -242,6 +242,11 @@ impl Final {
         &self.bound
     }
 
+    /// Returns whether this is the unit type
+    pub fn is_unit(&self) -> bool {
+        self.bound == CompleteBound::Unit
+    }
+
     /// Accessor for both children of the type, if they exist.
     pub fn split(&self) -> Option<(Arc<Self>, Arc<Self>)> {
         match &self.bound {

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -12,37 +12,16 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-//! Type Variables
-//!
+//! Names for type variables
 
-use std::collections::VecDeque;
-use std::iter::FromIterator;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
-/// Factory for creating free variables with fresh names.
-/// Identifiers are assigned sequentially as follows:
-/// `A`, `B`, `C`, ... `Z`, `AA`, `AB`, `AC`, ...
-pub(crate) struct Factory {
-    next_id: usize,
-}
+/// Global counter used to give type variables unique names.
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
 
-impl Factory {
-    /// Create a new factory.
-    pub fn new() -> Self {
-        Self { next_id: 1 }
-    }
-
-    /// Return a free variable with a fresh name.
-    pub fn new_name(&mut self) -> String {
-        let mut n = self.next_id;
-        self.next_id += 1;
-        let mut ascii_bytes = VecDeque::new();
-
-        while n / 26 > 0 {
-            ascii_bytes.push_front((n % 26) as u8 + 65);
-            n /= 26;
-        }
-
-        ascii_bytes.push_front((n % 26) as u8 + 64);
-        String::from_utf8(Vec::from_iter(ascii_bytes.into_iter())).unwrap()
-    }
+/// Obtain a fresh variable name, with the given `prefix` and a unique incrementing
+/// numeric suffix.
+pub fn new_name(prefix: &str) -> String {
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    format!("{}{:02}", prefix, id)
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -31,7 +31,7 @@ use std::hash::Hash;
 ///
 /// Bitstrings are represented as a tree of _products_ (a.k.a. a tuple)
 /// with sums of unit as its leaves (a.k.a. bits).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Value {
     /// Unit value
     Unit,
@@ -224,6 +224,12 @@ impl Value {
     /// Convenience constructor for product of two values
     pub fn prod(a: Value, b: Value) -> Value {
         Value::Prod(Box::new(a), Box::new(b))
+    }
+}
+
+impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
We temporarily introduce some conversion functions from the new node types to the old ones. When we do encoding we'll introduce conversions in the opposite direction. Then later we'll delete the entire `core` module along with those functions.

Also includes several commits which are essentially cleanups; only the last two commits are the meat of this PR.