### PR TITLE
Node refactors prior to human-readable encoding

### DIFF
--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -121,13 +121,7 @@ impl<N: NodeData<J>, J: Jet> Default for EncodeSharing<N, J> {
 }
 
 impl<'n, N: NodeData<J>, J: Jet> SharingTracker<EncodeNode<'n, N, J>> for EncodeSharing<N, J> {
-    fn record(
-        &mut self,
-        d: &EncodeNode<N, J>,
-        index: usize,
-        _: Option<usize>,
-        _: Option<usize>,
-    ) -> Option<usize> {
+    fn record(&mut self, d: &EncodeNode<N, J>, index: usize) -> Option<usize> {
         let id = match d {
             EncodeNode::Node(n) => EncodeId::Node(n.sharing_id()?),
             EncodeNode::Hidden(cmr) => EncodeId::Hidden(*cmr),

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -160,6 +160,33 @@ where
     }
 }
 
+impl<N, J> SharingTracker<Arc<Node<N, J>>> for MaxSharing<N, J>
+where
+    J: jet::Jet,
+    N: NodeData<J>,
+{
+    fn record(
+        &mut self,
+        d: &Arc<Node<N, J>>,
+        index: usize,
+        _: Option<usize>,
+        _: Option<usize>,
+    ) -> Option<usize> {
+        let id = d.sharing_id()?;
+
+        match self.map.entry(id) {
+            Entry::Occupied(occ) => Some(*occ.get()),
+            Entry::Vacant(vac) => {
+                vac.insert(index);
+                None
+            }
+        }
+    }
+    fn seen_before(&self, d: &Arc<Node<N, J>>) -> Option<usize> {
+        d.sharing_id().and_then(|id| self.map.get(&id)).copied()
+    }
+}
+
 // Need to explicitly allow swapping children for `MaxSharing`; the other
 // sharing styles have blanket implementations for `D: DagLike` so they
 // automatically allow it.

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use crate::jet;
-use crate::node::{self, Node, NodeData};
+use crate::node::{self, Node};
 
 /// Abstract node of a directed acyclic graph.
 ///
@@ -108,12 +108,12 @@ impl<D: DagLike> SharingTracker<D> for InternalSharing {
 /// types of nodes it represents "as much sharing as we can currently
 /// safely do".
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct MaxSharing<N: NodeData<J>, J: jet::Jet> {
+pub struct MaxSharing<N: node::Marker<J>, J: jet::Jet> {
     map: HashMap<N::SharingId, usize>,
 }
 
 // Annoyingly we have to implement Default by hand
-impl<N: NodeData<J>, J: jet::Jet> Default for MaxSharing<N, J> {
+impl<N: node::Marker<J>, J: jet::Jet> Default for MaxSharing<N, J> {
     fn default() -> Self {
         MaxSharing {
             map: HashMap::default(),
@@ -124,7 +124,7 @@ impl<N: NodeData<J>, J: jet::Jet> Default for MaxSharing<N, J> {
 impl<N, J> SharingTracker<&Node<N, J>> for MaxSharing<N, J>
 where
     J: jet::Jet,
-    N: NodeData<J>,
+    N: node::Marker<J>,
 {
     fn record(&mut self, d: &&Node<N, J>, index: usize) -> Option<usize> {
         let id = d.sharing_id()?;
@@ -145,7 +145,7 @@ where
 impl<N, J> SharingTracker<Arc<Node<N, J>>> for MaxSharing<N, J>
 where
     J: jet::Jet,
-    N: NodeData<J>,
+    N: node::Marker<J>,
 {
     fn record(&mut self, d: &Arc<Node<N, J>>, index: usize) -> Option<usize> {
         let id = d.sharing_id()?;
@@ -171,7 +171,7 @@ where
     D: DagLike,
     MaxSharing<N, J>: SharingTracker<D>,
     J: jet::Jet,
-    N: NodeData<J>,
+    N: node::Marker<J>,
 {
     fn record(&mut self, d: &SwapChildren<D>, index: usize) -> Option<usize> {
         self.record(&d.0, index)
@@ -376,7 +376,7 @@ impl<D: DagLike> DagLike for SwapChildren<D> {
     }
 }
 
-impl<'a, N: NodeData<J>, J: jet::Jet> DagLike for &'a Node<N, J> {
+impl<'a, N: node::Marker<J>, J: jet::Jet> DagLike for &'a Node<N, J> {
     type Node = Node<N, J>;
 
     fn data(&self) -> &Node<N, J> {
@@ -406,7 +406,7 @@ impl<'a, N: NodeData<J>, J: jet::Jet> DagLike for &'a Node<N, J> {
     }
 }
 
-impl<N: NodeData<J>, J: jet::Jet> DagLike for Arc<Node<N, J>> {
+impl<N: node::Marker<J>, J: jet::Jet> DagLike for Arc<Node<N, J>> {
     type Node = Node<N, J>;
 
     fn data(&self) -> &Node<N, J> {
@@ -667,7 +667,7 @@ impl<D: DagLike, S: SharingTracker<D>> Iterator for PostOrderIter<D, S> {
     }
 }
 
-impl<'a, N: NodeData<J>, J: jet::Jet, S: SharingTracker<&'a Node<N, J>> + Clone>
+impl<'a, N: node::Marker<J>, J: jet::Jet, S: SharingTracker<&'a Node<N, J>> + Clone>
     PostOrderIter<&'a Node<N, J>, S>
 {
     /// Adapt the iterator to only yield witnesses

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -348,7 +348,7 @@ pub trait DagLike: Sized {
 /// To avoid confusion, this structure cannot be directly costructed.
 /// Instead it is implicit in the [`DagLike::rtl_post_order_iter`]
 /// method.
-pub struct SwapChildren<D: DagLike>(D);
+pub struct SwapChildren<D>(D);
 
 impl<D: DagLike> DagLike for SwapChildren<D> {
     type Node = D::Node;
@@ -445,7 +445,7 @@ enum Previous {
 }
 
 #[derive(Clone, Debug)]
-struct IterStackItem<D: DagLike> {
+struct IterStackItem<D> {
     /// The element on the stack
     elem: D,
     /// Whether we have dealt with this item (and pushed its children,
@@ -499,7 +499,7 @@ impl<D: DagLike> IterStackItem<D> {
 /// Nodes may be repeated or not, based on the `S` parameter which defines how
 /// the iterator treats sharing.
 #[derive(Clone, Debug)]
-pub struct PostOrderIter<D: DagLike, S: SharingTracker<D>> {
+pub struct PostOrderIter<D, S> {
     /// The index of the next item to be yielded
     index: usize,
     /// A stack of elements to be yielded; each element is a node, then its left
@@ -511,7 +511,7 @@ pub struct PostOrderIter<D: DagLike, S: SharingTracker<D>> {
 }
 
 /// A set of data yielded by a `PostOrderIter`
-pub struct PostOrderIterItem<D: DagLike> {
+pub struct PostOrderIterItem<D> {
     /// The actual node data
     pub node: D,
     /// The index of this node (equivalent to if you'd called `.enumerate()` on
@@ -716,7 +716,7 @@ impl<D: DagLike, S: SharingTracker<D>> PostOrderIter<D, S> {
 /// post-order iterator, collect into a vector, then iterate through that
 /// backward.
 #[derive(Clone, Debug)]
-pub struct PreOrderIter<D: DagLike, S: SharingTracker<D>> {
+pub struct PreOrderIter<D, S> {
     /// A stack of elements to be yielded. As items are yielded, their right
     /// children are put onto the stack followed by their left, so that the
     /// appropriate one will be yielded on the next iteration.
@@ -768,7 +768,7 @@ impl<D: DagLike, S: SharingTracker<D>> Iterator for PreOrderIter<D, S> {
 /// skipped, but the node itself will still be re-yielded as many times
 /// as it has children.
 #[derive(Clone, Debug)]
-pub struct VerbosePreOrderIter<D: DagLike + Clone, S: SharingTracker<D>> {
+pub struct VerbosePreOrderIter<D, S> {
     /// A stack of elements to be yielded. As items are yielded, their right
     /// children are put onto the stack followed by their left, so that the
     /// appropriate one will be yielded on the next iteration.
@@ -830,7 +830,7 @@ impl<D: DagLike + Clone, S: SharingTracker<D>> Iterator for VerbosePreOrderIter<
 
 /// A set of data yielded by a [`VerbosePreOrderIter`].
 #[derive(Clone, Debug)]
-pub struct PreOrderIterItem<D: DagLike + Clone> {
+pub struct PreOrderIterItem<D> {
     /// The actual element being yielded.
     pub node: D,
     /// The parent of this node. `None` for the initial node, but will be

--- a/src/jet/mod.rs
+++ b/src/jet/mod.rs
@@ -67,7 +67,9 @@ impl std::error::Error for JetFailed {}
 /// Jets may read values from their _environment_.
 ///
 /// Jets are **always** leaves in a Simplicity DAG.
-pub trait Jet: Copy + Eq + Ord + Hash + std::fmt::Debug + std::fmt::Display {
+pub trait Jet:
+    Copy + Eq + Ord + Hash + std::fmt::Debug + std::fmt::Display + std::str::FromStr + 'static
+{
     /// Environment for jet to read from
     type Environment;
     /// CJetEnvironment to interact with C FFI.

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -19,8 +19,8 @@ use crate::{encode, types};
 use crate::{Amr, BitIter, BitWriter, Cmr, Error, FirstPassImr, Imr};
 
 use super::{
-    Construct, ConstructData, ConstructNode, Constructible, Converter, Inner, NoWitness, Node,
-    NodeData, Redeem, RedeemNode,
+    Construct, ConstructData, ConstructNode, Constructible, Converter, Inner, Marker, NoWitness,
+    Node, Redeem, RedeemNode,
 };
 
 use std::io;
@@ -30,7 +30,7 @@ use std::sync::Arc;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Commit {}
 
-impl<J: Jet> NodeData<J> for Commit {
+impl<J: Jet> Marker<J> for Commit {
     type CachedData = Arc<CommitData<J>>;
     type Witness = NoWitness;
     type SharingId = Imr;

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -28,7 +28,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Commit<J: Jet> {
+pub struct Commit<J> {
     /// Makes the type non-constructible.
     never: std::convert::Infallible,
     /// Required by Rust.
@@ -47,7 +47,7 @@ impl<J: Jet> Marker for Commit<J> {
 }
 
 #[derive(Clone, Debug)]
-pub struct CommitData<J: Jet> {
+pub struct CommitData<J> {
     /// The source and target types of the node
     arrow: FinalArrow,
     /// The first-pass IMR of the node if it exists.
@@ -64,7 +64,7 @@ pub struct CommitData<J: Jet> {
     phantom: PhantomData<J>,
 }
 
-impl<J: Jet> PartialEq for CommitData<J> {
+impl<J> PartialEq for CommitData<J> {
     // Two nodes are equal if they both have IMRs and those IMRs are equal.
     fn eq(&self, other: &Self) -> bool {
         self.imr

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -46,7 +46,7 @@ impl<J: Jet> Marker for Commit<J> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CommitData<J> {
     /// The source and target types of the node
     arrow: FinalArrow,
@@ -62,16 +62,6 @@ pub struct CommitData<J> {
     /// struct has a <J> parameter, since it forces the choice of jets to
     /// be consistent without the user needing to specify it too many times.
     phantom: PhantomData<J>,
-}
-
-impl<J> PartialEq for CommitData<J> {
-    // Two nodes are equal if they both have IMRs and those IMRs are equal.
-    fn eq(&self, other: &Self) -> bool {
-        self.imr
-            .zip(other.imr)
-            .map(|(a, b)| a == b)
-            .unwrap_or(false)
-    }
 }
 
 impl<J: Jet> CommitData<J> {

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -33,7 +33,7 @@ use super::{CoreConstructible, JetConstructible, WitnessConstructible};
 pub enum ConstructId {}
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Construct<J: Jet> {
+pub struct Construct<J> {
     /// Makes the type non-constructible.
     never: std::convert::Infallible,
     /// Required by Rust.
@@ -135,7 +135,7 @@ impl<J: Jet> ConstructNode<J> {
 }
 
 #[derive(Clone, Debug)]
-pub struct ConstructData<J: Jet> {
+pub struct ConstructData<J> {
     arrow: Arrow,
     /// This isn't really necessary, but it helps type inference if every
     /// struct has a <J> parameter, since it forces the choice of jets to
@@ -158,7 +158,7 @@ impl<J: Jet> ConstructData<J> {
     }
 }
 
-impl<J: Jet> CoreConstructible for ConstructData<J> {
+impl<J> CoreConstructible for ConstructData<J> {
     fn iden() -> Self {
         ConstructData {
             arrow: Arrow::iden(),
@@ -258,7 +258,7 @@ impl<J: Jet> CoreConstructible for ConstructData<J> {
     }
 }
 
-impl<J: Jet> WitnessConstructible<NoWitness> for ConstructData<J> {
+impl<J> WitnessConstructible<NoWitness> for ConstructData<J> {
     fn witness(witness: NoWitness) -> Self {
         ConstructData {
             arrow: Arrow::witness(witness),

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -22,7 +22,7 @@ use std::io;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use super::{Commit, CommitData, CommitNode, Converter, Inner, NoWitness, Node, NodeData};
+use super::{Commit, CommitData, CommitNode, Converter, Inner, Marker, NoWitness, Node};
 use super::{CoreConstructible, JetConstructible, WitnessConstructible};
 
 /// ID used to share [`ConstructNode`]s.
@@ -35,7 +35,7 @@ pub enum ConstructId {}
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Construct {}
 
-impl<J: Jet> NodeData<J> for Construct {
+impl<J: Jet> Marker<J> for Construct {
     type CachedData = ConstructData<J>;
     type Witness = NoWitness;
     type SharingId = ConstructId;

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -50,7 +50,7 @@ pub type ConstructNode<J> = Node<Construct, J>;
 impl<J: Jet> ConstructNode<J> {
     /// Accessor for the node's arrow
     pub fn arrow(&self) -> &Arrow {
-        &self.data.arrow
+        self.data.arrow()
     }
 
     /// Sets the source and target type of the node to unit
@@ -144,6 +144,11 @@ impl<J: Jet> ConstructData<J> {
             arrow,
             phantom: PhantomData,
         }
+    }
+
+    /// Accessor for the node's arrow
+    pub fn arrow(&self) -> &Arrow {
+        &self.arrow
     }
 }
 

--- a/src/node/convert.rs
+++ b/src/node/convert.rs
@@ -31,7 +31,7 @@ use crate::dag::PostOrderIterItem;
 use crate::jet::Jet;
 use crate::Value;
 
-use super::{Commit, CommitNode, Inner, NoWitness, Node, NodeData, Redeem, RedeemData, RedeemNode};
+use super::{Commit, CommitNode, Inner, Marker, NoWitness, Node, Redeem, RedeemData, RedeemNode};
 
 use std::sync::Arc;
 
@@ -76,7 +76,7 @@ pub enum Hide {
 ///
 /// The finalization method will not return any errors except those returned by
 /// methods on [`Converter`].
-pub trait Converter<N: NodeData<J>, M: NodeData<J>, J: Jet> {
+pub trait Converter<N: Marker<J>, M: Marker<J>, J: Jet> {
     /// The error type returned by the methods on this trait.
     type Error;
 

--- a/src/node/convert.rs
+++ b/src/node/convert.rs
@@ -76,7 +76,7 @@ pub enum Hide {
 ///
 /// The finalization method will not return any errors except those returned by
 /// methods on [`Converter`].
-pub trait Converter<N: Marker<J>, M: Marker<J>, J: Jet> {
+pub trait Converter<N: Marker, M: Marker> {
     /// The error type returned by the methods on this trait.
     type Error;
 
@@ -84,7 +84,7 @@ pub trait Converter<N: Marker<J>, M: Marker<J>, J: Jet> {
     /// state of the iterator.
     ///
     /// No action needs to be taken. The default implementation does nothing.
-    fn visit_node(&mut self, _data: &PostOrderIterItem<&Node<N, J>>) {}
+    fn visit_node(&mut self, _data: &PostOrderIterItem<&Node<N>>) {}
 
     /// For witness nodes, this method is called first to attach witness data to
     /// the node.
@@ -98,7 +98,7 @@ pub trait Converter<N: Marker<J>, M: Marker<J>, J: Jet> {
     /// actually matches the type of the combinator that it is being attached to.
     fn convert_witness(
         &mut self,
-        data: &PostOrderIterItem<&Node<N, J>>,
+        data: &PostOrderIterItem<&Node<N>>,
         witness: &N::Witness,
     ) -> Result<M::Witness, Self::Error>;
 
@@ -111,9 +111,9 @@ pub trait Converter<N: Marker<J>, M: Marker<J>, J: Jet> {
     /// The default implementation doesn't do any hiding.
     fn prune_case(
         &mut self,
-        _data: &PostOrderIterItem<&Node<N, J>>,
-        _left: &Arc<Node<M, J>>,
-        _right: &Arc<Node<M, J>>,
+        _data: &PostOrderIterItem<&Node<N>>,
+        _left: &Arc<Node<M>>,
+        _right: &Arc<Node<M>>,
     ) -> Result<Hide, Self::Error> {
         Ok(Hide::Neither)
     }
@@ -132,8 +132,8 @@ pub trait Converter<N: Marker<J>, M: Marker<J>, J: Jet> {
     /// Returns new cached data which will be attached to the newly-converted node.
     fn convert_data(
         &mut self,
-        data: &PostOrderIterItem<&Node<N, J>>,
-        inner: Inner<&Arc<Node<M, J>>, J, &M::Witness>,
+        data: &PostOrderIterItem<&Node<N>>,
+        inner: Inner<&Arc<Node<M>>, M::Jet, &M::Witness>,
     ) -> Result<M::CachedData, Self::Error>;
 }
 
@@ -153,7 +153,9 @@ impl<W: Iterator<Item = Arc<Value>>> SimpleFinalizer<W> {
     }
 }
 
-impl<W: Iterator<Item = Arc<Value>>, J: Jet> Converter<Commit, Redeem, J> for SimpleFinalizer<W> {
+impl<W: Iterator<Item = Arc<Value>>, J: Jet> Converter<Commit<J>, Redeem<J>>
+    for SimpleFinalizer<W>
+{
     type Error = crate::Error;
 
     fn convert_witness(

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -128,7 +128,7 @@ pub trait Marker:
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct NoWitness;
 
-pub trait Constructible<W, J: Jet>:
+pub trait Constructible<W, J>:
     JetConstructible<J> + WitnessConstructible<W> + CoreConstructible + Sized
 {
     fn from_inner(inner: Inner<&Self, J, W>) -> Result<Self, types::Error> {
@@ -153,7 +153,7 @@ pub trait Constructible<W, J: Jet>:
     }
 }
 
-impl<W, J: Jet, T> Constructible<W, J> for T where
+impl<W, J, T> Constructible<W, J> for T where
     T: JetConstructible<J> + WitnessConstructible<W> + CoreConstructible + Sized
 {
 }
@@ -293,7 +293,7 @@ pub trait CoreConstructible: Sized {
     }
 }
 
-pub trait JetConstructible<J: Jet>: Sized {
+pub trait JetConstructible<J>: Sized {
     fn jet(jet: J) -> Self;
 }
 

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -27,19 +27,25 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub enum Redeem {}
+pub struct Redeem<J: Jet> {
+    /// Makes the type non-constructible.
+    never: std::convert::Infallible,
+    /// Required by Rust.
+    phantom: std::marker::PhantomData<J>,
+}
 
-impl<J: Jet> Marker<J> for Redeem {
+impl<J: Jet> Marker for Redeem<J> {
     type CachedData = Arc<RedeemData<J>>;
     type Witness = Arc<Value>;
     type SharingId = Imr;
+    type Jet = J;
 
     fn compute_sharing_id(_: Cmr, cached_data: &Arc<RedeemData<J>>) -> Option<Imr> {
         Some(cached_data.imr)
     }
 }
 
-pub type RedeemNode<J> = Node<Redeem, J>;
+pub type RedeemNode<J> = Node<Redeem<J>>;
 
 #[derive(Clone, Debug)]
 pub struct RedeemData<J: Jet> {
@@ -182,7 +188,7 @@ impl<J: Jet> RedeemNode<J> {
     pub fn unfinalize(&self) -> Result<Arc<CommitNode<J>>, types::Error> {
         struct Unfinalizer<J: Jet>(PhantomData<J>);
 
-        impl<J: Jet> Converter<Redeem, Commit, J> for Unfinalizer<J> {
+        impl<J: Jet> Converter<Redeem<J>, Commit<J>> for Unfinalizer<J> {
             type Error = types::Error;
             fn convert_witness(
                 &mut self,
@@ -205,7 +211,7 @@ impl<J: Jet> RedeemNode<J> {
             }
         }
 
-        self.convert::<MaxSharing<Redeem, J>, _, _>(&mut Unfinalizer(PhantomData))
+        self.convert::<MaxSharing<Redeem<J>>, _, _>(&mut Unfinalizer(PhantomData))
     }
 
     /// Decode a Simplicity program from bits, including the witness data.
@@ -216,7 +222,7 @@ impl<J: Jet> RedeemNode<J> {
             phantom: PhantomData<J>,
         }
 
-        impl<'bits, J: Jet, I: Iterator<Item = u8>> Converter<Commit, Redeem, J>
+        impl<'bits, J: Jet, I: Iterator<Item = u8>> Converter<Commit<J>, Redeem<J>>
             for DecodeFinalizer<'bits, J, I>
         {
             type Error = Error;
@@ -282,7 +288,7 @@ impl<J: Jet> RedeemNode<J> {
 
     /// Encode a Simplicity program to bits, including the witness data.
     pub fn encode<W: io::Write>(&self, w: &mut BitWriter<W>) -> io::Result<usize> {
-        let sharing_iter = self.post_order_iter::<MaxSharing<Redeem, J>>();
+        let sharing_iter = self.post_order_iter::<MaxSharing<Redeem<J>>>();
         let program_bits = encode::encode_program(self, w)?;
         let witness_bits =
             encode::encode_witness(sharing_iter.into_witnesses().map(Arc::as_ref), w)?;

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -19,7 +19,7 @@ use crate::jet::Jet;
 use crate::types::{self, arrow::FinalArrow};
 use crate::{Amr, BitIter, BitWriter, Cmr, Error, FirstPassImr, Imr, Value};
 
-use super::{Commit, CommitData, CommitNode, Converter, Inner, NoWitness, Node, NodeData};
+use super::{Commit, CommitData, CommitNode, Converter, Inner, Marker, NoWitness, Node};
 
 use std::collections::HashSet;
 use std::io;
@@ -29,7 +29,7 @@ use std::sync::Arc;
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Redeem {}
 
-impl<J: Jet> NodeData<J> for Redeem {
+impl<J: Jet> Marker<J> for Redeem {
     type CachedData = Arc<RedeemData<J>>;
     type Witness = Arc<Value>;
     type SharingId = Imr;

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -27,7 +27,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Redeem<J: Jet> {
+pub struct Redeem<J> {
     /// Makes the type non-constructible.
     never: std::convert::Infallible,
     /// Required by Rust.
@@ -48,7 +48,7 @@ impl<J: Jet> Marker for Redeem<J> {
 pub type RedeemNode<J> = Node<Redeem<J>>;
 
 #[derive(Clone, Debug)]
-pub struct RedeemData<J: Jet> {
+pub struct RedeemData<J> {
     amr: Amr,
     first_pass_imr: FirstPassImr,
     imr: Imr,
@@ -60,14 +60,14 @@ pub struct RedeemData<J: Jet> {
     phantom: PhantomData<J>,
 }
 
-impl<J: Jet> PartialEq for RedeemData<J> {
+impl<J> PartialEq for RedeemData<J> {
     fn eq(&self, other: &Self) -> bool {
         self.imr == other.imr
     }
 }
-impl<J: Jet> Eq for RedeemData<J> {}
+impl<J> Eq for RedeemData<J> {}
 
-impl<J: Jet> std::hash::Hash for RedeemData<J> {
+impl<J> std::hash::Hash for RedeemData<J> {
     fn hash<H: std::hash::Hasher>(&self, hasher: &mut H) {
         self.imr.hash(hasher)
     }
@@ -186,7 +186,7 @@ impl<J: Jet> RedeemNode<J> {
     /// Convert a [`RedeemNode`] back to a [`CommitNode`] by forgetting witnesses
     /// and cached data.
     pub fn unfinalize(&self) -> Result<Arc<CommitNode<J>>, types::Error> {
-        struct Unfinalizer<J: Jet>(PhantomData<J>);
+        struct Unfinalizer<J>(PhantomData<J>);
 
         impl<J: Jet> Converter<Redeem<J>, Commit<J>> for Unfinalizer<J> {
             type Error = types::Error;

--- a/src/node/witness.rs
+++ b/src/node/witness.rs
@@ -21,7 +21,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use super::{Constructible, CoreConstructible, JetConstructible, WitnessConstructible};
-use super::{Converter, Hide, Inner, NoWitness, Node, NodeData, Redeem, RedeemData, RedeemNode};
+use super::{Converter, Hide, Inner, Marker, NoWitness, Node, Redeem, RedeemData, RedeemNode};
 
 /// ID used to share [`WitnessNode`]s.
 ///
@@ -33,7 +33,7 @@ pub enum WitnessId {}
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub enum Witness {}
 
-impl<J: Jet> NodeData<J> for Witness {
+impl<J: Jet> Marker<J> for Witness {
     type CachedData = WitnessData<J>;
     type Witness = Option<Arc<Value>>;
     type SharingId = WitnessId;

--- a/src/node/witness.rs
+++ b/src/node/witness.rs
@@ -31,7 +31,7 @@ use super::{Converter, Hide, Inner, Marker, NoWitness, Node, Redeem, RedeemData,
 pub enum WitnessId {}
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-pub struct Witness<J: Jet> {
+pub struct Witness<J> {
     /// Makes the type non-constructible.
     never: std::convert::Infallible,
     /// Required by Rust.
@@ -81,7 +81,7 @@ impl<J: Jet> WitnessNode<J> {
     }
 
     pub fn prune_and_retype(&self) -> Arc<Self> {
-        struct Retyper<J: Jet>(PhantomData<J>);
+        struct Retyper<J>(PhantomData<J>);
 
         impl<J: Jet> Converter<Witness<J>, Witness<J>> for Retyper<J> {
             type Error = types::Error;
@@ -195,7 +195,7 @@ impl<J: Jet> WitnessNode<J> {
 }
 
 #[derive(Clone, Debug)]
-pub struct WitnessData<J: Jet> {
+pub struct WitnessData<J> {
     arrow: Arrow,
     must_prune: bool,
     /// This isn't really necessary, but it helps type inference if every
@@ -204,7 +204,7 @@ pub struct WitnessData<J: Jet> {
     phantom: PhantomData<J>,
 }
 
-impl<J: Jet> CoreConstructible for WitnessData<J> {
+impl<J> CoreConstructible for WitnessData<J> {
     fn iden() -> Self {
         WitnessData {
             arrow: Arrow::iden(),
@@ -322,7 +322,7 @@ impl<J: Jet> CoreConstructible for WitnessData<J> {
     }
 }
 
-impl<J: Jet> WitnessConstructible<Option<Arc<Value>>> for WitnessData<J> {
+impl<J> WitnessConstructible<Option<Arc<Value>>> for WitnessData<J> {
     fn witness(witness: Option<Arc<Value>>) -> Self {
         WitnessData {
             arrow: Arrow::witness(NoWitness),

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -23,11 +23,11 @@ use crate::{FailEntropy, Value};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-pub type ArcNode<N> = Arc<Node<N, Elements>>;
+pub type ArcNode<N> = Arc<Node<N>>;
 
 pub fn unsatisfiable<N>(entropy: FailEntropy) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible,
 {
     ArcNode::fail(entropy)
@@ -35,7 +35,7 @@ where
 
 pub fn trivial<N>() -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible,
 {
     ArcNode::unit()
@@ -44,7 +44,7 @@ where
 pub fn key<N, Pk>(key: &Pk, witness: N::Witness) -> ArcNode<N>
 where
     Pk: ToPublicKey,
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     let key_value = Arc::new(Value::u256_from_slice(&key.to_x_only_pubkey().serialize()));
@@ -60,7 +60,7 @@ where
 
 pub fn after<N>(n: u32) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let n_value = Arc::new(Value::u32(n));
@@ -72,7 +72,7 @@ where
 
 pub fn older<N>(n: u16) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let n_value = Arc::new(Value::u16(n));
@@ -84,7 +84,7 @@ where
 
 fn compute_sha256<N>(witness256: &ArcNode<N>) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let ctx = ArcNode::jet(Elements::Sha256Ctx8Init);
@@ -97,7 +97,7 @@ where
 
 fn verify_bexp<N>(input: &ArcNode<N>, bexp: &ArcNode<N>) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let computed_bexp = ArcNode::comp(input, bexp).expect("consistent types");
@@ -108,7 +108,7 @@ where
 pub fn sha256<N, Pk>(hash: &Pk::Sha256, witness: N::Witness) -> ArcNode<N>
 where
     Pk: ToPublicKey,
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     let hash_value = Arc::new(Value::u256_from_slice(Pk::to_sha256(hash).as_ref()));
@@ -124,7 +124,7 @@ where
 
 pub fn and<N>(left: &ArcNode<N>, right: &ArcNode<N>) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible,
 {
     ArcNode::comp(left, right).expect("consistent types")
@@ -132,7 +132,7 @@ where
 
 fn selector<N>(witness_bit: N::Witness) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
 {
     let witness = ArcNode::witness(witness_bit);
@@ -142,7 +142,7 @@ where
 
 pub fn or<N>(left: &ArcNode<N>, right: &ArcNode<N>, witness_bit: N::Witness) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
 {
     let drop_left = ArcNode::drop_(left);
@@ -158,7 +158,7 @@ where
 /// summand(child): 1 → 2^32
 fn thresh_summand<N>(child: &ArcNode<N>, witness_bit: N::Witness) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
 {
     // 1 → 2 x 1
@@ -187,7 +187,7 @@ where
 /// add(sum, summand): 1 → 2^32
 fn thresh_add<N>(sum: &ArcNode<N>, summand: &ArcNode<N>) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     // 1 → 2^32 × 2^32
@@ -210,7 +210,7 @@ where
 /// verify(sum): 1 → 1
 fn thresh_verify<N>(sum: &ArcNode<N>, k: u32) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     // 1 → 2^32
@@ -226,7 +226,7 @@ where
 
 pub fn threshold<N>(k: u32, subs: &[ArcNode<N>], witness_bits: &[N::Witness]) -> ArcNode<N>
 where
-    N: node::Marker<Elements>,
+    N: node::Marker,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     let n = u32::try_from(subs.len()).expect("can have at most 2^32 children in a threshold");

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -16,8 +16,8 @@
 
 use crate::jet::Elements;
 use crate::miniscript::ToPublicKey;
+use crate::node::{self, Node};
 use crate::node::{CoreConstructible, JetConstructible, WitnessConstructible};
-use crate::node::{Node, NodeData};
 use crate::{FailEntropy, Value};
 
 use std::convert::TryFrom;
@@ -27,7 +27,7 @@ pub type ArcNode<N> = Arc<Node<N, Elements>>;
 
 pub fn unsatisfiable<N>(entropy: FailEntropy) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible,
 {
     ArcNode::fail(entropy)
@@ -35,7 +35,7 @@ where
 
 pub fn trivial<N>() -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible,
 {
     ArcNode::unit()
@@ -44,7 +44,7 @@ where
 pub fn key<N, Pk>(key: &Pk, witness: N::Witness) -> ArcNode<N>
 where
     Pk: ToPublicKey,
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     let key_value = Arc::new(Value::u256_from_slice(&key.to_x_only_pubkey().serialize()));
@@ -60,7 +60,7 @@ where
 
 pub fn after<N>(n: u32) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let n_value = Arc::new(Value::u32(n));
@@ -72,7 +72,7 @@ where
 
 pub fn older<N>(n: u16) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let n_value = Arc::new(Value::u16(n));
@@ -84,7 +84,7 @@ where
 
 fn compute_sha256<N>(witness256: &ArcNode<N>) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let ctx = ArcNode::jet(Elements::Sha256Ctx8Init);
@@ -97,7 +97,7 @@ where
 
 fn verify_bexp<N>(input: &ArcNode<N>, bexp: &ArcNode<N>) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
 {
     let computed_bexp = ArcNode::comp(input, bexp).expect("consistent types");
@@ -108,7 +108,7 @@ where
 pub fn sha256<N, Pk>(hash: &Pk::Sha256, witness: N::Witness) -> ArcNode<N>
 where
     Pk: ToPublicKey,
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     let hash_value = Arc::new(Value::u256_from_slice(Pk::to_sha256(hash).as_ref()));
@@ -124,7 +124,7 @@ where
 
 pub fn and<N>(left: &ArcNode<N>, right: &ArcNode<N>) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible,
 {
     ArcNode::comp(left, right).expect("consistent types")
@@ -132,7 +132,7 @@ where
 
 fn selector<N>(witness_bit: N::Witness) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
 {
     let witness = ArcNode::witness(witness_bit);
@@ -142,7 +142,7 @@ where
 
 pub fn or<N>(left: &ArcNode<N>, right: &ArcNode<N>, witness_bit: N::Witness) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
 {
     let drop_left = ArcNode::drop_(left);
@@ -158,7 +158,7 @@ where
 /// summand(child): 1 → 2^32
 fn thresh_summand<N>(child: &ArcNode<N>, witness_bit: N::Witness) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
 {
     // 1 → 2 x 1
@@ -187,7 +187,7 @@ where
 /// add(sum, summand): 1 → 2^32
 fn thresh_add<N>(sum: &ArcNode<N>, summand: &ArcNode<N>) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     // 1 → 2^32 × 2^32
@@ -210,7 +210,7 @@ where
 /// verify(sum): 1 → 1
 fn thresh_verify<N>(sum: &ArcNode<N>, k: u32) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     // 1 → 2^32
@@ -226,7 +226,7 @@ where
 
 pub fn threshold<N>(k: u32, subs: &[ArcNode<N>], witness_bits: &[N::Witness]) -> ArcNode<N>
 where
-    N: NodeData<Elements>,
+    N: node::Marker<Elements>,
     ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
 {
     let n = u32::try_from(subs.len()).expect("can have at most 2^32 children in a threshold");


### PR DESCRIPTION
This PR does some first steps to making the `Node` types more general and powerful. The next one will similarly generalize things to allow `disconnect` nodes to have missing children (and correctly have `CommitNode` without disconnected expressions and `ReedemNode` with). Once we've done that we can start merging the human-readable encoding. Or if you get impatient we can re-order things :).

My full branch, which has some example programs etc as well as a parser, is at https://github.com/BlockstreamResearch/rust-simplicity/tree/2023-06--simplang . I will try to keep it up to date. Note the `2023-06-`. There is also a `2023-05-` branch with the same name which is badly out of date.