### PR TITLE
Ranged descriptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bitcoin = { version = "0.29.2", optional = true }
 bitcoin_hashes = "0.11"
 byteorder = "1.3"
 elements = { version = "0.21.1", optional = true }
-elements-miniscript = { git = "https://github.com/ElementsProject/elements-miniscript", rev = "955f380" }
+elements-miniscript = { git = "https://github.com/apoelstra/elements-miniscript", tag = "2023-07--rust-simplicity-patch" }
 simplicity-sys = { version = "0.1.0", path = "./simplicity-sys" }
 actual-serde = { package = "serde", version = "1.0.103", features = ["derive"], optional = true }
 

--- a/src/policy/descriptor.rs
+++ b/src/policy/descriptor.rs
@@ -282,7 +282,7 @@ impl<Pk: MiniscriptKey> fmt::Display for Descriptor<Pk> {
 
 impl<Pk> FromStr for Descriptor<Pk>
 where
-    Pk: UnspendableKey + ToPublicKey + FromStr,
+    Pk: UnspendableKey + MiniscriptKey + FromStr,
     Pk::Sha256: FromStr,
     <Pk as FromStr>::Err: ToString,
     <Pk::Sha256 as FromStr>::Err: ToString,

--- a/src/policy/descriptor.rs
+++ b/src/policy/descriptor.rs
@@ -7,7 +7,7 @@ use elements::taproot::{
     ControlBlock, LeafVersion, TapBranchHash, TapLeafHash, TaprootBuilder, TaprootMerkleBranch,
     TaprootSpendInfo,
 };
-use elements_miniscript::{MiniscriptKey, ToPublicKey};
+use miniscript::{DescriptorPublicKey, MiniscriptKey, ToPublicKey};
 use std::fmt;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
@@ -19,6 +19,15 @@ pub trait UnspendableKey: MiniscriptKey {
 impl UnspendableKey for XOnlyPublicKey {
     fn unspendable() -> Self {
         XOnlyPublicKey::from_slice(&UNSPENDABLE_PUBLIC_KEY).expect("unspendable pubkey is valid")
+    }
+}
+
+impl UnspendableKey for DescriptorPublicKey {
+    fn unspendable() -> Self {
+        Self::Single(miniscript::descriptor::SinglePub {
+            origin: None,
+            key: miniscript::descriptor::SinglePubKey::XOnly(XOnlyPublicKey::unspendable()),
+        })
     }
 }
 

--- a/src/policy/descriptor.rs
+++ b/src/policy/descriptor.rs
@@ -1,4 +1,3 @@
-use crate::policy::satisfy::PolicySatisfier;
 use crate::{miniscript, Error, Policy};
 use bitcoin_hashes::Hash;
 use elements::schnorr::{TapTweak, XOnlyPublicKey};
@@ -11,7 +10,7 @@ use miniscript::descriptor::ConversionError;
 use miniscript::Error as MSError;
 use miniscript::{
     translate_hash_clone, DefiniteDescriptorKey, DescriptorPublicKey, ForEachKey, MiniscriptKey,
-    ToPublicKey, Translator,
+    Satisfier, ToPublicKey, Translator,
 };
 use std::fmt;
 use std::str::FromStr;
@@ -189,9 +188,9 @@ impl<Pk: ToPublicKey> Descriptor<Pk> {
     /// Return a satisfying non-malleable witness and script sig with minimum weight
     /// to spend an output controlled by the given descriptor if it is possible to satisfy
     /// given the `satisfier`
-    pub fn get_satisfaction(
+    pub fn get_satisfaction<S: Satisfier<Pk>>(
         &self,
-        satisfier: &PolicySatisfier<Pk>,
+        satisfier: S,
     ) -> Result<(Vec<Vec<u8>>, elements::Script), Error> {
         let program = self.policy.satisfy(satisfier)?;
 

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -160,9 +160,9 @@ impl<Pk: ToPublicKey> Policy<Pk> {
 
     pub fn satisfy<S: Satisfier<Pk>>(
         &self,
-        satisfier: &S,
+        satisfier: S,
     ) -> Result<Arc<RedeemNode<Elements>>, Error> {
-        let witnode = self.satisfy_internal(satisfier)?;
+        let witnode = self.satisfy_internal(&satisfier)?;
         if witnode.must_prune() {
             Err(Error::IncompleteFinalization)
         } else {


### PR DESCRIPTION
Adds rudimentary support for ranged descriptors. ~We could add more convenience methods, but this requires us to copy / implement a lot of traits such as `ForEachKey`.~