### PR TITLE
Latest miniscript

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,10 @@ jobs:
               cargo update -p serde_json --precise 1.0.99
               # 1.0.157 uses syn 2.0
               cargo update -p serde --precise 1.0.156
+              # 1.0.31 uses proc-macro 1.0.66
+              cargo update -p quote --precise 1.0.30
+              # 1.0.66 uses edition 2021
+              cargo update -p proc-macro2 --precise 1.0.65
           fi
           for f in $FEATURES; do echo "Features: $f" && cargo test --no-default-features --features="$f"; done
           echo "No default features" && cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ name = "simplicity"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoin = { version = "0.29.2", optional = true }
-bitcoin_hashes = "0.11"
+bitcoin = { version = "0.30.0", optional = true }
+bitcoin_hashes = "0.12"
 byteorder = "1.3"
-elements = { version = "0.21.1", optional = true }
-elements-miniscript = { git = "https://github.com/apoelstra/elements-miniscript", tag = "2023-07--rust-simplicity-patch" }
+elements = { version = "0.22.0", optional = true }
+elements-miniscript = "0.2.0"
 simplicity-sys = { version = "0.1.0", path = "./simplicity-sys" }
 actual-serde = { package = "serde", version = "1.0.103", features = ["derive"], optional = true }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,8 +13,8 @@ honggfuzz = { version = "0.5.55", default-features = false }
 simplicity = { path = ".." }
 
 [patch.crates-io.bitcoin_hashes]
-git = "https://github.com/apoelstra/bitcoin_hashes"
-branch = "2023-04--fuzzcfg"
+git = "https://github.com/apoelstra/rust-bitcoin"
+tag = "2023-07--0.30.1-with-fuzzcfg"
 
 [[bin]]
 name = "c_rust_merkle"

--- a/fuzz/fuzz_targets/parse_compile.rs
+++ b/fuzz/fuzz_targets/parse_compile.rs
@@ -14,7 +14,7 @@
 
 use honggfuzz::fuzz;
 
-use simplicity::bitcoin::XOnlyPublicKey;
+use simplicity::bitcoin::key::XOnlyPublicKey;
 use simplicity::policy::Policy;
 use std::str::{self, FromStr};
 

--- a/jets-bench/Cargo.toml
+++ b/jets-bench/Cargo.toml
@@ -11,10 +11,10 @@ serde_cbor = "0.11.1"
 serde_json = "1.0.70"
 serde = { version = "1.0.130", features = ["derive"] }
 chrono = "0.4.19"
-simplicity = {version = "0.1.0", path = "../"}
+simplicity = { path = ".." }
 criterion = "0.4.0"
 rand = "0.8"
-bitcoin_hashes = "0.11.0"
+bitcoin_hashes = "0.12.0"
 
 [[bench]]
 name = "elements"

--- a/jets-bench/benches/elements/data_structures.rs
+++ b/jets-bench/benches/elements/data_structures.rs
@@ -301,7 +301,7 @@ impl BenchSample for elements::OutPoint {
         rng.fill_bytes(&mut txid);
         let vout = rng.next_u32();
         elements::OutPoint {
-            txid: Txid::from_inner(txid),
+            txid: Txid::from_byte_array(txid),
             vout,
         }
     }

--- a/jets-bench/benches/elements/env.rs
+++ b/jets-bench/benches/elements/env.rs
@@ -1,7 +1,8 @@
 use bitcoin::hashes as bitcoin_hashes;
 use bitcoin_hashes::Hash;
+use elements::locktime::LockTime;
 use elements::taproot::ControlBlock;
-use elements::{BlockHash, PackedLockTime, Transaction};
+use elements::{BlockHash, Transaction};
 use simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
 use simplicity::Cmr;
 use simplicity::{bitcoin, elements};
@@ -69,7 +70,7 @@ impl EnvSampling {
         }
         let tx = Transaction {
             version: u32::default(),
-            lock_time: PackedLockTime::ZERO,
+            lock_time: LockTime::ZERO,
             input: tx_ins,
             output: tx_outs,
         };
