### PR TITLE
Node overhaul 3: generalize node conversion a bit, add `SimpleFinalizer` for tests

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,4 @@
 msrv = "1.48.0"
+
+# Default 250, not sure what units. But it does not like the generic node stuff.
+type-complexity-threshold = 1000

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -449,9 +449,11 @@ mod tests {
     use crate::encode;
     use crate::exec::BitMachine;
     use crate::jet::Core;
+    use crate::node::SimpleFinalizer;
     use crate::BitWriter;
     use crate::CommitNode;
     use bitcoin_hashes::hex::ToHex;
+    use std::iter;
 
     fn assert_program_deserializable<J: Jet>(
         prog_bytes: &[u8],
@@ -479,7 +481,9 @@ mod tests {
             let fprog = prog
                 .finalize_types()
                 .expect("finalizing types")
-                .finalize_no_witnesses()
+                .finalize(&mut SimpleFinalizer::new(iter::repeat(Arc::new(
+                    Value::Unit,
+                ))))
                 .expect("can't be finalized without witnesses; can't check AMR or IMR");
             if let Some(amr) = amr_str {
                 assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,9 @@ pub enum Error {
     Policy(policy::Error),
     /// Program does not have maximal sharing
     SharingNotMaximal,
+    /// Finalization led to the root node being hidden, because not enough witnesses
+    /// were provided (or some branches incomplete branches were kept instead of pruned).
+    IncompleteFinalization,
 }
 
 impl fmt::Display for Error {
@@ -113,6 +116,9 @@ impl fmt::Display for Error {
             #[cfg(feature = "elements")]
             Error::Policy(ref e) => fmt::Display::fmt(e, f),
             Error::SharingNotMaximal => f.write_str("Decoded programs must have maximal sharing"),
+            Error::IncompleteFinalization => {
+                f.write_str("finalization did not complete (missing witnesses)")
+            }
         }
     }
 }
@@ -129,6 +135,7 @@ impl std::error::Error for Error {
             Error::MiniscriptError(ref e) => Some(e),
             #[cfg(feature = "elements")]
             Error::Policy(ref e) => Some(e),
+            Error::IncompleteFinalization => None,
         }
     }
 }

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -12,15 +12,15 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use crate::dag::{DagLike, MaxSharing};
+use crate::dag::{DagLike, MaxSharing, PostOrderIterItem};
 use crate::jet::Jet;
 use crate::types;
 use crate::types::arrow::{Arrow, FinalArrow};
 use crate::{BitIter, Cmr, Error, FirstPassImr, Imr, Value};
 
 use super::{
-    Construct, ConstructData, ConstructNode, Constructible, Inner, NoWitness, Node, NodeData,
-    RedeemData, RedeemNode,
+    Construct, ConstructData, ConstructNode, Constructible, Converter, Inner, NoWitness, Node,
+    NodeData, Redeem, RedeemData, RedeemNode,
 };
 
 use std::marker::PhantomData;
@@ -71,7 +71,7 @@ impl<J: Jet> CommitData<J> {
     }
 
     /// Helper function to compute a cached first-pass IMR
-    fn first_pass_imr(inner: Inner<&Arc<Self>, J, NoWitness>) -> Option<FirstPassImr> {
+    fn first_pass_imr(inner: Inner<&Arc<Self>, J, &NoWitness>) -> Option<FirstPassImr> {
         match inner {
             Inner::Iden => Some(FirstPassImr::iden()),
             Inner::Unit => Some(FirstPassImr::unit()),
@@ -107,7 +107,7 @@ impl<J: Jet> CommitData<J> {
 
     pub fn new(
         arrow: &Arrow,
-        inner: Inner<&Arc<Self>, J, NoWitness>,
+        inner: Inner<&Arc<Self>, J, &NoWitness>,
     ) -> Result<Self, types::Error> {
         let final_arrow = arrow.finalize()?;
         let first_pass_imr = Self::first_pass_imr(inner);
@@ -119,7 +119,7 @@ impl<J: Jet> CommitData<J> {
         })
     }
 
-    pub fn from_final(arrow: FinalArrow, inner: Inner<&Arc<Self>, J, NoWitness>) -> Self {
+    pub fn from_final(arrow: FinalArrow, inner: Inner<&Arc<Self>, J, &NoWitness>) -> Self {
         let first_pass_imr = Self::first_pass_imr(inner);
         CommitData {
             first_pass_imr,
@@ -150,33 +150,63 @@ impl<J: Jet> CommitNode<J> {
     /// testing purposes. But for any other witness nodes, it will error out with
     /// [`Error::NoMoreWitnesses`].
     pub fn finalize_no_witnesses(&self) -> Result<Arc<RedeemNode<J>>, Error> {
-        self.convert::<MaxSharing<Commit, J>, _, _, _, _>(
-            |data, converted| {
-                let converted_data = converted.map(|node| node.cached_data());
-                Ok(Arc::new(RedeemData::new(
-                    data.node.data.arrow.shallow_clone(),
-                    converted_data,
-                )))
-            },
-            |data, _| {
+        struct SimpleFinalizer<J: Jet>(PhantomData<J>);
+
+        impl<J: Jet> Converter<Commit, Redeem, J> for SimpleFinalizer<J> {
+            type Error = Error;
+            fn convert_witness(
+                &mut self,
+                data: &PostOrderIterItem<&CommitNode<J>>,
+                _: &NoWitness,
+            ) -> Result<Arc<Value>, Self::Error> {
                 if data.node.arrow().target.is_unit() {
                     Ok(Arc::new(Value::Unit))
                 } else {
                     Err(Error::NoMoreWitnesses)
                 }
-            },
-        )
+            }
+
+            fn convert_data(
+                &mut self,
+                data: &PostOrderIterItem<&CommitNode<J>>,
+                inner: Inner<&Arc<RedeemNode<J>>, J, &Arc<Value>>,
+            ) -> Result<Arc<RedeemData<J>>, Self::Error> {
+                let converted_data = inner.map(|node| node.cached_data()).map_witness(Arc::clone);
+                Ok(Arc::new(RedeemData::new(
+                    data.node.data.arrow.shallow_clone(),
+                    converted_data,
+                )))
+            }
+        }
+
+        self.convert::<MaxSharing<Commit, J>, _, _>(&mut SimpleFinalizer(PhantomData))
     }
 
     /// Convert a [`CommitNode`] back to a [`ConstructNode`] by redoing type inference
     pub fn unfinalize_types(&self) -> Result<Arc<ConstructNode<J>>, types::Error> {
-        self.convert::<MaxSharing<Commit, J>, _, _, Construct, _>(
-            |_, inner| {
+        struct UnfinalizeTypes<J: Jet>(PhantomData<J>);
+
+        impl<J: Jet> Converter<Commit, Construct, J> for UnfinalizeTypes<J> {
+            type Error = types::Error;
+            fn convert_witness(
+                &mut self,
+                _: &PostOrderIterItem<&CommitNode<J>>,
+                _: &NoWitness,
+            ) -> Result<NoWitness, Self::Error> {
+                Ok(NoWitness)
+            }
+
+            fn convert_data(
+                &mut self,
+                _: &PostOrderIterItem<&CommitNode<J>>,
+                inner: Inner<&Arc<ConstructNode<J>>, J, &NoWitness>,
+            ) -> Result<ConstructData<J>, Self::Error> {
                 let inner = inner.map(|node| node.arrow());
                 Ok(ConstructData::new(Arrow::from_inner(inner)?))
-            },
-            |_, _| Ok(NoWitness),
-        )
+            }
+        }
+
+        self.convert::<MaxSharing<Commit, J>, _, _>(&mut UnfinalizeTypes(PhantomData))
     }
 
     /// Decode a Simplicity program from bits, without witness data.

--- a/src/node/convert.rs
+++ b/src/node/convert.rs
@@ -1,0 +1,137 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Node Conversion
+//!
+//! This module defines a trait [`Conversion`] which is called by the
+//! [`Node::convert`] method. The `Convert` trait is used to convert between
+//! one node type and another, controlling several nuanced aspects of the
+//! conversion. Specifically:
+//!
+//! 1. Cached data can be translated from the old type to the new one.
+//! 2. Witness data can be provided (or translated from the old witness type,
+//!    if it was nontrivial) to attach to witness nodes.
+//! 3. For `case` nodes, the decision can be made to hide one of the children.
+//!    In this case the `case` node is converted to an `AssertL` or `AssertR`
+//!    node, depending which child was hidden.
+//!
+
+use crate::dag::PostOrderIterItem;
+use crate::jet::Jet;
+
+use super::{Inner, Node, NodeData};
+
+use std::sync::Arc;
+
+/// A decision about which, if any, child branches of a `case` combinator to hide
+/// during a [`Node::convert_hiding`] conversion
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Hide {
+    Neither,
+    Left,
+    Right,
+}
+
+/// The primary trait controlling how a node conversion is done.
+///
+/// When a node is converted using [`Node::convert`], the original DAG rooted at
+/// that node is traversed in post order. For each node, the following steps are
+/// taken:
+///
+/// 1. First, [`Self::visit_node`] is called, before any other checks are
+///    done. This happens regardless of the node's type or whether it is going
+///    to be pruned.
+///
+///    This method is provided for convenience and does not affect the course
+///    of the algorithm. It has a default implementation which does nothing.
+///
+/// 2. Then, if the node is a witness node, `Self::convert_witness` is called
+///    to obtain witness data.
+///
+/// 3. If the node is a case node, [`Self::prune_case`] is called to decide
+///    whether to prune either child of the node (turning the `case` into an
+///    `assertl` or `assertr`). The default implementation hides neither.
+///
+/// 4. Finally, the node's data is passed to [`Self::convert_data`], whose job
+///    it is to compute the cached data for the new node. For `case` combinators
+///    where one child was pruned, `convert_data` will receive an `assertl` or
+///    `assertl`, as appropriate, rather than a `case`.
+///
+/// If any method returns an error, then iteration is aborted immediately and
+/// the error returned to the caller. If the converter would like to recover
+/// from errors and/or accumulate multiple errors, it needs to do this by
+/// tracking errors internally.
+///
+/// The finalization method will not return any errors except those returned by
+/// methods on [`Converter`].
+pub trait Converter<N: NodeData<J>, M: NodeData<J>, J: Jet> {
+    /// The error type returned by the methods on this trait.
+    type Error;
+
+    /// This method is called on every node, to inform the `Converter` about the
+    /// state of the iterator.
+    ///
+    /// No action needs to be taken. The default implementation does nothing.
+    fn visit_node(&mut self, _data: &PostOrderIterItem<&Node<N, J>>) {}
+
+    /// For witness nodes, this method is called first to attach witness data to
+    /// the node.
+    ///
+    /// It takes the iteration data of the current node, as well as the current
+    /// witness (which in a typical scenario will be an empty structure, but
+    /// with custom node types may be a placeholder or other useful information)
+    ///
+    /// No typechecking or other sanity-checking is done on the returned value.
+    /// It is the caller's responsibility to make sure that the provided witness
+    /// actually matches the type of the combinator that it is being attached to.
+    fn convert_witness(
+        &mut self,
+        data: &PostOrderIterItem<&Node<N, J>>,
+        witness: &N::Witness,
+    ) -> Result<M::Witness, Self::Error>;
+
+    /// For case nodes, this method is called first to decide which, if any, children
+    /// to prune.
+    ///
+    /// It takes the iteration data of the current node, as well as both of its already
+    /// converted children. This method returns a hiding decision.
+    ///
+    /// The default implementation doesn't do any hiding.
+    fn prune_case(
+        &mut self,
+        _data: &PostOrderIterItem<&Node<N, J>>,
+        _left: &Arc<Node<M, J>>,
+        _right: &Arc<Node<M, J>>,
+    ) -> Result<Hide, Self::Error> {
+        Ok(Hide::Neither)
+    }
+
+    /// This method is called for every node, after [`Self::convert_witness`] or
+    /// [`Self::prune_case`], if either is applicable.
+    ///
+    /// For case nodes for which [`Self::prune_case`] returned [`Hide::Left`] or
+    /// [`Hide::Right`], `inner` will be an [`Inner::AssertR`] or [`Inner::AssertL`]
+    /// respectively; the pruned child will then appear only as a CMR.
+    ///
+    /// It accepts the iteration data of the current node, from which the existing
+    /// cached data can be obtained by calling `data.node.cached_data()`, as well
+    /// as an `Inner` structure containing its already-converted children.
+    ///
+    /// Returns new cached data which will be attached to the newly-converted node.
+    fn convert_data(
+        &mut self,
+        data: &PostOrderIterItem<&Node<N, J>>,
+        inner: Inner<&Arc<Node<M, J>>, J, &M::Witness>,
+    ) -> Result<M::CachedData, Self::Error>;
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -97,7 +97,7 @@ mod redeem;
 
 pub use commit::{Commit, CommitData, CommitNode};
 pub use construct::{Construct, ConstructData, ConstructNode};
-pub use convert::{Converter, Hide};
+pub use convert::{Converter, Hide, SimpleFinalizer};
 pub use inner::Inner;
 pub use redeem::{Redeem, RedeemData, RedeemNode};
 


### PR DESCRIPTION
Introduce a new trait for node conversions, and the ability to prune nodes while converting. Unclear yet whether we will use this for policy satisfaction, but the result seems generally useful, and allows us to port all our existing unit tests to the new node types. Introduces a new `SimpleFinalizer` for this purpose which implements the trait and simple adapts a witness iterator to it.