### PR TITLE
Eliminate recursion from `value` and from most of `types`

### DIFF
--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -282,7 +282,7 @@ where
     let start_n = w.n_total_written();
 
     for value in witness.clone() {
-        bit_len += get_bit_len(value);
+        bit_len += value.len();
     }
 
     if bit_len == 0 {
@@ -297,16 +297,6 @@ where
     }
 
     Ok(w.n_total_written() - start_n)
-}
-
-/// Return the bit length of the given `value` when encoded.
-pub fn get_bit_len(value: &Value) -> usize {
-    match value {
-        Value::Unit => 0,
-        Value::SumL(left) => 1 + get_bit_len(left),
-        Value::SumR(right) => 1 + get_bit_len(right),
-        Value::Prod(left, right) => get_bit_len(left) + get_bit_len(right),
-    }
 }
 
 /// Encode a value to bits.

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -350,6 +350,19 @@ pub trait DagLike: Sized {
         }
     }
 
+    /// Number of children that the node has.
+    ///
+    /// This has a default implementation which simply inspects the children, but
+    /// in some cases it may be more efficient for implementors to implement this
+    /// manually.
+    fn n_children(&self) -> usize {
+        match self.as_dag_node() {
+            Dag::Nullary | Dag::Witness => 0,
+            Dag::Unary(..) => 1,
+            Dag::Binary(..) | Dag::Disconnect(..) => 2,
+        }
+    }
+
     /// Obtains an iterator of all the nodes rooted at the DAG, in right-to-left post order.
     ///
     /// An ordinary post-order iterator yields children in the order
@@ -379,6 +392,25 @@ pub trait DagLike: Sized {
     fn pre_order_iter<S: SharingTracker<Self> + Default>(self) -> PreOrderIter<Self, S> {
         PreOrderIter {
             stack: vec![self],
+            tracker: Default::default(),
+        }
+    }
+
+    /// Obtains a verbose iterator of all the nodes rooted at the DAG, in pre-order.
+    ///
+    /// See the documentation of [`VerbosePreOrderIter`] for more information about what
+    /// this does. Essentially, if you find yourself using [`Self::pre_order_iter`] and
+    /// then adding a stack to manually track which items and their children have been
+    /// yielded, you may be better off using this iterator instead.
+    fn verbose_pre_order_iter<S: SharingTracker<Self> + Default>(
+        self,
+    ) -> VerbosePreOrderIter<Self, S>
+    where
+        Self: Clone,
+    {
+        VerbosePreOrderIter {
+            stack: vec![PreOrderIterItem::initial(self, None)],
+            index: 0,
             tracker: Default::default(),
         }
     }
@@ -978,7 +1010,7 @@ impl<D: DagLike, S: SharingTracker<D>> Iterator for PreOrderIter<D, S> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // This algorithm is _significantly_ simpler than the post-order one,
-        // mainly because we don't care about indices.
+        // mainly because we don't care about child indices.
         while let Some(top) = self.stack.pop() {
             // Only yield if this is the first time we have seen this node.
             if self.tracker.record(&top, 0, None, None).is_none() {
@@ -993,5 +1025,129 @@ impl<D: DagLike, S: SharingTracker<D>> Iterator for PreOrderIter<D, S> {
             }
         }
         None
+    }
+}
+
+/// Iterates over a DAG in "verbose pre order", yielding extra state changes.
+///
+/// This yields nodes followed by their children, followed by the node *again*
+/// after each child. This means that each node will be yielded a total of
+/// (n+1) times, where n is its number of children.
+///
+/// The different times that a node is yielded can be distinguished by looking
+/// at the [`PreOrderIterItem::n_children_yielded`]  (which, in particular,
+/// will be 0 on the first yield) and [`PreOrderIterItem::is_complete`] (which
+/// will be true on the last yield) fields of the yielded item.
+///
+/// If you use this iterator with a non-trivial sharing tracker, then any
+/// items which have been initially yielded before will not be initially
+/// yielded again.
+///
+/// If node's *children* have been initially yielded before, they will be
+/// skipped, but the node itself will still be re-yielded as many times
+/// as it has children.
+#[derive(Clone, Debug)]
+pub struct VerbosePreOrderIter<D: DagLike + Clone, S: SharingTracker<D>> {
+    /// A stack of elements to be yielded. As items are yielded, their right
+    /// children are put onto the stack followed by their left, so that the
+    /// appropriate one will be yielded on the next iteration.
+    stack: Vec<PreOrderIterItem<D>>,
+    /// The index of the next item to be yielded.
+    ///
+    /// Note that unlike the [`PostOrderIter`], this value is not monotonic
+    /// and not equivalent to just using `enumerate` on the iterator, because
+    /// elements may be yielded multiple times.
+    index: usize,
+    /// Data which tracks which nodes have been yielded already and therefore
+    /// should be skipped.
+    tracker: S,
+}
+
+impl<D: DagLike + Clone, S: SharingTracker<D>> Iterator for VerbosePreOrderIter<D, S> {
+    type Item = PreOrderIterItem<D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // This algorithm is still simpler than the post-order one, because while
+        // we care about node indices, we don't care about their childrens' indices.
+        while let Some(mut top) = self.stack.pop() {
+            // If this is the *first* time we'd be yielding this element, act
+            // like the non-verbose pre-order iterator.
+            if top.n_children_yielded == 0 {
+                // If we've seen the node before, skip it.
+                if self.tracker.record(&top.node, 0, None, None).is_some() {
+                    continue;
+                }
+                // Set its index.
+                top.index = self.index;
+                self.index += 1;
+            }
+            // Push the next child.
+            match (top.n_children_yielded, top.node.n_children()) {
+                (0, 0) => {}
+                (0, n) => {
+                    self.stack.push(top.clone().increment(n == 1));
+                    let child = top.node.left_child().unwrap();
+                    self.stack
+                        .push(PreOrderIterItem::initial(child, Some(top.node.clone())));
+                }
+                (1, 0) => unreachable!(),
+                (1, 1) => {}
+                (1, _) => {
+                    self.stack.push(top.clone().increment(true));
+                    let child = top.node.right_child().unwrap();
+                    self.stack
+                        .push(PreOrderIterItem::initial(child, Some(top.node.clone())));
+                }
+                (_, _) => {}
+            }
+            // Then yield the element.
+            return Some(top);
+        }
+        None
+    }
+}
+
+/// A set of data yielded by a [`VerbosePreOrderIter`].
+#[derive(Clone, Debug)]
+pub struct PreOrderIterItem<D: DagLike + Clone> {
+    /// The actual element being yielded.
+    pub node: D,
+    /// The parent of this node. `None` for the initial node, but will be
+    /// populated for all other nodes.
+    pub parent: Option<D>,
+    /// The index when the element was first yielded.
+    pub index: usize,
+    /// How many of this item's children have been yielded.
+    ///
+    /// This can also be interpreted as a count of how many times this
+    /// item has been yielded before.
+    pub n_children_yielded: usize,
+    /// Whether this item is done (will not be yielded again).
+    pub is_complete: bool,
+}
+
+impl<D: DagLike + Clone> PreOrderIterItem<D> {
+    /// Creates a `PreOrderIterItem` which yields a given element for the first time.
+    ///
+    /// Marks the index as 0. The index must be manually set before yielding.
+    fn initial(d: D, parent: Option<D>) -> Self {
+        PreOrderIterItem {
+            is_complete: matches!(d.as_dag_node(), Dag::Nullary),
+            node: d,
+            parent,
+            index: 0,
+            n_children_yielded: 0,
+        }
+    }
+
+    /// Creates a `PreOrderIterItem` which yields a given element again.
+    fn increment(self, is_complete: bool) -> Self {
+        PreOrderIterItem {
+            node: self.node,
+            index: self.index,
+            parent: self.parent,
+            n_children_yielded: self.n_children_yielded + 1,
+            is_complete,
+        }
     }
 }

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -292,4 +292,29 @@ mod tests {
             panic!("Expected type check error")
         }
     }