@@ -101,7 +102,7 @@ fn env_with_spent_utxos(
 fn null_env() -> ElementsEnv {
     let tx = Transaction {
         version: u32::default(),
-        lock_time: PackedLockTime::ZERO,
+        lock_time: LockTime::ZERO,
         input: Vec::default(),
         output: Vec::default(),
     };
@@ -109,8 +110,8 @@ fn null_env() -> ElementsEnv {
 }
 
 pub(super) mod txout_utils {
-    use bitcoin::XOnlyPublicKey;
-    use bitcoin_hashes::hex::FromHex;
+    use bitcoin::key::XOnlyPublicKey;
+    use elements::hex::FromHex;
     use elements::{confidential, encode::deserialize, schnorr::TapTweak, AssetId, Transaction};
     use simplicity::{bitcoin, elements};
 
@@ -143,10 +144,10 @@ pub(super) mod txout_utils {
     }
 }
 pub(super) mod txin_utils {
-    use bitcoin_hashes::{hex::FromHex, Hash};
+    use bitcoin_hashes::Hash;
     use elements::{
-        confidential, encode::deserialize, AssetIssuance, OutPoint, Script, Sequence, TxInWitness,
-        Txid,
+        confidential, encode::deserialize, hex::FromHex, AssetIssuance, OutPoint, Script, Sequence,
+        TxInWitness, Txid,
     };
     use simplicity::{elements, jet::elements::ElementsUtxo};
 
@@ -162,7 +163,7 @@ pub(super) mod txin_utils {
         let tx_bytes = rand::random::<[u8; 32]>();
         let vout = rand::random::<u16>() as u32;
         let txin = elements::TxIn {
-            previous_output: OutPoint::new(Txid::from_inner(tx_bytes), vout),
+            previous_output: OutPoint::new(Txid::from_byte_array(tx_bytes), vout),
             is_pegin: false,
             script_sig: Script::new(),
             sequence: Sequence::MAX,
@@ -179,7 +180,7 @@ pub(super) mod txin_utils {
         let tx_bytes = rand::random::<[u8; 32]>();
         let vout = rand::random::<u16>() as u32;
         let txin = elements::TxIn {
-            previous_output: OutPoint::new(Txid::from_inner(tx_bytes), vout),
+            previous_output: OutPoint::new(Txid::from_byte_array(tx_bytes), vout),
             is_pegin: false,
             script_sig: Script::new(),
             sequence: Sequence::MAX,

--- a/simplicity-sys/Cargo.toml
+++ b/simplicity-sys/Cargo.toml
@@ -10,7 +10,7 @@ cc = "1.0"
 
 [dependencies]
 libc = "0.2"
-bitcoin_hashes = "0.11"
+bitcoin_hashes = "0.12"
 
 [features]
 test-utils = []

--- a/simplicity-sys/src/c_jets/c_env.rs
+++ b/simplicity-sys/src/c_jets/c_env.rs
@@ -198,7 +198,7 @@ extern "C" {
 impl CElementsTxEnv {
     pub fn sighash_all(&self) -> sha256::Hash {
         let midstate: sha256::Midstate = self.sighash_all.into();
-        sha256::Hash::from_inner(midstate.into_inner())
+        sha256::Hash::from_byte_array(midstate.to_byte_array())
     }
 }
 

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -501,7 +501,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "elements")]
-    use crate::bitcoin_hashes::hex::ToHex;
+    use crate::hex::ToHex;
     #[cfg(feature = "elements")]
     use crate::jet::{elements::ElementsEnv, Elements};
     #[cfg(feature = "elements")]

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Hex Encoding and Decoding
+
+// The rust-bitcoin hex stury is such a mess right now that the most
+// straightforward thing is to just reimplement everything here.
+//
+// This is a copy/paste of the bitcoin_hashes hex module, with the
+// std/alloc feature gates, and the benchmarks, removed.
+//
+
+use std::{fmt, io, str};
+
+/// Hex decoding error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Error {
+    /// Non-hexadecimal character.
+    InvalidChar(u8),
+    /// Purported hex string had odd length.
+    OddLengthString(usize),
+    /// Tried to parse fixed-length hash from a string with the wrong type (expected, got).
+    InvalidLength(usize, usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::InvalidChar(ch) => write!(f, "invalid hex character {}", ch),
+            Error::OddLengthString(ell) => write!(f, "odd hex string length {}", ell),
+            Error::InvalidLength(ell, ell2) => {
+                write!(f, "bad hex string length {} (expected {})", ell2, ell)
+            }
+        }
+    }
+}
+
+/// Trait for objects that can be serialized as hex strings.
+pub trait ToHex {
+    /// Converts to a hexadecimal representation of the object.
+    fn to_hex(&self) -> String;
+}
+
+/// Trait for objects that can be deserialized from hex strings.
+pub trait FromHex: Sized {
+    /// Produces an object from a byte iterator.
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator;
+
+    /// Produces an object from a hex string.
+    fn from_hex(s: &str) -> Result<Self, Error> {
+        Self::from_byte_iter(HexIterator::new(s)?)
+    }
+}
+
+impl<T: fmt::LowerHex> ToHex for T {
+    /// Outputs the hash in hexadecimal form.
+    fn to_hex(&self) -> String {
+        format!("{:x}", self)
+    }
+}
+
+/// Iterator over a hex-encoded string slice which decodes hex and yields bytes.
+pub struct HexIterator<'a> {
+    /// The `Bytes` iterator whose next two bytes will be decoded to yield
+    /// the next byte.
+    iter: str::Bytes<'a>,
+}
+
+impl<'a> HexIterator<'a> {
+    /// Constructs a new `HexIterator` from a string slice.
+    ///
+    /// # Errors
+    ///
+    /// If the input string is of odd length.
+    pub fn new(s: &'a str) -> Result<HexIterator<'a>, Error> {
+        if s.len() % 2 != 0 {
+            Err(Error::OddLengthString(s.len()))
+        } else {
+            Ok(HexIterator { iter: s.bytes() })
+        }
+    }
+}
+
+fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
+    let hih = (hi as char).to_digit(16).ok_or(Error::InvalidChar(hi))?;
+    let loh = (lo as char).to_digit(16).ok_or(Error::InvalidChar(lo))?;
+
+    let ret = (hih << 4) + loh;
+    Ok(ret as u8)
+}
+
+impl<'a> Iterator for HexIterator<'a> {
+    type Item = Result<u8, Error>;
+
+    fn next(&mut self) -> Option<Result<u8, Error>> {
+        let hi = self.iter.next()?;
+        let lo = self.iter.next().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.iter.size_hint();
+        (min / 2, max.map(|x| x / 2))
+    }
+}
+
+impl<'a> io::Read for HexIterator<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0usize;
+        for dst in buf {
+            match self.next() {
+                Some(Ok(src)) => {
+                    *dst = src;
+                    bytes_read += 1;
+                }
+                _ => break,
+            }
+        }
+        Ok(bytes_read)
+    }
+}
+
+impl<'a> DoubleEndedIterator for HexIterator<'a> {
+    fn next_back(&mut self) -> Option<Result<u8, Error>> {
+        let lo = self.iter.next_back()?;
+        let hi = self.iter.next_back().unwrap();
+        Some(chars_to_hex(hi, lo))
+    }
+}
+
+impl<'a> ExactSizeIterator for HexIterator<'a> {}
+
+/// Outputs hex into an object implementing `fmt::Write`.
+///
+/// This is usually more efficient than going through a `String` using [`ToHex`].
+pub fn format_hex(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
+    let prec = f.precision().unwrap_or(2 * data.len());
+    let width = f.width().unwrap_or(2 * data.len());
+    for _ in (2 * data.len())..width {
+        f.write_str("0")?;
+    }
+    for ch in data.iter().take(prec / 2) {
+        write!(f, "{:02x}", *ch)?;
+    }
+    if prec < 2 * data.len() && prec % 2 == 1 {
+        write!(f, "{:x}", data[prec / 2] / 16)?;
+    }
+    Ok(())
+}
+
+/// Outputs hex in reverse order.
+///
+/// Used for `sha256d::Hash` whose standard hex encoding has the bytes reversed.
+pub fn format_hex_reverse(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
+    let prec = f.precision().unwrap_or(2 * data.len());
+    let width = f.width().unwrap_or(2 * data.len());
+    for _ in (2 * data.len())..width {
+        f.write_str("0")?;
+    }
+    for ch in data.iter().rev().take(prec / 2) {
+        write!(f, "{:02x}", *ch)?;
+    }
+    if prec < 2 * data.len() && prec % 2 == 1 {
+        write!(f, "{:x}", data[data.len() - 1 - prec / 2] / 16)?;
+    }
+    Ok(())
+}
+
+impl ToHex for [u8] {
+    fn to_hex(&self) -> String {
+        use core::fmt::Write;
+        let mut ret = String::with_capacity(2 * self.len());
+        for ch in self {
+            write!(ret, "{:02x}", ch).expect("writing to string");
+        }
+        ret
+    }
+}
+
+/// A struct implementing [`io::Write`] that converts what's written to it into
+/// a hex String.
+///
+/// If you already have the data to be converted in a `Vec<u8>` use [`ToHex`]
+/// but if you have an encodable object, by using this you avoid the
+/// serialization to `Vec<u8>` by going directly to `String`.
+///
+/// Note that to achieve better perfomance than [`ToHex`] the struct must be
+/// created with the right `capacity` of the final hex string so that the inner
+/// `String` doesn't re-allocate.
+pub struct HexWriter(String);
+
+impl HexWriter {
+    /// Creates a new [`HexWriter`] with the `capacity` of the inner `String`
+    /// that will contain final hex value.
+    pub fn new(capacity: usize) -> Self {
+        HexWriter(String::with_capacity(capacity))
+    }
+
+    /// Returns the resulting hex string.
+    pub fn result(self) -> String {
+        self.0
+    }
+}
+
+impl io::Write for HexWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        use core::fmt::Write;
+        for ch in buf {
+            write!(self.0, "{:02x}", ch).expect("writing to string");
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl FromHex for Vec<u8> {
+    fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+    {
+        iter.collect()
+    }
+}
+
+macro_rules! impl_fromhex_array {
+    ($len:expr) => {
+        impl FromHex for [u8; $len] {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
+            where
+                I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
+            {
+                if iter.len() == $len {
+                    let mut ret = [0; $len];
+                    for (n, byte) in iter.enumerate() {
+                        ret[n] = byte?;
+                    }
+                    Ok(ret)
+                } else {
+                    Err(Error::InvalidLength(2 * $len, 2 * iter.len()))
+                }
+            }
+        }
+    };
+}
+
+impl_fromhex_array!(2);
+impl_fromhex_array!(4);
+impl_fromhex_array!(6);
+impl_fromhex_array!(8);
+impl_fromhex_array!(10);
+impl_fromhex_array!(12);
+impl_fromhex_array!(14);
+impl_fromhex_array!(16);
+impl_fromhex_array!(20);
+impl_fromhex_array!(24);
+impl_fromhex_array!(28);
+impl_fromhex_array!(32);
+impl_fromhex_array!(33);
+impl_fromhex_array!(64);
+impl_fromhex_array!(65);
+impl_fromhex_array!(128);
+impl_fromhex_array!(256);
+impl_fromhex_array!(384);
+impl_fromhex_array!(512);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use core::fmt;
+    use std::io::Write;
+
+    #[test]
+    fn hex_roundtrip() {
+        let expected = "0123456789abcdef";
+        let expected_up = "0123456789ABCDEF";
+
+        let parse: Vec<u8> = FromHex::from_hex(expected).expect("parse lowercase string");
+        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_hex();
+        assert_eq!(ser, expected);
+
+        let parse: Vec<u8> = FromHex::from_hex(expected_up).expect("parse uppercase string");
+        assert_eq!(parse, vec![0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_hex();
+        assert_eq!(ser, expected);
+
+        let parse: [u8; 8] = FromHex::from_hex(expected_up).expect("parse uppercase string");
+        assert_eq!(parse, [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef]);
+        let ser = parse.to_hex();
+        assert_eq!(ser, expected);
+    }
+
+    #[test]
+    fn hex_truncate() {
+        struct HexBytes(Vec<u8>);
+        impl fmt::LowerHex for HexBytes {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                format_hex(&self.0, f)
+            }
+        }
+
+        let bytes = HexBytes(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        assert_eq!(format!("{:x}", bytes), "0102030405060708090a");
+
+        for i in 0..20 {
+            assert_eq!(
+                format!("{:.prec$x}", bytes, prec = i),
+                &"0102030405060708090a"[0..i]
+            );
+        }
+
+        assert_eq!(format!("{:25x}", bytes), "000000102030405060708090a");
+        assert_eq!(format!("{:26x}", bytes), "0000000102030405060708090a");
+    }
+
+    #[test]
+    fn hex_truncate_rev() {
+        struct HexBytes(Vec<u8>);
+        impl fmt::LowerHex for HexBytes {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                format_hex_reverse(&self.0, f)
+            }
+        }
+
+        let bytes = HexBytes(vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        assert_eq!(format!("{:x}", bytes), "0a090807060504030201");
+
+        for i in 0..20 {
+            assert_eq!(
+                format!("{:.prec$x}", bytes, prec = i),
+                &"0a090807060504030201"[0..i]
+            );
+        }
+
+        assert_eq!(format!("{:25x}", bytes), "000000a090807060504030201");
+        assert_eq!(format!("{:26x}", bytes), "0000000a090807060504030201");
+    }
+
+    #[test]
+    fn hex_error() {
+        let oddlen = "0123456789abcdef0";
+        let badchar1 = "Z123456789abcdef";
+        let badchar2 = "012Y456789abcdeb";
+        let badchar3 = "«23456789abcdef";
+
+        assert_eq!(Vec::<u8>::from_hex(oddlen), Err(Error::OddLengthString(17)));
+        assert_eq!(<[u8; 4]>::from_hex(oddlen), Err(Error::OddLengthString(17)));
+        assert_eq!(<[u8; 8]>::from_hex(oddlen), Err(Error::OddLengthString(17)));
+        assert_eq!(Vec::<u8>::from_hex(badchar1), Err(Error::InvalidChar(b'Z')));
+        assert_eq!(Vec::<u8>::from_hex(badchar2), Err(Error::InvalidChar(b'Y')));
+        assert_eq!(Vec::<u8>::from_hex(badchar3), Err(Error::InvalidChar(194)));
+    }
+
+    #[test]
+    fn hex_writer() {
+        let vec: Vec<_> = (0u8..32).collect();
+        let mut writer = HexWriter::new(64);
+        writer.write_all(&vec[..]).unwrap();
+        assert_eq!(vec.to_hex(), writer.result());
+    }
+}

--- a/src/human_encoding/serialize.rs
+++ b/src/human_encoding/serialize.rs
@@ -14,10 +14,10 @@
 
 //! Serialization
 
-use bitcoin_hashes::hex::ToHex;
 use std::fmt;
 
 use crate::dag::{DagLike, NoSharing};
+use crate::hex::ToHex;
 use crate::Value;
 
 pub struct DisplayWord<'a>(pub &'a crate::Value);

--- a/src/jet/bitcoin/environment.rs
+++ b/src/jet/bitcoin/environment.rs
@@ -12,7 +12,7 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-use bitcoin::PackedLockTime;
+use bitcoin::absolute;
 
 /// Environment for Bitcoin Simplicity
 pub struct BitcoinEnv {
@@ -30,7 +30,7 @@ impl Default for BitcoinEnv {
         // FIXME: Review and check if the defaults make sense
         BitcoinEnv::new(bitcoin::Transaction {
             version: 2,
-            lock_time: PackedLockTime::ZERO,
+            lock_time: absolute::LockTime::ZERO,
             input: vec![],
             output: vec![],
         })

--- a/src/jet/elements/environment.rs
+++ b/src/jet/elements/environment.rs
@@ -131,11 +131,11 @@ impl ElementsEnv {
 impl ElementsEnv {
     /// Return a dummy Elements environment
     pub fn dummy() -> Self {
-        Self::dummy_with(elements::PackedLockTime::ZERO, elements::Sequence::MAX)
+        Self::dummy_with(elements::LockTime::ZERO, elements::Sequence::MAX)
     }
 
     /// Return a dummy Elements environment with given locktime
-    pub fn dummy_with(lock_time: elements::PackedLockTime, sequence: elements::Sequence) -> Self {
+    pub fn dummy_with(lock_time: elements::LockTime, sequence: elements::Sequence) -> Self {
         use bitcoin_hashes::Hash;
         use elements::AssetIssuance;
 

--- a/src/jet/elements/tests.rs
+++ b/src/jet/elements/tests.rs
@@ -9,8 +9,8 @@ use bitcoin_hashes::Hash;
 use elements::secp256k1_zkp::Tweak;
 use elements::taproot::ControlBlock;
 use elements::{
-    confidential, AssetId, AssetIssuance, BlockHash, OutPoint, PackedLockTime, Sequence,
-    Transaction, TxIn, TxInWitness, TxOut, TxOutWitness,
+    confidential, AssetId, AssetIssuance, BlockHash, OutPoint, Sequence, Transaction, TxIn,
+    TxInWitness, TxOut, TxOutWitness,
 };
 
 #[test]
@@ -30,13 +30,14 @@ fn test_ffi_env() {
         0x33, 0x2f, 0xb7, 0x1d, 0xda, 0x90, 0xff, 0x4b, 0xef, 0x53, 0x70, 0xf2, 0x52, 0x26, 0xd3,
         0xbc, 0x09, 0xfc,
     ];
-    let asset = confidential::Asset::Explicit(AssetId::from_inner(Midstate::from_inner(asset)));
+    let asset =
+        confidential::Asset::Explicit(AssetId::from_inner(Midstate::from_byte_array(asset)));
     let tx = Transaction {
         version: 2,
-        lock_time: PackedLockTime(100),
+        lock_time: elements::LockTime::from_consensus(100),
         input: vec![TxIn {
             previous_output: OutPoint {
-                txid: elements::Txid::from_inner(tx_id),
+                txid: elements::Txid::from_byte_array(tx_id),
                 vout: 0,
             },
             sequence: Sequence::ENABLE_LOCKTIME_NO_RBF,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ mod analysis;
 mod bit_encoding;
 pub mod bit_machine;
 pub mod dag;
+#[allow(dead_code)]
+mod hex;
 pub mod human_encoding;
 pub mod jet;
 mod merkle;

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -290,7 +290,7 @@ impl<J: Jet> CommitNode<J> {
 mod tests {
     use super::*;
 
-    use bitcoin_hashes::hex::ToHex;
+    use crate::hex::ToHex;
     use std::fmt;
 
     use crate::decode::Error;

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -342,7 +342,7 @@ impl<J: Jet> RedeemNode<J> {
 mod tests {
     use super::*;
 
-    use bitcoin_hashes::hex::ToHex;
+    use crate::hex::ToHex;
     use std::fmt;
 
     use crate::jet::Core;

--- a/src/policy/descriptor.rs
+++ b/src/policy/descriptor.rs
@@ -153,7 +153,7 @@ impl<Pk: ToPublicKey> Descriptor<Pk> {
         // Single leaf: leaf hash = merkle root
         let (script, leaf_version) = self.leaf();
         let leaf_hash = TapLeafHash::from_script(&script, leaf_version);
-        let merkle_root = TapBranchHash::from_inner(leaf_hash.into_inner());
+        let merkle_root = TapBranchHash::from_byte_array(leaf_hash.to_byte_array());
         // Single leaf: empty merkle inclusion proof
         let merkle_branch = TaprootMerkleBranch::from_inner(Vec::new()).expect("constant branch");
 

--- a/src/policy/embed.rs
+++ b/src/policy/embed.rs
@@ -111,7 +111,7 @@ impl<'a, Pk: ToPublicKey, Ctx: ScriptContext> TryFrom<&'a Miniscript<Pk, Ctx>> f
             Terminal::PkH(_) | Terminal::RawPkH(_) => {
                 Err(Error::Policy(policy::Error::PublicKeyHash))
             }
-            Terminal::After(n) => Ok(Policy::After(n.0)),
+            Terminal::After(n) => Ok(Policy::After(n.to_consensus_u32())),
             Terminal::Older(n) => {
                 if !n.is_height_locked() {
                     return Err(Error::Policy(policy::Error::InvalidSequence));
@@ -178,7 +178,7 @@ impl<'a, Pk: ToPublicKey, Ctx: ScriptContext> TryFrom<&'a Miniscript<Pk, Ctx>> f
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::miniscript::bitcoin::XOnlyPublicKey;
+    use crate::miniscript::bitcoin::key::XOnlyPublicKey;
 
     #[test]
     fn parse_bad_thresh() {

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -250,12 +250,12 @@ mod tests {
     use crate::policy::Policy;
     use crate::{BitMachine, FailEntropy, Value};
     use bitcoin_hashes::{sha256, Hash};
-    use elements::{bitcoin, secp256k1_zkp};
+    use elements::bitcoin::key::XOnlyPublicKey;
+    use elements::locktime::Height;
+    use elements::secp256k1_zkp;
     use std::sync::Arc;
 
-    fn compile(
-        policy: Policy<bitcoin::XOnlyPublicKey>,
-    ) -> (Arc<ConstructNode<Elements>>, ElementsEnv) {
+    fn compile(policy: Policy<XOnlyPublicKey>) -> (Arc<ConstructNode<Elements>>, ElementsEnv) {
         let commit = policy.serialize_no_witness();
         let env = ElementsEnv::dummy();
 
@@ -314,32 +314,34 @@ mod tests {
 
     #[test]
     fn execute_after() {
-        let env = ElementsEnv::dummy_with(elements::PackedLockTime(42), elements::Sequence::ZERO);
+        let height = Height::from_consensus(42).unwrap();
+        let env =
+            ElementsEnv::dummy_with(elements::LockTime::Blocks(height), elements::Sequence::ZERO);
 
-        let commit = Policy::<bitcoin::XOnlyPublicKey>::After(41).serialize_no_witness();
+        let commit = Policy::<XOnlyPublicKey>::After(41).serialize_no_witness();
         assert!(execute_successful(&commit, vec![], &env));
 
-        let commit = Policy::<bitcoin::XOnlyPublicKey>::After(42).serialize_no_witness();
+        let commit = Policy::<XOnlyPublicKey>::After(42).serialize_no_witness();
         assert!(execute_successful(&commit, vec![], &env));
 
-        let commit = Policy::<bitcoin::XOnlyPublicKey>::After(43).serialize_no_witness();
+        let commit = Policy::<XOnlyPublicKey>::After(43).serialize_no_witness();
         assert!(!execute_successful(&commit, vec![], &env));
     }
 
     #[test]
     fn execute_older() {
         let env = ElementsEnv::dummy_with(
-            elements::PackedLockTime::ZERO,
+            elements::LockTime::ZERO,
             elements::Sequence::from_consensus(42),
         );
 
-        let commit = Policy::<bitcoin::XOnlyPublicKey>::Older(41).serialize_no_witness();
+        let commit = Policy::<XOnlyPublicKey>::Older(41).serialize_no_witness();
         assert!(execute_successful(&commit, vec![], &env));
 
-        let commit = Policy::<bitcoin::XOnlyPublicKey>::Older(42).serialize_no_witness();
+        let commit = Policy::<XOnlyPublicKey>::Older(42).serialize_no_witness();
         assert!(execute_successful(&commit, vec![], &env));
 
-        let commit = Policy::<bitcoin::XOnlyPublicKey>::Older(43).serialize_no_witness();
+        let commit = Policy::<XOnlyPublicKey>::Older(43).serialize_no_witness();
         assert!(!execute_successful(&commit, vec![], &env));
     }
 


### PR DESCRIPTION
Updates simplicity to the latest bitcoin(-hashes), elements and elements-miniscript.

I had to copy hex.rs because bitcoin-hashes dropped support. We might want to use a stable workaround instead once it exists.

There are also problems in the fuzz and bench crate that need to be resolved.