### PR TITLE
Node overhaul 2: use new node types for decoding

### DIFF
--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -503,7 +503,7 @@ mod tests {
             }
         }
 
-        let prog = crate::CommitNode::from_node(&prog);
+        let prog = crate::CommitNode::from_node(prog.as_ref());
         let mut reser_sink = Vec::<u8>::new();
         let mut w = BitWriter::from(&mut reser_sink);
         prog.encode(&mut w)

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -672,8 +672,7 @@ impl<J: Jet> CommitNode<J> {
     pub fn decode<I: Iterator<Item = u8>>(
         bits: &mut BitIter<I>,
     ) -> Result<Rc<Self>, crate::decode::Error> {
-        let node = crate::decode::decode_expression(bits)?;
-        Ok(Self::from_node(&node))
+        Ok(Self::from_node(node::ConstructNode::decode(bits)?.as_ref()))
     }
 
     /// Encode a Simplicity program to bits, without witness data.

--- a/src/core/commit.rs
+++ b/src/core/commit.rs
@@ -20,6 +20,7 @@ use crate::jet::Jet;
 use crate::merkle::amr::Amr;
 use crate::merkle::cmr::Cmr;
 use crate::merkle::imr::{FirstPassImr, Imr};
+use crate::node;
 use crate::types::{self, arrow::Arrow};
 use crate::{analysis, Error};
 use crate::{BitIter, BitWriter, FailEntropy, RedeemNode, Value};
@@ -128,6 +129,41 @@ pub enum UsedCaseBranch {
 }
 
 impl<J: Jet> CommitNode<J> {
+    /// [will be removed] create a CommitNode from a newfangled `node::ConstructNode`
+    pub fn from_node(node: &node::ConstructNode<J>) -> Rc<Self> {
+        let mut converted = vec![];
+        for data in node.post_order_iter::<InternalSharing>() {
+            let left = data.left_index.map(|idx| Rc::clone(&converted[idx]));
+            let right = data.right_index.map(|idx| Rc::clone(&converted[idx]));
+            let new_node = Rc::new(CommitNode {
+                inner: match data.node.inner() {
+                    node::Inner::Iden => CommitNodeInner::Iden,
+                    node::Inner::Unit => CommitNodeInner::Unit,
+                    node::Inner::InjL(..) => CommitNodeInner::InjL(left.unwrap()),
+                    node::Inner::InjR(..) => CommitNodeInner::InjR(left.unwrap()),
+                    node::Inner::Take(..) => CommitNodeInner::Take(left.unwrap()),
+                    node::Inner::Drop(..) => CommitNodeInner::Drop(left.unwrap()),
+                    node::Inner::Comp(..) => CommitNodeInner::Comp(left.unwrap(), right.unwrap()),
+                    node::Inner::Case(..) => CommitNodeInner::Case(left.unwrap(), right.unwrap()),
+                    node::Inner::AssertL(_, cmr) => CommitNodeInner::AssertL(left.unwrap(), *cmr),
+                    node::Inner::AssertR(cmr, _) => CommitNodeInner::AssertR(*cmr, left.unwrap()),
+                    node::Inner::Pair(..) => CommitNodeInner::Pair(left.unwrap(), right.unwrap()),
+                    node::Inner::Disconnect(..) => {
+                        CommitNodeInner::Disconnect(left.unwrap(), right.unwrap())
+                    }
+                    node::Inner::Witness(..) => CommitNodeInner::Witness,
+                    node::Inner::Jet(j) => CommitNodeInner::Jet(*j),
+                    node::Inner::Word(w) => CommitNodeInner::Word(w.as_ref().clone()),
+                    node::Inner::Fail(entropy) => CommitNodeInner::Fail(*entropy),
+                },
+                cmr: data.node.cmr(),
+                arrow: data.node.arrow().shallow_clone(),
+            });
+            converted.push(new_node);
+        }
+        converted.pop().unwrap()
+    }
+
     /// Accessor for the node's "inner value", i.e. its combinator
     pub fn inner(&self) -> &CommitNodeInner<J> {
         &self.inner
@@ -636,7 +672,8 @@ impl<J: Jet> CommitNode<J> {
     pub fn decode<I: Iterator<Item = u8>>(
         bits: &mut BitIter<I>,
     ) -> Result<Rc<Self>, crate::decode::Error> {
-        crate::decode::decode_expression(bits)
+        let node = crate::decode::decode_expression(bits)?;
+        Ok(Self::from_node(&node))
     }
 
     /// Encode a Simplicity program to bits, without witness data.

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -152,7 +152,8 @@ impl<J: Jet> RedeemNode<J> {
 
     /// Decode a Simplicity program from bits, including the witness data.
     pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Rc<Self>, Error> {
-        let commit = crate::bit_encoding::decode::decode_program(bits)?;
+        let commit = crate::bit_encoding::decode::decode_expression(bits)?;
+        let commit = crate::CommitNode::from_node(&commit);
         let witness = WitnessDecoder::new(bits)?;
         let program = commit.finalize(witness, false)?;
 
@@ -210,7 +211,7 @@ mod tests {
 
     use super::*;
 
-    use crate::bit_encoding::decode::decode_program;
+    use crate::bit_encoding::decode::decode_expression;
     use crate::jet::Core;
 
     #[test]
@@ -223,7 +224,8 @@ mod tests {
         // main = comp wits_are_equal jet_verify            :: 1 -> 1
         let eqwits = vec![0xc9, 0xc4, 0x6d, 0xb8, 0x82, 0x30, 0x10];
         let mut iter = BitIter::from(&eqwits[..]);
-        let eqwits_prog = decode_program::<_, Core>(&mut iter).unwrap();
+        let eqwits_prog = decode_expression::<_, Core>(&mut iter).unwrap();
+        let eqwits_prog = crate::CommitNode::from_node(&eqwits_prog);
 
         let mut witness_iter = iter::repeat(Value::u32(0xDEADBEEF));
         // Generally when we are manually adding witnesses we want to unshare them so that

--- a/src/core/redeem.rs
+++ b/src/core/redeem.rs
@@ -152,7 +152,7 @@ impl<J: Jet> RedeemNode<J> {
 
     /// Decode a Simplicity program from bits, including the witness data.
     pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Rc<Self>, Error> {
-        let commit = crate::decode_program(bits)?;
+        let commit = crate::bit_encoding::decode::decode_program(bits)?;
         let witness = WitnessDecoder::new(bits)?;
         let program = commit.finalize(witness, false)?;
 
@@ -210,6 +210,7 @@ mod tests {
 
     use super::*;
 
+    use crate::bit_encoding::decode::decode_program;
     use crate::jet::Core;
 
     #[test]
@@ -222,7 +223,7 @@ mod tests {
         // main = comp wits_are_equal jet_verify            :: 1 -> 1
         let eqwits = vec![0xc9, 0xc4, 0x6d, 0xb8, 0x82, 0x30, 0x10];
         let mut iter = BitIter::from(&eqwits[..]);
-        let eqwits_prog = crate::decode_program::<_, Core>(&mut iter).unwrap();
+        let eqwits_prog = decode_program::<_, Core>(&mut iter).unwrap();
 
         let mut witness_iter = iter::repeat(Value::u32(0xDEADBEEF));
         // Generally when we are manually adding witnesses we want to unshare them so that

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -331,6 +331,23 @@ pub trait DagLike: Sized {
         }
     }
 
+    /// Checks whether a DAG's internal sharing (as expressed by shared pointers)
+    /// matches the given target sharing.
+    #[allow(clippy::wrong_self_convention)] // clippy doesn't like is_* taking a pointer by value
+    fn is_shared_as<S: SharingTracker<Self> + Default>(self) -> bool
+    where
+        Self: Clone,
+    {
+        let iter_is = self.clone().post_order_iter::<InternalSharing>();
+        let iter_ought = self.post_order_iter::<S>();
+        for (data_is, data_ought) in iter_is.zip(iter_ought) {
+            if PointerId::from(&data_is.node) != PointerId::from(&data_ought.node) {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Obtains an post-order iterator of all the nodes rooted at DAG, using the
     /// given tracker.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub use crate::bit_machine::exec;
 pub use crate::core::commit::CommitNodeInner;
 pub use crate::core::redeem::RedeemNodeInner;
 pub use crate::core::{CommitNode, RedeemNode};
-pub use crate::decode::{decode_program, WitnessDecoder};
+pub use crate::decode::WitnessDecoder;
 pub use crate::encode::{encode_natural, encode_value, encode_witness};
 pub use crate::merkle::{
     amr::Amr,

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -12,11 +12,11 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use crate::dag::MaxSharing;
+use crate::dag::{DagLike, MaxSharing};
 use crate::jet::Jet;
 use crate::types;
 use crate::types::arrow::{Arrow, FinalArrow};
-use crate::{Cmr, Error, FirstPassImr, Imr, Value};
+use crate::{BitIter, Cmr, Error, FirstPassImr, Imr, Value};
 
 use super::{
     Construct, ConstructData, ConstructNode, Constructible, Inner, NoWitness, Node, NodeData,
@@ -177,5 +177,25 @@ impl<J: Jet> CommitNode<J> {
             },
             |_, _| Ok(NoWitness),
         )
+    }
+
+    /// Decode a Simplicity program from bits, without witness data.
+    ///
+    /// # Usage
+    ///
+    /// Use this method only if the serialization **does not** include the witness data.
+    /// This means, the program simply has no witness during commitment,
+    /// or the witness is provided by other means.
+    ///
+    /// If the serialization contains the witness data, then use [`RedeemNode::decode()`].
+    pub fn decode<I: Iterator<Item = u8>>(bits: &mut BitIter<I>) -> Result<Arc<Self>, Error> {
+        // 1. Decode program with out witnesses.
+        let program = crate::decode::decode_program(bits)?;
+        // 2. Do sharing check, using incomplete IMRs
+        if program.as_ref().is_shared_as::<MaxSharing<Commit, J>>() {
+            Ok(program)
+        } else {
+            Err(Error::SharingNotMaximal)
+        }
     }
 }

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -15,7 +15,7 @@
 use crate::dag::InternalSharing;
 use crate::jet::Jet;
 use crate::types::{self, arrow::Arrow};
-use crate::{Cmr, FailEntropy, Value};
+use crate::{BitIter, Cmr, FailEntropy, Value};
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -85,6 +85,21 @@ impl<J: Jet> ConstructNode<J> {
             },
             |_, _| Ok(NoWitness),
         )
+    }
+
+    /// Decode a Simplicity expression from bits, without witness data.
+    ///
+    /// # Usage
+    ///
+    /// Use this method only if the serialization **does not** include the witness data.
+    /// This means, the program simply has no witness during commitment,
+    /// or the witness is provided by other means.
+    ///
+    /// If the serialization contains the witness data, then use [`RedeemNode::decode()`].
+    pub fn decode<I: Iterator<Item = u8>>(
+        bits: &mut BitIter<I>,
+    ) -> Result<Arc<Self>, crate::decode::Error> {
+        crate::decode::decode_expression(bits)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -248,6 +248,11 @@ impl Final {
         &self.bound
     }
 
+    /// Returns whether this is the unit type
+    pub fn is_unit(&self) -> bool {
+        self.bound == CompleteBound::Unit
+    }
+
     /// Accessor for both children of the type, if they exist.
     pub fn split(&self) -> Option<(Arc<Self>, Arc<Self>)> {
         match &self.bound {


### PR DESCRIPTION
We temporarily introduce some conversion functions from the new node types to the old ones. When we do encoding we'll introduce conversions in the opposite direction. Then later we'll delete the entire core module along with those functions.

Replaces #132.