+
+    #[test]
+    fn scribe() {
+        let unit = Arc::<ConstructNode<Core>>::unit();
+        let bit0 = Arc::<ConstructNode<Core>>::injl(&unit);
+        let bit1 = Arc::<ConstructNode<Core>>::injr(&unit);
+        let bits01 = Arc::<ConstructNode<Core>>::pair(&bit0, &bit1).unwrap();
+
+        assert_eq!(
+            unit.cmr(),
+            Arc::<ConstructNode<Core>>::scribe(&Value::Unit).cmr()
+        );
+        assert_eq!(
+            bit0.cmr(),
+            Arc::<ConstructNode<Core>>::scribe(&Value::u1(0)).cmr()
+        );
+        assert_eq!(
+            bit1.cmr(),
+            Arc::<ConstructNode<Core>>::scribe(&Value::u1(1)).cmr()
+        );
+        assert_eq!(
+            bits01.cmr(),
+            Arc::<ConstructNode<Core>>::scribe(&Value::u2(1)).cmr()
+        );
+    }
 }

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -233,15 +233,16 @@ impl Arrow {
         let target = Type::free(String::new());
         if let Some(lchild_arrow) = lchild_arrow {
             lchild_arrow.source.bind(
-                Bound::Product(a, c.shallow_clone()),
+                Arc::new(Bound::Product(a, c.shallow_clone())),
                 "case combinator: left source = A × C",
             )?;
             target.unify(&lchild_arrow.target, "").unwrap();
         }
         if let Some(rchild_arrow) = rchild_arrow {
-            rchild_arrow
-                .source
-                .bind(Bound::Product(b, c), "case combinator: left source = B × C")?;
+            rchild_arrow.source.bind(
+                Arc::new(Bound::Product(b, c)),
+                "case combinator: left source = B × C",
+            )?;
             target.unify(
                 &rchild_arrow.target,
                 "case combinator: left target = right target",
@@ -265,12 +266,14 @@ impl Arrow {
         let prod_b_c = Bound::Product(b.shallow_clone(), c);
         let prod_b_d = Type::product(b, d);
 
-        lchild_arrow
-            .source
-            .bind(prod_256_a, "disconnect combinator: left source = 2^256 × A")?;
-        lchild_arrow
-            .target
-            .bind(prod_b_c, "disconnect combinator: left target = B × C")?;
+        lchild_arrow.source.bind(
+            Arc::new(prod_256_a),
+            "disconnect combinator: left source = 2^256 × A",
+        )?;
+        lchild_arrow.target.bind(
+            Arc::new(prod_b_c),
+            "disconnect combinator: left target = B × C",
+        )?;
 
         Ok(Arrow {
             source: a,

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -234,17 +234,14 @@ impl Arrow {
         if let Some(lchild_arrow) = lchild_arrow {
             lchild_arrow.source.bind(
                 Bound::Product(a, c.shallow_clone()),
-                &None,
                 "case combinator: left source = A × C",
             )?;
             target.unify(&lchild_arrow.target, "").unwrap();
         }
         if let Some(rchild_arrow) = rchild_arrow {
-            rchild_arrow.source.bind(
-                Bound::Product(b, c),
-                &None,
-                "case combinator: left source = B × C",
-            )?;
+            rchild_arrow
+                .source
+                .bind(Bound::Product(b, c), "case combinator: left source = B × C")?;
             target.unify(
                 &rchild_arrow.target,
                 "case combinator: left target = right target",
@@ -268,16 +265,12 @@ impl Arrow {
         let prod_b_c = Bound::Product(b.shallow_clone(), c);
         let prod_b_d = Type::product(b, d);
 
-        lchild_arrow.source.bind(
-            prod_256_a,
-            &None,
-            "disconnect combinator: left source = 2^256 × A",
-        )?;
-        lchild_arrow.target.bind(
-            prod_b_c,
-            &None,
-            "disconnect combinator: left target = B × C",
-        )?;
+        lchild_arrow
+            .source
+            .bind(prod_256_a, "disconnect combinator: left source = 2^256 × A")?;
+        lchild_arrow
+            .target
+            .bind(prod_b_c, "disconnect combinator: left target = B × C")?;
 
         Ok(Arrow {
             source: a,

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -1,0 +1,147 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Finalized (Complete) Type Data
+//!
+//! Once a type is complete (has no free variables), it can be represented as
+//! a much simpler data structure than [`super::Type`], which we call [`Final`].
+//! This contains a recursively-defined [`CompleteBound`] which specifies what
+//! the type is, as well as a cached Merkle root (the TMR) and bit-width.
+//!
+//! We refer to types as "finalized" when they are represented by this data
+//! structure, since this structure is immutable.
+//!
+
+use crate::Tmr;
+
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::{cmp, fmt};
+
+/// A finalized type bound, whose tree is accessible without any mutex locking
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum CompleteBound {
+    /// The unit type
+    Unit,
+    /// A sum of two other types
+    Sum(Arc<Final>, Arc<Final>),
+    /// A product of two other types
+    Product(Arc<Final>, Arc<Final>),
+}
+
+/// Data related to a finalized type, which can be extracted from a [`super::Type`]
+/// if (and only if) it is finalized.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct Final {
+    /// Underlying type
+    bound: CompleteBound,
+    /// Width of the type, in bits, in the bit machine
+    bit_width: usize,
+    /// TMR of the type
+    tmr: Tmr,
+    /// Cached string representation of the type
+    display: Cow<'static, str>,
+}
+
+impl Final {
+    /// (Non-public) constructor for the final data of the unit type
+    pub(super) const fn unit() -> Self {
+        Final {
+            bound: CompleteBound::Unit,
+            bit_width: 0,
+            tmr: Tmr::unit(),
+            display: Cow::Borrowed("1"),
+        }
+    }
+
+    /// Return a precomputed copy of 2^(2^n), for given n.
+    pub fn two_two_n(n: usize) -> Arc<Self> {
+        super::precomputed::nth_power_of_2(n).final_data().unwrap()
+    }
+
+    /// (Non-public) constructor for the final data of a sum type
+    pub(super) fn sum(left: Arc<Self>, right: Arc<Self>) -> Self {
+        Final {
+            tmr: Tmr::sum(left.tmr, right.tmr),
+            bit_width: 1 + cmp::max(left.bit_width, right.bit_width),
+            display: if left.bound == CompleteBound::Unit && right.bound == CompleteBound::Unit {
+                "2".into()
+            } else {
+                format!("({} + {})", left.display, right.display).into()
+            },
+            bound: CompleteBound::Sum(left, right),
+        }
+    }
+
+    /// (Non-public) constructor for the final data of a product type
+    pub(super) fn product(left: Arc<Self>, right: Arc<Self>) -> Self {
+        Final {
+            tmr: Tmr::product(left.tmr, right.tmr),
+            bit_width: left.bit_width + right.bit_width,
+            display: if left.display == right.display {
+                match left.display.as_ref() {
+                    "2" => "2^2".into(),
+                    "2^2" => "2^4".into(),
+                    "2^4" => "2^8".into(),
+                    "2^8" => "2^16".into(),
+                    "2^16" => "2^32".into(),
+                    "2^32" => "2^64".into(),
+                    "2^64" => "2^128".into(),
+                    "2^128" => "2^256".into(),
+                    "2^256" => "2^512".into(),
+                    _ => format!("({} × {})", left.display, right.display).into(),
+                }
+            } else {
+                format!("({} × {})", left.display, right.display).into()
+            },
+            bound: CompleteBound::Product(left, right),
+        }
+    }
+
+    /// Accessor for the TMR
+    pub fn tmr(&self) -> Tmr {
+        self.tmr
+    }
+
+    /// Accessor for the Bit Machine bit-width of the type
+    pub fn bit_width(&self) -> usize {
+        self.bit_width
+    }
+
+    /// Accessor for the type bound
+    pub fn bound(&self) -> &CompleteBound {
+        &self.bound
+    }
+
+    /// Returns whether this is the unit type
+    pub fn is_unit(&self) -> bool {
+        self.bound == CompleteBound::Unit
+    }
+
+    /// Accessor for both children of the type, if they exist.
+    pub fn split(&self) -> Option<(Arc<Self>, Arc<Self>)> {
+        match &self.bound {
+            CompleteBound::Unit => None,
+            CompleteBound::Sum(left, right) | CompleteBound::Product(left, right) => {
+                Some((Arc::clone(left), Arc::clone(right)))
+            }
+        }
+    }
+}
+
+impl fmt::Display for Final {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.display, f)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -358,10 +358,12 @@ impl DagLike for Arc<Bound> {
     }
 }
 
-/// Source or target type of a Simplicity expression
+/// Source or target type of a Simplicity expression.
 ///
-/// This is just a mutex holding the actual data, which defined by the
-/// `TypeInner` type.
+/// Internally this type is essentially just a refcounted pointer; it is
+/// therefore quite cheap to clone, but be aware that cloning will not
+/// actually create a new independent type, just a second pointer to the
+/// first one.
 #[derive(Clone, Debug)]
 pub struct Type {
     /// A set of constraints, which maintained by the union-bound algorithm and

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -475,3 +475,28 @@ impl From<Bound> for Type {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::jet::Core;
+    use crate::node::{ConstructNode, CoreConstructible};
+
+    #[test]
+    fn inference_failure() {
+        // unit: A -> 1
+        let unit = Arc::<ConstructNode<Core>>::unit(); // 1 -> 1
+
+        // Force unit to be 1->1
+        Arc::<ConstructNode<Core>>::comp(&unit, &unit).unwrap();
+
+        // take unit: 1 * B -> 1
+        let take_unit = Arc::<ConstructNode<Core>>::take(&unit); // 1*1 -> 1
+
+        // Pair will try to unify 1 and 1*B
+        Arc::<ConstructNode<Core>>::pair(&unit, &take_unit).unwrap_err();
+        // Trying to do it again should not work.
+        Arc::<ConstructNode<Core>>::pair(&unit, &take_unit).unwrap_err();
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -82,14 +82,17 @@
 //!     or a sum or product of other types.
 //!
 
+use self::union_bound::UbElement;
 use crate::Tmr;
 
-use std::sync::{Arc, Mutex, MutexGuard};
-use std::{cmp, fmt, mem, ops};
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 pub mod arrow;
 mod final_data;
 mod precomputed;
+mod union_bound;
 mod variable;
 
 pub use final_data::{CompleteBound, Final};
@@ -111,7 +114,7 @@ pub enum Error {
         hint: &'static str,
     },
     /// A type is recursive (i.e., occurs within itself), violating the "occurs check"
-    OccursCheck { incomplete_type: Type },
+    OccursCheck { incomplete_bound: Arc<Bound> },
 }
 
 impl fmt::Display for Error {
@@ -140,12 +143,12 @@ impl fmt::Display for Error {
                 )
             }
             Error::OccursCheck {
-                ref incomplete_type,
+                ref incomplete_bound,
             } => {
                 write!(
                     f,
-                    "occurs check failed (incomplete type: {})",
-                    incomplete_type,
+                    "occurs check failed (incomplete bound: {})",
+                    incomplete_bound,
                 )
             }
         }
@@ -160,98 +163,121 @@ impl std::error::Error for Error {}
 /// `TypeInner` type.
 #[derive(Clone, Debug)]
 pub struct Type {
-    /// A mutex around the actual type data
-    inner: Arc<Mutex<TypeInner>>,
+    /// A set of constraints, which maintained by the union-bound algorithm and
+    /// is progressively tightened as type inference proceeds.
+    bound: UbElement<bound_mutex::BoundMutex>,
+    /// Used during finalization to detect infinitely-sized types.
+    occurs_check: Arc<AtomicBool>,
 }
 
-/// Source or target type of a Simplicity expression
-#[derive(Clone, Debug)]
-struct TypeInner {
-    /// The type's status according to the union-bound algorithm.
-    constraint: Constraint,
-    /// Used during finalization; whether this type has been seen before while
-    /// traversing the type tree. If it has, it means we have a type containing
-    /// itself, which is illegal. This is referred to as the "occurs check".
-    occurs_check: bool,
-    /// The rank of the type which provides an ordering within disjoint sets
-    /// during the union-bound type inference algorithm.
-    rank: usize,
-}
+mod bound_mutex {
+    use super::{Bound, CompleteBound, Error, Final};
+    use std::sync::{Arc, Mutex};
 
-impl TypeInner {
-    fn final_data(&self) -> Option<&Arc<Final>> {
-        if let Constraint::Bound {
-            bound: Bound::Complete(ref final_data),
-        } = self.constraint
-        {
-            Some(final_data)
-        } else {
-            None
+    /// Source or target type of a Simplicity expression
+    #[derive(Debug)]
+    pub struct BoundMutex {
+        /// The type's status according to the union-bound algorithm.
+        inner: Mutex<Arc<Bound>>,
+    }
+
+    impl BoundMutex {
+        pub fn new(bound: Bound) -> Self {
+            BoundMutex {
+                inner: Mutex::new(Arc::new(bound)),
+            }
+        }
+
+        pub fn get(&self) -> Arc<Bound> {
+            Arc::clone(&self.inner.lock().unwrap())
+        }
+
+        pub fn set(&self, new: Arc<Bound>) {
+            let mut lock = self.inner.lock().unwrap();
+            assert!(
+                !matches!(**lock, Bound::Complete(..)),
+                "tried to modify finalized type",
+            );
+            *lock = new;
+        }
+
+        pub fn bind(&self, bound: Arc<Bound>, hint: &'static str) -> Result<(), Error> {
+            let existing_bound = self.get();
+            let bind_error = || Error::Bind {
+                existing_bound: existing_bound.shallow_clone(),
+                new_bound: bound.shallow_clone(),
+                hint,
+            };
+
+            match (existing_bound.as_ref(), bound.as_ref()) {
+                // Binding a free type to anything is a no-op
+                (_, Bound::Free(_)) => Ok(()),
+                // Free types are simply dropped and replaced by the new bound
+                (Bound::Free(_), _) => {
+                    // Free means non-finalized, so set() is ok.
+                    self.set(bound);
+                    Ok(())
+                }
+                // Binding complete->complete shouldn't ever happen, but if so, we just
+                // compare the two types and return a pass/fail
+                (Bound::Complete(ref existing_final), Bound::Complete(ref new_final)) => {
+                    if existing_final == new_final {
+                        Ok(())
+                    } else {
+                        Err(bind_error())
+                    }
+                }
+                // Binding an incomplete to a complete type requires recursion.
+                (Bound::Complete(complete), incomplete)
+                | (incomplete, Bound::Complete(complete)) => {
+                    match (complete.bound(), incomplete) {
+                        // A unit might match a Bound::Free(..) or a Bound::Complete(..),
+                        // and both cases were handled above. So this is an error.
+                        (CompleteBound::Unit, _) => Err(bind_error()),
+                        (
+                            CompleteBound::Product(ref comp1, ref comp2),
+                            Bound::Product(ref ty1, ref ty2),
+                        )
+                        | (
+                            CompleteBound::Sum(ref comp1, ref comp2),
+                            Bound::Sum(ref ty1, ref ty2),
+                        ) => {
+                            ty1.bind(Arc::new(Bound::Complete(Arc::clone(comp1))), hint)?;
+                            ty2.bind(Arc::new(Bound::Complete(Arc::clone(comp2))), hint)
+                        }
+                        _ => Err(bind_error()),
+                    }
+                }
+                (Bound::Sum(ref x1, ref x2), Bound::Sum(ref y1, ref y2))
+                | (Bound::Product(ref x1, ref x2), Bound::Product(ref y1, ref y2)) => {
+                    x1.unify(y1, hint)?;
+                    x2.unify(y2, hint)?;
+                    // This type was not complete, but it may be after unification, giving us
+                    // an opportunity to finaliize it. We do this eagerly to make sure that
+                    // "complete" (no free children) is always equivalent to "finalized" (the
+                    // bound field having variant Bound::Complete(..)), even during inference.
+                    //
+                    // It also gives the user access to more information about the type,
+                    // prior to finalization.
+                    if let (Some(data1), Some(data2)) = (y1.final_data(), y2.final_data()) {
+                        self.set(Arc::new(Bound::Complete(Arc::new(
+                            if let Bound::Sum(..) = *bound {
+                                Final::sum(data1, data2)
+                            } else {
+                                Final::product(data1, data2)
+                            },
+                        ))));
+                    }
+                    Ok(())
+                }
+                (x, y) => Err(Error::Bind {
+                    existing_bound: x.shallow_clone(),
+                    new_bound: y.shallow_clone(),
+                    hint,
+                }),
+            }
         }
     }
-}
-
-/// Internal structure used to add mutability controls to the mutex guarding the
-/// internal data of a `Type`.
-///
-/// An invariant this module maintains is that once a `Type` is final, it will
-/// never change again. (We need this to make sure that our precomputed 2^n
-/// types don't get modified in the course of type inference.) To do so, we
-/// only lock the inner mutex using the `inner_lock()` method on `Type`, which
-/// provides read-only access. IT IS A BUG TO DIRECTLY LOCK THE MUTEX.
-///
-/// If we need to mutate the data, we then call `into_mutable` or `as_mutable`
-/// on the returned `ReadOnlyMutexGuard`. Every such call should have a comment
-/// justifying why the type in question is not final at the point of the call.
-struct ReadOnlyMutexGuard<'g> {
-    inner: MutexGuard<'g, TypeInner>,
-}
-
-impl<'g> ReadOnlyMutexGuard<'g> {
-    /// Enable mutable access to the `TypeInner`.
-    ///
-    /// # Panics
-    /// Will panic if it is called on a finalized typpe.
-    fn into_mutable(self) -> MutexGuard<'g, TypeInner> {
-        debug_assert!(
-            self.inner.final_data().is_none(),
-            "tried to get mutable access to a finalized type",
-        );
-        self.inner
-    }
-
-    /// Same as `into_mutable` but does not consume the original guard
-    ///
-    /// # Panics
-    /// Will panic if it is called on a finalized typpe.
-    fn as_mutable(&mut self) -> &mut MutexGuard<'g, TypeInner> {
-        debug_assert!(
-            self.inner.final_data().is_none(),
-            "tried to get mutable access to a finalized type",
-        );
-        &mut self.inner
-    }
-}
-
-impl<'g> ops::Deref for ReadOnlyMutexGuard<'g> {
-    type Target = TypeInner;
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-/// Whether a `Type` is free, bound to some `Bound`, or equal to another `Type`
-#[derive(Clone, Debug)]
-enum Constraint {
-    /// Type bound to a particular `Bound`. If the type is complete, this bound
-    /// fully specifies the type.
-    Bound {
-        /// The bound
-        bound: Bound,
-    },
-    /// Type is equal to another type, which is referred to as the "parent" of
-    /// the type.
-    EqualTo { parent: Type },
 }
 
 /// The state of a [`Type`] based on all constraints currently imposed on it.
@@ -267,36 +293,48 @@ pub enum Bound {
     Product(Type, Type),
 }
 
-impl Constraint {
+impl Bound {
+    /// Clones the `Bound`.
+    ///
+    /// This is the same as just calling `.clone()` but has a different name to
+    /// emphasize that what's being cloned is (at most) a pair of ref-counted
+    /// pointers.
+    pub fn shallow_clone(&self) -> Bound {
+        self.clone()
+    }
+
     fn free(name: String) -> Self {
-        Constraint::Bound {
-            bound: Bound::Free(name),
-        }
+        Bound::Free(name)
     }
 
     fn unit() -> Self {
-        Constraint::Bound {
-            bound: Bound::Complete(Arc::new(Final::unit())),
-        }
+        Bound::Complete(Arc::new(Final::unit()))
     }
 
     fn sum(a: Type, b: Type) -> Self {
-        Constraint::Bound {
-            bound: if let (Some(adata), Some(bdata)) = (a.final_data(), b.final_data()) {
-                Bound::Complete(Arc::new(Final::sum(adata, bdata)))
-            } else {
-                Bound::Sum(a, b)
-            },
+        if let (Some(adata), Some(bdata)) = (a.final_data(), b.final_data()) {
+            Bound::Complete(Arc::new(Final::sum(adata, bdata)))
+        } else {
+            Bound::Sum(a, b)
         }
     }
 
     fn product(a: Type, b: Type) -> Self {
-        Constraint::Bound {
-            bound: if let (Some(adata), Some(bdata)) = (a.final_data(), b.final_data()) {
-                Bound::Complete(Arc::new(Final::product(adata, bdata)))
-            } else {
-                Bound::Product(a, b)
-            },
+        if let (Some(adata), Some(bdata)) = (a.final_data(), b.final_data()) {
+            Bound::Complete(Arc::new(Final::product(adata, bdata)))
+        } else {
+            Bound::Product(a, b)
+        }
+    }
+}
+
+impl fmt::Display for Bound {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Bound::Free(ref name) => f.write_str(name),
+            Bound::Complete(ref data) => fmt::Display::fmt(data, f),
+            Bound::Sum(ref a, ref b) => write!(f, "({} + {})", a, b),
+            Bound::Product(ref a, ref b) => write!(f, "({} × {})", a, b),
         }
     }
 }
@@ -304,12 +342,12 @@ impl Constraint {
 impl Type {
     /// Return an unbound type with the given name
     pub fn free(name: String) -> Self {
-        Type::from(Constraint::free(name))
+        Type::from(Bound::free(name))
     }
 
     /// Return a unit type.
     pub fn unit() -> Self {
-        Type::from(Constraint::unit())
+        Type::from(Bound::unit())
     }
 
     /// Return a precomputed copy of 2^(2^n), for given n.
@@ -319,19 +357,12 @@ impl Type {
 
     /// Return the sum of the given two types.
     pub fn sum(a: Self, b: Self) -> Self {
-        Type::from(Constraint::sum(a, b))
+        Type::from(Bound::sum(a, b))
     }
 
     /// Return the product of the given two types.
     pub fn product(a: Self, b: Self) -> Self {
-        Type::from(Constraint::product(a, b))
-    }
-
-    /// Read-only pointer to data (used internally to make mutability easier to analyse)
-    fn inner_lock(&self) -> ReadOnlyMutexGuard {
-        ReadOnlyMutexGuard {
-            inner: self.inner.lock().unwrap(),
-        }
+        Type::from(Bound::product(a, b))
     }
 
     /// Clones the `Type`.
@@ -342,241 +373,41 @@ impl Type {
         self.clone()
     }
 
-    /// Find the representative of this type in its disjoint set.
-    ///
-    /// Used by the union-bound algorithm.
-    fn find_root(&self) -> Self {
-        let mut x = self.shallow_clone();
-        loop {
-            let x_lock = x.inner_lock();
-            // Find the parent of the current target, if there is one. If not, we
-            // are done, so return.
-            let parent = match x_lock.constraint {
-                Constraint::EqualTo { ref parent } => parent.shallow_clone(),
-                _ => {
-                    drop(x_lock);
-                    return x;
-                }
-            };
-            // If the parent has a parent, remove the intermediate link. (This is
-            // the "halving" variant of union-bound.)
-            let parent_lock = parent.inner_lock();
-            if let Constraint::EqualTo {
-                parent: ref grandparent,
-            } = parent_lock.constraint
-            {
-                let mut x_lock = x_lock.into_mutable(); // ok since x is `EqualTo` but only `Bound` constraints are finalized
-                x_lock.constraint = Constraint::EqualTo {
-                    parent: grandparent.shallow_clone(),
-                };
-                drop(x_lock); // needed for borrowck to give us access to `x`
-                x = grandparent.shallow_clone();
-            } else {
-                // If there is no grandparent, return the parent.
-                drop(parent_lock); // needed for borrowck to give us access to `parent`
-                return parent;
-            }
-        }
-    }
-
     /// Binds the type to a given bound. If this fails, attach the provided
     /// hint to the error.
     ///
     /// Fails if the type has an existing incompatible bound.
-    pub fn bind(&self, bound: Bound, hint: &'static str) -> Result<(), Error> {
-        let root = self.find_root();
-        let lock = root.inner_lock();
-        match lock.constraint {
-            // Types with bounds are more interesting: we have to recursively unify
-            // the existing bound with the new one.
-            Constraint::Bound {
-                bound: ref existing_bound,
-            } => {
-                let bind_error = || Error::Bind {
-                    existing_bound: existing_bound.shallow_clone(),
-                    new_bound: bound.shallow_clone(),
-                    hint,
-                };
-
-                match (&existing_bound, &bound) {
-                    // Binding a free type to anything is a no-op
-                    (_, Bound::Free(_)) => Ok(()),
-                    // Free types are simply dropped and replaced by the new bound
-                    (Bound::Free(_), _) => {
-                        let mut lock = lock.into_mutable(); // free means non-finalized
-                        lock.constraint = Constraint::Bound { bound };
-                        Ok(())
-                    }
-                    // Binding complete->complete shouldn't ever happen, but if so, we just
-                    // compare the two types and return a pass/fail
-                    (Bound::Complete(ref existing_final), Bound::Complete(ref new_final)) => {
-                        if existing_final == new_final {
-                            Ok(())
-                        } else {
-                            Err(bind_error())
-                        }
-                    }
-                    // Binding an incomplete to a complete type requires recursion.
-                    (Bound::Complete(ref complete), incomplete)
-                    | (&incomplete, Bound::Complete(ref complete)) => {
-                        match (complete.bound(), incomplete) {
-                            // A unit might match a Bound::Free(..) or a Bound::Complete(..),
-                            // and both cases were handled above. So this is an error.
-                            (CompleteBound::Unit, _) => Err(bind_error()),
-                            (
-                                CompleteBound::Product(ref comp1, ref comp2),
-                                Bound::Product(ref ty1, ref ty2),
-                            )
-                            | (
-                                CompleteBound::Sum(ref comp1, ref comp2),
-                                Bound::Sum(ref ty1, ref ty2),
-                            ) => {
-                                ty1.bind(Bound::Complete(Arc::clone(comp1)), hint)?;
-                                ty2.bind(Bound::Complete(Arc::clone(comp2)), hint)
-                            }
-                            _ => Err(bind_error()),
-                        }
-                    }
-                    (Bound::Sum(ref x1, ref x2), Bound::Sum(ref y1, ref y2))
-                    | (Bound::Product(ref x1, ref x2), Bound::Product(ref y1, ref y2)) => {
-                        // Before recursing we need to drop the lock, and before
-                        // that we need to clone some types from inside it.
-                        let x1 = x1.shallow_clone();
-                        let x2 = x2.shallow_clone();
-                        drop(lock); // drop lock before recursing
-                        x1.unify(y1, hint)?;
-                        x2.unify(y2, hint)?;
-                        // This type was not complete, but it may be after unification, giving us
-                        // an opportunity to finaliize it. We do this eagerly to make sure that
-                        // "complete" (no free children) is always equivalent to "finalized" (the
-                        // bound field having variant Bound::Complete(..)), even during inference.
-                        //
-                        // It also gives the user access to more information about the type,
-                        // prior to finalization.
-                        if let (Some(data1), Some(data2)) = (y1.final_data(), y2.final_data()) {
-                            let mut lock = root.inner_lock().into_mutable(); // ok, we are in a `if is_not_finalized` block
-                            lock.constraint = Constraint::Bound {
-                                bound: Bound::Complete(Arc::new(if let Bound::Sum(..) = bound {
-                                    Final::sum(data1, data2)
-                                } else {
-                                    Final::product(data1, data2)
-                                })),
-                            };
-                        }
-                        Ok(())
-                    }
-                    (x, y) => Err(Error::Bind {
-                        existing_bound: x.shallow_clone(),
-                        new_bound: y.shallow_clone(),
-                        hint,
-                    }),
-                }
-            }
-            // Our call to `find_root` above makes this case impossible
-            Constraint::EqualTo { .. } => unreachable!("lock is a root node"),
-        }
+    pub fn bind(&self, bound: Arc<Bound>, hint: &'static str) -> Result<(), Error> {
+        let root = self.bound.root();
+        root.bind(bound, hint)
     }
 
     /// Unify the type with another one.
     ///
     /// Fails if the bounds on the two types are incompatible
     pub fn unify(&self, other: &Self, hint: &'static str) -> Result<(), Error> {
-        let x_root = self.find_root();
-        let y_root = other.find_root();
-        // Already in same set
-        if Arc::ptr_eq(&x_root.inner, &y_root.inner) {
-            return Ok(());
-        }
-
-        let mut x_lock = x_root.inner_lock();
-        let mut y_lock = y_root.inner_lock();
-        // We need to swap x_root and y_root below, and the only way to make the
-        // borrowck okay with that is to replace both types by references
-        // to themselves.
-        let mut x_root = &x_root;
-        let mut y_root = &y_root;
-        // Deterine which of x or y should be the parent. This means the finalized
-        // one, if only one is finalized, or the higher-ranked one, if neither is.
-        match (&x_lock.final_data(), &y_lock.final_data()) {
-            // If both are finalized, unification just means checking that
-            // they're equal.
-            (Some(xdata), Some(ydata)) => {
-                if xdata.tmr() == ydata.tmr() {
-                    return Ok(());
-                } else {
-                    return Err(Error::CompleteTypeMismatch {
-                        type1: Arc::clone(xdata),
-                        type2: Arc::clone(ydata),
-                        hint,
-                    });
-                }
-            }
-            // If one is finalized but not the other, that one is the parent
-            (Some(_), None) => {} // x is the parent
-            (None, Some(_)) => {
-                mem::swap(&mut x_lock, &mut y_lock);
-                mem::swap(&mut x_root, &mut y_root);
-            }
-            // If neither is finalized, then we use the normal union-bound rank
-            // comparison: we ensure that x's rank is strictly greater than y's
-            // rank. If they are equal, simply increment x's rank.
-            (None, None) => {
-                let rank_ord = x_lock.rank.cmp(&y_lock.rank);
-                let mut x_lock = x_lock.as_mutable(); // ok since we checked that x is not final
-                let mut y_lock = y_lock.as_mutable(); // ok since we checked that y is not final
-                match rank_ord {
-                    cmp::Ordering::Less => mem::swap(&mut x_lock, &mut y_lock),
-                    cmp::Ordering::Equal => x_lock.rank += 1,
-                    _ => {}
-                }
-            }
-        }
-
-        // At this point we know that y is not final (if both it and x were final,
-        // we did an early return; if it was final but x was not, we swapped them
-        // so that the opposite is true). So we can mutate y.
-        let mut y_lock = y_lock.into_mutable(); // ok by above swap logic
-
-        // Make x the parent of y
-        let old_y_constraint = mem::replace(
-            &mut y_lock.constraint,
-            Constraint::EqualTo {
-                parent: x_root.shallow_clone(),
-            },
-        );
-        // Drop mutexes before recursing.
-        drop(x_lock);
-        drop(y_lock);
-        match old_y_constraint {
-            // If y was already bound to a type, then x must be bound, too
-            Constraint::Bound { bound: y_bound } => x_root.bind(y_bound, hint),
-            Constraint::EqualTo { .. } => unreachable!("y_lock is a root node"),
-        }
+        self.bound.unify(&other.bound, |x_bound, y_bound| {
+            x_bound.bind(y_bound.get(), hint)
+        })
     }
 
     /// Accessor for this type's bound
-    pub fn bound(&self) -> Bound {
-        let root = self.find_root();
-        let root_lock = root.inner_lock();
-        if let Constraint::Bound { ref bound, .. } = root_lock.constraint {
-            bound.shallow_clone()
-        } else {
-            panic!("Bound is the only variant for Constraint now")
-        }
+    pub fn bound(&self) -> Arc<Bound> {
+        self.bound.root().get()
     }
 
     /// Accessor for the TMR of this type, if it is final
     pub fn tmr(&self) -> Option<Tmr> {
-        let root = self.find_root(); // Final data is only actually set on root nodes
-        let root_lock = root.inner_lock();
-        root_lock.final_data().map(|data| data.tmr())
+        self.final_data().map(|data| data.tmr())
     }
 
     /// Accessor for the data of this type, if it is complete
     pub fn final_data(&self) -> Option<Arc<Final>> {
-        let root = self.find_root(); // Final data is only actually set on root nodes
-        let root_lock = root.inner_lock();
-        root_lock.final_data().map(Arc::clone)
+        if let Bound::Complete(ref data) = *self.bound.root().get() {
+            Some(Arc::clone(data))
+        } else {
+            None
+        }
     }
 
     /// Whether this type is known to be final
@@ -585,71 +416,44 @@ impl Type {
     /// complete, since its children may have been unified to a complete type. To
     /// ensure a type is complete, call [`Type::finalize`].
     pub fn is_final(&self) -> bool {
-        self.final_data().is_some()
-    }
-
-    /// If a type is finalized, return its final type. Otherwise panic.
-    pub fn expect_finalized(&self) -> Arc<Final> {
-        self.final_data().unwrap()
+        matches!(*self.bound.root().get(), Bound::Complete(..))
     }
 
     /// Attempts to finalize the type. Returns its TMR on success.
     pub fn finalize(&self) -> Result<Arc<Final>, Error> {
-        let root = self.find_root();
-        if let Some(data) = root.final_data() {
-            return Ok(data);
+        let root = self.bound.root();
+        let bound = root.get();
+        if let Bound::Complete(ref data) = *bound {
+            return Ok(Arc::clone(data));
         }
 
-        // Because we checked above that the type was not finalized, we know
-        // at this point that it is not, so we are free to use `.into_mutable()`
-        // to edit it.
-        let mut root_lock = root.inner_lock().into_mutable();
-        if root_lock.occurs_check {
+        // FIXME there is a race condition (which actually predates this version
+        // of the logic) in case the same type is being finalized from multiple
+        // threads at once.
+        if self.occurs_check.fetch_or(true, Ordering::SeqCst) {
             return Err(Error::OccursCheck {
-                incomplete_type: root.shallow_clone(),
+                incomplete_bound: bound,
             });
         }
-        root_lock.occurs_check = true;
-        let data = match root_lock.constraint {
-            Constraint::Bound { ref bound, .. } => {
-                match bound {
-                    Bound::Free(_) => Arc::new(Final::unit()),
-                    Bound::Complete(ref arc) => Arc::clone(arc),
-                    Bound::Sum(ref ty1, ref ty2) => {
-                        // Drop the lock before recursing
-                        let ty1 = ty1.clone();
-                        let ty2 = ty2.clone();
-                        drop(root_lock);
-                        let data1 = ty1.finalize()?;
-                        let data2 = ty2.finalize()?;
-                        // Then re-lock to update own final data
-                        root_lock = root.inner_lock().into_mutable();
-                        Arc::new(Final::sum(data1, data2))
-                    }
-                    Bound::Product(ref ty1, ref ty2) => {
-                        // Drop the lock before recursing
-                        let ty1 = ty1.clone();
-                        let ty2 = ty2.clone();
-                        drop(root_lock);
-                        let data1 = ty1.finalize()?;
-                        let data2 = ty2.finalize()?;
-                        // Then re-lock to update own final data
-                        root_lock = root.inner_lock().into_mutable();
-                        Arc::new(Final::product(data1, data2))
-                    }
-                }
-            }
-            Constraint::EqualTo { .. } => unreachable!("lock is a root node"),
-        };
 
-        // After the above code, we definitely have a `Constraint::Bound` with
-        // a populated `final_data` field.
-        if let Constraint::Bound { ref mut bound, .. } = root_lock.constraint {
-            *bound = Bound::Complete(Arc::clone(&data));
-            Ok(data)
-        } else {
-            unreachable!("we just set the constraint to Bound and now it's not Bound")
-        }
+        let data = match *bound {
+            Bound::Free(_) => Arc::new(Final::unit()),
+            Bound::Complete(ref arc) => Arc::clone(arc),
+            Bound::Sum(ref ty1, ref ty2) => {
+                let data1 = ty1.finalize()?;
+                let data2 = ty2.finalize()?;
+                Arc::new(Final::sum(data1, data2))
+            }
+            Bound::Product(ref ty1, ref ty2) => {
+                let data1 = ty1.finalize()?;
+                let data2 = ty2.finalize()?;
+                Arc::new(Final::product(data1, data2))
+            }
+        };
+        // We checked at the start of the function that this type was not final,
+        // so set() is okay here.
+        root.set(Arc::new(Bound::Complete(Arc::clone(&data))));
+        Ok(data)
     }
 
     /// Return a vector containing the types 2^(2^i) for i from 0 to n-1.
@@ -668,46 +472,16 @@ impl Type {
 
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let root = self.find_root();
-        let lock = root.inner_lock();
-        match lock.constraint {
-            Constraint::Bound { ref bound } => fmt::Display::fmt(bound, f),
-            Constraint::EqualTo { ref parent } => fmt::Display::fmt(parent, f),
-        }
+        fmt::Display::fmt(&self.bound.root().get(), f)
     }
 }
 
-impl Bound {
-    /// Clones the `Bound`.
-    ///
-    /// This is the same as just calling `.clone()` but has a different name to
-    /// emphasize that what's being cloned is (at most) a pair of ref-counted
-    /// pointers.
-    pub fn shallow_clone(&self) -> Bound {
-        self.clone()
-    }
-}
-
-impl fmt::Display for Bound {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Bound::Free(ref name) => f.write_str(name),
-            Bound::Complete(ref data) => fmt::Display::fmt(data, f),
-            Bound::Sum(ref a, ref b) => write!(f, "({} + {})", a, b),
-            Bound::Product(ref a, ref b) => write!(f, "({} × {})", a, b),
-        }
-    }
-}
-
-impl From<Constraint> for Type {
-    /// Promotes a `Constraint` to a type defined by that constraint
-    fn from(constraint: Constraint) -> Type {
+impl From<Bound> for Type {
+    /// Promotes a `Bound` to a type defined by that constraint
+    fn from(bound: Bound) -> Type {
         Type {
-            inner: Arc::new(Mutex::new(TypeInner {
-                rank: 0,
-                occurs_check: false,
-                constraint,
-            })),
+            bound: UbElement::new(Arc::new(bound_mutex::BoundMutex::new(bound))),
+            occurs_check: Arc::new(AtomicBool::new(false)),
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -18,6 +18,8 @@
 //! Simplicity processes data in terms of [`Value`]s,
 //! i.e., inputs, intermediate results and outputs.
 
+use crate::dag::{Dag, DagLike, NoSharing};
+
 use std::convert::TryInto;
 use std::fmt;
 use std::hash::Hash;
@@ -43,16 +45,29 @@ pub enum Value {
     Prod(Box<Value>, Box<Value>),
 }
 
+impl<'a> DagLike for &'a Value {
+    type Node = Value;
+
+    fn data(&self) -> &Value {
+        self
+    }
+
+    fn as_dag_node(&self) -> Dag<Self> {
+        match self {
+            Value::Unit => Dag::Nullary,
+            Value::SumL(child) | Value::SumR(child) => Dag::Unary(child),
+            Value::Prod(left, right) => Dag::Binary(left, right),
+        }
+    }
+}
+
 impl Value {
     #![allow(clippy::len_without_is_empty)]
     /// The length, in bits, of the value when encoded in the Bit Machine
     pub fn len(&self) -> usize {
-        match *self {
-            Value::Unit => 0,
-            Value::SumL(ref s) => 1 + s.len(),
-            Value::SumR(ref s) => 1 + s.len(),
-            Value::Prod(ref s, ref t) => s.len() + t.len(),
-        }
+        self.pre_order_iter::<NoSharing>()
+            .filter(|inner| matches!(inner, Value::SumL(_) | Value::SumR(_)))
+            .count()
     }
 
     /// Encode a single bit as a value. Will panic if the input is out of range
@@ -152,23 +167,12 @@ impl Value {
     where
         F: FnMut(bool),
     {
-        let mut value_stack = vec![self];
-
-        while let Some(value) = value_stack.pop() {
-            match value {
+        for val in self.pre_order_iter::<NoSharing>() {
+            match val {
                 Value::Unit => {}
-                Value::SumL(l) => {
-                    f(false);
-                    value_stack.push(l);
-                }
-                Value::SumR(r) => {
-                    f(true);
-                    value_stack.push(r);
-                }
-                Value::Prod(l, r) => {
-                    value_stack.push(r);
-                    value_stack.push(l);
-                }
+                Value::SumL(..) => f(false),
+                Value::SumR(..) => f(true),
+                Value::Prod(..) => {}
             }
         }
     }
@@ -235,28 +239,58 @@ impl fmt::Debug for Value {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Value::Unit => f.write_str("ε"),
-            Value::SumL(ref sub) => {
-                f.write_str("0")?;
-                if **sub != Value::Unit {
-                    write!(f, "{}", sub)
-                } else {
-                    Ok(())
+        #[derive(PartialEq, Eq)]
+        enum Parent {
+            Sum,
+            ProdL,
+            ProdR,
+        }
+
+        let mut parent_stack = vec![];
+        for val in self.pre_order_iter::<NoSharing>() {
+            match val {
+                Value::Unit => {
+                    if parent_stack.last() != Some(&Parent::Sum) {
+                        f.write_str("ε")?;
+                    }
+                    while let Some(parent) = parent_stack.pop() {
+                        if parent == Parent::ProdL {
+                            f.write_str(",")?;
+                            parent_stack.push(Parent::ProdR);
+                            break;
+                        } else if parent == Parent::ProdR {
+                            f.write_str(")")?;
+                        }
+                    }
                 }
-            }
-            Value::SumR(ref sub) => {
-                f.write_str("1")?;
-                if **sub != Value::Unit {
-                    write!(f, "{}", sub)
-                } else {
-                    Ok(())
+                Value::SumL(..) => {
+                    f.write_str("0")?;
+                    parent_stack.push(Parent::Sum);
                 }
-            }
-            Value::Prod(ref l, ref r) => {
-                write!(f, "({},", l)?;
-                write!(f, "{})", r)
+                Value::SumR(..) => {
+                    f.write_str("1")?;
+                    parent_stack.push(Parent::Sum);
+                }
+                Value::Prod(..) => {
+                    f.write_str("(")?;
+                    parent_stack.push(Parent::ProdL);
+                }
             }
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_display() {
+        // Only test a couple values becasue we probably want to change this
+        // at some point and will have to redo this test.
+        assert_eq!(Value::u1(0).to_string(), "0",);
+        assert_eq!(Value::u1(1).to_string(), "1",);
+        assert_eq!(Value::u4(6).to_string(), "((0,1),(1,0))",);
     }
 }


### PR DESCRIPTION
This gets rid of almost all the recursion in the library. In particular, there should be no remaining methods which recurse on `Value` nor on `Type` with the exception of the union-bound stuff, which I didn't do because this PR was already getting too big and I was running out of weekend and probably need to get back to the human-readable encoding.

Basically, it introduces a new pre-order iterator to dag.rs and then implements `DagLike` for a ton more structures. This often lets us get rid of recursion by just handing off to the pre-order iterator, and the resulting code is even smaller and easier to read.

Unfortunately refactoring the recursion in the various `types` functions required a nontrivial refactoring of the module. But I think the result is significantly easier to understand, and since I did the refactoring as a series of small-ish steps, hopefully not too bad to review. Essentially, I moved the union-bound algorithm into its own module, taking the worst of the mutex-manipulation with it, then I was able to fold `Constraint` into `Bound` (which I usually manipulate from behind a new `MutexBound` type which checks that we aren't editing bounds on complete types); then I was able to move the occurs-check stuff out of the data structures and into a local hashset in the `finalize` algorithm.

Aside from eliminating many stack-overflow vectors, this PR also:

* Exposes free variables and their names in the public API; previously these were not accessible except maybe by parsing `Debug` output
* Exposes the ability to iterate over types, values, etc., in pre-order and post-order.
* Significantly reduces the `Debug` output of `types::Final` by only displaying the top-level TMR and bitwidth, and showing a compact string representation of the types.
* Speeds up the unit tests by around 4x, by short-cutting unification of complete types with incomplete ones.
* FIxes a race condition in `Types::finalize` where we might incorrectly trigger the occurs check if the user is finalizing the same types at the same time from multiple threads. (This was a consequence of us storing the `occurs_check` boolean in the types themselves.)
* Fixes a bug where type unification still happens even when errors occur. So you can force inference to succeed by trying it, ignoring the error, and trying again.

This started as an exploratory weekend project and kinda got away from me, but the result is a significant improvement so I'd like to keep it.