### PR TITLE
Human-readable encoding 3: add parser

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,7 +34,7 @@ decode_program,
           key: cache-${{ matrix.target }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58
+          toolchain: 1.64
           override: true
           profile: minimal
       - name: fuzz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.48.0
+          - 1.58.0
           - beta
           - nightly
     steps:
@@ -93,7 +93,7 @@ jobs:
         env:
           FEATURES: bitcoin elements test-utils
         run: |
-          if cargo --version | grep "1\.48"; then
+          if cargo --version | grep "1\.58"; then
               # 1.0.100 uses syn 2.0 which requires edition 2021
               cargo update -p serde_json --precise 1.0.99
               # 1.0.157 uses syn 2.0
@@ -102,6 +102,8 @@ jobs:
               cargo update -p quote --precise 1.0.30
               # 1.0.66 uses edition 2021
               cargo update -p proc-macro2 --precise 1.0.65
+              # 1.8.0 requires cargo 1.60+
+              cargo update -p regex --precise 1.7.0
           fi
           for f in $FEATURES; do echo "Features: $f" && cargo test --no-default-features --features="$f"; done
           echo "No default features" && cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ byteorder = "1.3"
 elements = { version = "0.22.0", optional = true }
 hashes = { package = "bitcoin_hashes", version = "0.12" }
 hex = { package = "hex-conservative", version = "0.1.1" }
+santiago = "1.3"
 simplicity-sys = { version = "0.1.0", path = "./simplicity-sys" }
 actual-serde = { package = "serde", version = "1.0.103", features = ["derive"], optional = true }
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Under development....
 
 # Minimum Supported Rust Version
 
-The MSRV of this crate is **1.48.0**.
+The MSRV of this crate is **1.58.0**.
 
 # Updating jets code
 

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -74,7 +74,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
           key: cache-\${{ matrix.target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58
+          toolchain: 1.64
           override: true
           profile: minimal
       - name: fuzz

--- a/simpcli/Cargo.toml
+++ b/simpcli/Cargo.toml
@@ -13,4 +13,3 @@ simplicity = { version = "0.1", path = "..", features = [ "serde", "elements" ] 
 [[bin]]
 name = "simpcli"
 path = "src/main.rs"
-

--- a/src/human_encoding/error.rs
+++ b/src/human_encoding/error.rs
@@ -87,6 +87,11 @@ impl ErrorSet {
             .push(err.into());
     }
 
+    /// Adds an error to the error set.
+    pub fn add_no_position<E: Into<Error>>(&mut self, err: E) {
+        self.errors.entry(None).or_insert(vec![]).push(err.into());
+    }
+
     /// Merges another set of errors into the current set.
     ///
     /// # Panics
@@ -177,6 +182,7 @@ impl error::Error for ErrorSet {
             Error::TypeCheck(ref e) => Some(e),
             Error::Undefined(_) => None,
             Error::UnknownJet(_) => None,
+            Error::WitnessDisconnectRepeated { .. } => None,
         }
     }
 }
@@ -260,6 +266,8 @@ pub enum Error {
     Undefined(String),
     /// A given jet is not a known jet
     UnknownJet(String),
+    /// A witness or disconnect node was accessible from multiple paths.
+    WitnessDisconnectRepeated { name: Arc<str>, count: usize },
 }
 
 impl From<types::Error> for Error {
@@ -305,6 +313,11 @@ impl fmt::Display for Error {
             Error::TypeCheck(ref e) => fmt::Display::fmt(e, f),
             Error::Undefined(ref s) => write!(f, "reference to undefined symbol `{}`", s),
             Error::UnknownJet(ref s) => write!(f, "unknown jet `{}`", s),
+            Error::WitnessDisconnectRepeated { ref name, count } => write!(
+                f,
+                "witness/disconnect node {} was accessible by {} distinct paths from the same root",
+                name, count,
+            ),
         }
     }
 }

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -22,6 +22,7 @@
 
 mod error;
 mod named_node;
+mod parse;
 mod serialize;
 
 use crate::dag::{DagLike, MaxSharing};
@@ -34,6 +35,7 @@ use std::sync::Arc;
 
 pub use self::error::{Error, ErrorSet};
 pub use self::named_node::NamedCommitNode;
+pub use self::parse::parse;
 
 /// Line/column pair
 ///
@@ -46,12 +48,35 @@ pub struct Position {
     column: usize,
 }
 
+impl<'a> From<&'a santiago::lexer::Position> for Position {
+    fn from(position: &'a santiago::lexer::Position) -> Position {
+        Position {
+            line: position.line,
+            column: position.column,
+        }
+    }
+}
+
+impl From<santiago::lexer::Position> for Position {
+    fn from(position: santiago::lexer::Position) -> Position {
+        Position {
+            line: position.line,
+            column: position.column,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Forest<J: Jet> {
     roots: HashMap<Arc<str>, Arc<NamedCommitNode<J>>>,
 }
 
 impl<J: Jet> Forest<J> {
+    /// Parses a forest from a string
+    pub fn parse(s: &str) -> Result<Self, ErrorSet> {
+        parse::parse(s).map(|roots| Forest { roots })
+    }
+
     /// Parses a program from a bytestring
     pub fn from_program(root: Arc<CommitNode<J>>) -> Self {
         let root = NamedCommitNode::from_node(&root);

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -85,6 +85,11 @@ impl<J: Jet> Forest<J> {
         Forest { roots }
     }
 
+    /// Accessor for the map of roots of this forest
+    pub fn roots(&self) -> &HashMap<Arc<str>, Arc<NamedCommitNode<J>>> {
+        &self.roots
+    }
+
     /// Serialize the program in human-readable form
     pub fn string_serialize(&self) -> String {
         struct Print {

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -186,6 +186,18 @@ impl<J: Jet> NamedConstructNode<J> {
         Ok(Node::from_parts(inner, named_data))
     }
 
+    /// Creates a copy of a node with a different name.
+    pub fn renamed(&self, new_name: Arc<str>) -> Self {
+        let data = NamedConstructData {
+            internal: self.cached_data().internal.clone(),
+            user_source_types: Arc::clone(&self.cached_data().user_source_types),
+            user_target_types: Arc::clone(&self.cached_data().user_target_types),
+            name: new_name,
+            position: self.position(),
+        };
+        Self::from_parts(self.inner().clone(), data)
+    }
+
     /// Accessor for the node's name
     pub fn name(&self) -> &Arc<str> {
         &self.cached_data().name

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -210,7 +210,11 @@ impl<J: Jet> NamedConstructNode<J> {
                 data: &PostOrderIterItem<&NamedConstructNode<J>>,
                 inner: node::Inner<&Arc<NamedCommitNode<J>>, J, &NoDisconnect, &NoWitness>,
             ) -> Result<NamedCommitData<J>, Self::Error> {
-                let converted_data = inner.map(|node| &node.cached_data().internal);
+                let converted_data = inner
+                    .as_ref()
+                    .map(|node| &node.cached_data().internal)
+                    .map_disconnect(|disc| *disc)
+                    .copy_witness();
 
                 if !self.for_main {
                     // For non-`main` fragments, treat the ascriptions as normative, and apply them
@@ -313,6 +317,16 @@ impl Namer {
             wit_idx: 0,
             other_idx: 0,
             root_cmr: Some(root_cmr),
+        }
+    }
+
+    /// Costruct a new `Namer`.
+    pub fn new() -> Self {
+        Namer {
+            const_idx: 0,
+            wit_idx: 0,
+            other_idx: 0,
+            root_cmr: None,
         }
     }
 

--- a/src/human_encoding/parse/ast.rs
+++ b/src/human_encoding/parse/ast.rs
@@ -1,0 +1,846 @@
+// Simplicity "Human-Readable" Language
+// Written in 2023 by
+//   Andrew Poelstra <simplicity@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Parsing
+
+use std::mem;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use crate::human_encoding::{Error, ErrorSet, Position};
+use crate::jet::Jet;
+use crate::{node, types};
+use crate::{BitIter, Cmr, FailEntropy};
+use santiago::grammar::{Associativity, Grammar};
+use santiago::lexer::{Lexeme, LexerRules};
+
+/// A single non-empty line of a program, of the form x = y :: t
+///
+/// A program is simply a list of such lines
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Line<J> {
+    /// Position of the first character of the line.
+    pub position: Position,
+    /// The name of the expression being named on the line.
+    pub name: Arc<str>,
+    /// The actual expression, if present (missing for type declarations).
+    pub expression: Option<Expression<J>>,
+    /// The type of the expression, if given (inferred if missing).
+    pub arrow: (Option<Type>, Option<Type>),
+}
+
+/// An expression, as represented in the AST
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct Expression<J> {
+    pub inner: ExprInner<J>,
+    pub position: Position,
+}
+
+impl<J: Jet> Expression<J> {
+    fn reference(name: Arc<str>, position: Position) -> Self {
+        Expression {
+            inner: ExprInner::Reference(name),
+            position,
+        }
+    }
+}
+
+/// An expression, as represented in the AST
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum ExprInner<J> {
+    /// A reference to another expression
+    Reference(Arc<str>),
+    /// A left assertion (referring to the CMR of an expression on the right)
+    AssertL(Arc<Expression<J>>, AstCmr<J>),
+    /// A right assertion (referring to the CMR of an expression on the left)
+    AssertR(AstCmr<J>, Arc<Expression<J>>),
+    /// An inline expression
+    Inline(node::Inner<Arc<Expression<J>>, J, node::NoDisconnect, node::NoWitness>),
+}
+
+/// A CMR, as represented in the AST
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum AstCmr<J> {
+    Expr(Arc<Expression<J>>),
+    Literal(Cmr),
+}
+
+/// A type, as represented in the AST
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum Type {
+    /// A named type variable
+    Name(String),
+    /// The unit type 1
+    One,
+    /// The bit type 1+1
+    Two,
+    /// A product type (A * B)
+    Product(Box<Type>, Box<Type>),
+    /// A sum type (A + B)
+    Sum(Box<Type>, Box<Type>),
+    /// An exponential type 2^(2^n).
+    TwoTwoN(u32),
+}
+
+impl Type {
+    /// Convert to a Simplicity type
+    pub fn reify(self) -> types::Type {
+        match self {
+            Type::Name(s) => types::Type::free(s),
+            Type::One => types::Type::unit(),
+            Type::Two => types::Type::sum(types::Type::unit(), types::Type::unit()),
+            Type::Product(left, right) => types::Type::product(left.reify(), right.reify()),
+            Type::Sum(left, right) => types::Type::sum(left.reify(), right.reify()),
+            Type::TwoTwoN(n) => types::Type::two_two_n(n as usize), // cast OK as we are only using tiny numbers
+        }
+    }
+}
+
+/// Takes a program as a string and parses it into an AST (actually, a vector
+/// of lines, each of which is individually an AST)
+pub fn parse_line_vector<J: Jet + 'static>(input: &str) -> Result<Vec<Line<J>>, ErrorSet> {
+    let lexer_rules = lexer_rules();
+    let grammar = grammar::<J>();
+
+    let lexemes = match santiago::lexer::lex(&lexer_rules, input) {
+        Ok(lexemes) => lexemes,
+        Err(err) => return Err(err.into()),
+    };
+    let trees = santiago::parser::parse(&grammar, &lexemes)?;
+    assert_eq!(trees.len(), 1, "ambiguous parse (this is a bug)");
+    match trees[0].as_abstract_syntax_tree() {
+        Ast::Program(lines) => Ok(lines),
+        Ast::Error(errs) => Err(errs),
+        x => unreachable!(
+            "Parsed program into non-program non-error {:?}; this is a bug.",
+            x
+        ),
+    }
+}
+
+/// Check a list of AST elements for errors; if any are errors, combine them and return the result
+fn propagate_errors<J: Jet>(ast: &[Ast<J>]) -> Option<Ast<J>> {
+    let mut e = ErrorSet::new();
+    for elem in ast {
+        if let Ast::Error(errs) = elem {
+            e.merge(errs);
+        }
+    }
+    if e.is_empty() {
+        None
+    } else {
+        Some(Ast::Error(e))
+    }
+}
+
+/// Main AST structure
+///
+/// This structure is never really instantiated; during construction it is
+/// continually collapsed until in the end it will be in either the `Program`
+/// or `Error` variant.
+#[derive(Debug, Clone)]
+enum Ast<J: Jet> {
+    Combinator {
+        comb: node::Inner<(), J, node::NoDisconnect, node::NoWitness>,
+        position: Position,
+    },
+    /// A type->type arrow
+    Arrow(Option<Type>, Option<Type>),
+    /// A #{expr} or #abcd CMR
+    Cmr(AstCmr<J>),
+    /// An error occurred during parsing
+    Error(ErrorSet),
+    /// An expression
+    Expression(Expression<J>),
+    /// A full expression line
+    Line(Line<J>),
+    /// A hex or binary literal
+    Literal {
+        data: Vec<u8>,
+        bit_length: usize,
+        position: Position,
+    },
+    /// The top-level program
+    Program(Vec<Line<J>>),
+    /// A symbol
+    Symbol { value: Arc<str>, position: Position },
+    /// A type
+    Type(Option<Type>),
+    /// Dummy value used internally in the parser when building the tree.
+    ///
+    /// Any parse objects which have no information in themselves (e.g. the
+    /// plus or star symbols) but which are just used to shape the parse
+    /// tree, get mapped to this value and then discarded.
+    Dummy { position: Position },
+    /// Dummy value used when manipulating the tree in-place, to replace
+    /// data that we move out of the tree
+    Replaced,
+}
+
+impl<J: Jet> Ast<J> {
+    /// Creates an `Ast` from a single sub-AST
+    fn from_1<T, F1, F>(toks: &mut [Self], convert: F1, unconvert: F) -> Self
+    where
+        F1: FnOnce(&mut Self) -> T,
+        F: FnOnce(T) -> Self,
+    {
+        if let Some(e) = propagate_errors(toks) {
+            return e;
+        }
+        assert_eq!(toks.len(), 1);
+        unconvert(convert(&mut toks[0]))
+    }
+
+    /// Creates an `Ast` from two sub-`Ast`s with a dummy in between
+    fn from_2<T, U, F1, F2, F>(toks: &mut [Self], convert1: F1, convert2: F2, unconvert: F) -> Self
+    where
+        F1: FnOnce(&mut Self) -> T,
+        F2: FnOnce(&mut Self) -> U,
+        F: FnOnce(T, U) -> Self,
+    {
+        if let Some(e) = propagate_errors(toks) {
+            return e;
+        }
+        assert_eq!(toks.len(), 3);
+        toks[1].expect_position();
+        unconvert(convert1(&mut toks[0]), convert2(&mut toks[2]))
+    }
+
+    /// Creates an `Ast` from three sub-`Ast`s with dummies in between
+    fn from_3<T, U, V, F1, F2, F3, F>(
+        toks: &mut [Self],
+        convert1: F1,
+        convert2: F2,
+        convert3: F3,
+        unconvert: F,
+    ) -> Self
+    where
+        F1: FnOnce(&mut Self) -> T,
+        F2: FnOnce(&mut Self) -> U,
+        F3: FnOnce(&mut Self) -> V,
+        F: FnOnce(T, U, V) -> Self,
+    {
+        if let Some(e) = propagate_errors(toks) {
+            return e;
+        }
+        assert_eq!(toks.len(), 5);
+        toks[1].expect_position();
+        toks[3].expect_position();
+        unconvert(
+            convert1(&mut toks[0]),
+            convert2(&mut toks[2]),
+            convert3(&mut toks[4]),
+        )
+    }
+
+    /// Creates an AST from a combinator with no arguments
+    fn from_combinator(mut toks: Vec<Self>) -> Self {
+        if let Some(e) = propagate_errors(&toks) {
+            return e;
+        }
+
+        let (comb, position) = match mem::replace(&mut toks[0], Ast::Replaced) {
+            Ast::Combinator { comb, position } => (comb, position),
+            _ => unreachable!(),
+        };
+
+        // This stupid construction is needed to avoid borrowck rules
+        // around borrowing tok[1] and tok[2] mutably at the same time.
+        let arcs: Vec<Arc<_>> = toks[1..]
+            .iter_mut()
+            .map(Ast::expect_expression)
+            .map(Arc::new)
+            .collect();
+        let inner = comb.map_left_right(|_| Arc::clone(&arcs[0]), |_| Arc::clone(&arcs[1]));
+        Ast::Expression(Expression {
+            inner: ExprInner::Inline(inner),
+            position,
+        })
+    }
+
+    /// Creates an AST from a dummy lexeme
+    fn from_dummy_lexeme(lexemes: &[&std::rc::Rc<Lexeme>]) -> Self {
+        assert_eq!(lexemes.len(), 1);
+        let position = (&lexemes[0].position).into();
+        Ast::Dummy { position }
+    }
+
+    /// Creates an AST from a lexeme which forms a complete type
+    fn from_type_lexeme(lexemes: &[&std::rc::Rc<Lexeme>]) -> Self {
+        assert_eq!(lexemes.len(), 1);
+        let position = &lexemes[0].position;
+        match lexemes[0].raw.as_str() {
+            "1" => Ast::Type(Some(Type::One)),
+            "2" => Ast::Type(Some(Type::Two)),
+            other => {
+                assert_eq!(&other[..2], "2^");
+                match str::parse::<u32>(&other[2..]) {
+                    // TODO how many of these should we support?
+                    Ok(0) => Ast::Type(Some(Type::One)),
+                    Ok(1) => Ast::Type(Some(Type::Two)),
+                    Ok(2) => Ast::Type(Some(Type::TwoTwoN(1))),
+                    Ok(4) => Ast::Type(Some(Type::TwoTwoN(2))),
+                    Ok(8) => Ast::Type(Some(Type::TwoTwoN(3))),
+                    Ok(16) => Ast::Type(Some(Type::TwoTwoN(4))),
+                    Ok(32) => Ast::Type(Some(Type::TwoTwoN(5))),
+                    Ok(64) => Ast::Type(Some(Type::TwoTwoN(6))),
+                    Ok(128) => Ast::Type(Some(Type::TwoTwoN(7))),
+                    Ok(256) => Ast::Type(Some(Type::TwoTwoN(8))),
+                    Ok(512) => Ast::Type(Some(Type::TwoTwoN(9))),
+                    Ok(y) => Ast::Error(ErrorSet::single(position, Error::Bad2ExpNumber(y))),
+                    Err(_) => Ast::Error(ErrorSet::single(
+                        position,
+                        Error::NumberOutOfRange(other.to_owned()),
+                    )),
+                }
+            }
+        }
+    }
+
+    /// Creates an AST from a combinator lexeme
+    fn from_combinator_lexeme(lexemes: &[&std::rc::Rc<Lexeme>]) -> Self {
+        assert_eq!(lexemes.len(), 1);
+        let position = (&lexemes[0].position).into();
+        let comb = match lexemes[0].raw.as_str() {
+            "unit" => node::Inner::Unit,
+            "iden" => node::Inner::Iden,
+            "injl" => node::Inner::InjL(()),
+            "injr" => node::Inner::InjR(()),
+            "take" => node::Inner::Take(()),
+            "drop" => node::Inner::Drop(()),
+            "comp" => node::Inner::Comp((), ()),
+            "case" => node::Inner::Case((), ()),
+            "assertl" => node::Inner::AssertL((), Cmr::unit()),
+            "assertr" => node::Inner::AssertR(Cmr::unit(), ()),
+            "pair" => node::Inner::Pair((), ()),
+            "disconnect" => node::Inner::Disconnect((), node::NoDisconnect),
+            "witness" => node::Inner::Witness(node::NoWitness),
+            "fail" => node::Inner::Fail(FailEntropy::ZERO),
+            other => {
+                assert_eq!(&other[..4], "jet_");
+                if let Ok(jet) = J::from_str(&other[4..]) {
+                    node::Inner::Jet(jet)
+                } else {
+                    return Ast::Error(ErrorSet::single(
+                        position,
+                        Error::UnknownJet(other.to_owned()),
+                    ));
+                }
+            }
+        };
+        Ast::Combinator { comb, position }
+    }
+
+    /// Creates an AST from a literal lexeme
+    fn from_literal_lexeme(lexemes: &[&std::rc::Rc<Lexeme>]) -> Self {
+        assert_eq!(lexemes.len(), 1);
+        let position = (&lexemes[0].position).into();
+
+        if lexemes[0].raw == "_" {
+            return Ast::Literal {
+                data: vec![],
+                bit_length: 0,
+                position,
+            };
+        }
+
+        let s = &lexemes[0].raw[2..];
+        if &lexemes[0].raw[..2] == "0x" {
+            let bit_length = s.len() * 4;
+            let mut data = Vec::with_capacity((s.len() + 1) / 2);
+            for idx in (0..s.len() / 2).map(|n| n * 2) {
+                data.push(u8::from_str_radix(&s[idx..idx + 1], 16).unwrap());
+            }
+            if s.len() % 2 == 1 {
+                data.push(u8::from_str_radix(&s[s.len() - 1..], 16).unwrap() << 4);
+            }
+
+            Ast::Literal {
+                data,
+                bit_length,
+                position,
+            }
+        } else {
+            assert_eq!(&lexemes[0].raw[..2], "0b");
+
+            let bit_length = s.len();
+            let mut data = Vec::with_capacity((s.len() + 7) / 8);
+            let mut x = 0;
+            for (n, ch) in s.chars().enumerate() {
+                match ch {
+                    '0' => {}
+                    '1' => x |= 1 << (7 - (n % 8)),
+                    _ => unreachable!(),
+                }
+                if n % 8 == 7 {
+                    data.push(x);
+                    x = 0;
+                }
+            }
+            if s.len() % 8 != 0 {
+                data.push(x);
+            }
+
+            Ast::Literal {
+                data,
+                bit_length,
+                position,
+            }
+        }
+    }
+
+    /// Creates an AST from a CMR literal lexeme
+    fn from_cmr_literal_lexeme(lexemes: &[&std::rc::Rc<Lexeme>]) -> Self {
+        assert_eq!(lexemes.len(), 1);
+        assert_eq!(lexemes[0].raw.len(), 65);
+
+        Ast::Cmr(AstCmr::Literal(
+            Cmr::from_str(&lexemes[0].raw[1..]).unwrap(),
+        ))
+    }
+
+    fn expect_arrow(&mut self) -> (Option<Type>, Option<Type>) {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Arrow(a, b) = replaced {
+            (a, b)
+        } else {
+            panic!("Expected arrow, got {:?}", self);
+        }
+    }
+
+    /// Checks that a given AST element is a dummy value
+    fn expect_position(&self) -> Position {
+        match self {
+            Ast::Combinator { position, .. } => *position,
+            Ast::Dummy { position } => *position,
+            Ast::Literal { position, .. } => *position,
+            Ast::Symbol { position, .. } => *position,
+            _ => panic!("Expected some element with position, got {:?}", self),
+        }
+    }
+
+    fn expect_cmr(&mut self) -> AstCmr<J> {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Cmr(cmr) = replaced {
+            cmr
+        } else {
+            panic!("Expected CMR, got {:?}", replaced);
+        }
+    }
+
+    fn expect_expression(&mut self) -> Expression<J> {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Expression(exp) = replaced {
+            exp
+        } else {
+            panic!("Expected expression, got {:?}", replaced);
+        }
+    }
+
+    fn expect_line(&mut self) -> Line<J> {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Line(ell) = replaced {
+            ell
+        } else {
+            panic!("Expected line, got {:?}", replaced);
+        }
+    }
+
+    fn expect_literal(&mut self) -> (Vec<u8>, usize, Position) {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Literal {
+            data,
+            bit_length,
+            position,
+        } = replaced
+        {
+            (data, bit_length, position)
+        } else {
+            panic!("Expected literal, got {:?}", replaced);
+        }
+    }
+
+    fn expect_program(&mut self) -> Vec<Line<J>> {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Program(lines) = replaced {
+            lines
+        } else {
+            panic!("Expected program, got {:?}", replaced);
+        }
+    }
+
+    fn expect_symbol(&mut self) -> (Arc<str>, Position) {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Symbol { value, position } = replaced {
+            (value, position)
+        } else {
+            panic!("Expected symbol, got {:?}", replaced);
+        }
+    }
+
+    /// Checks that a given AST element is a type, and returns it if so
+    ///
+    /// Replaces the original value with a dummy, on the assumption that
+    /// it lives in a vector and therefore can't be simply moved.
+    fn expect_type(&mut self) -> Option<Type> {
+        let replaced = mem::replace(self, Ast::Replaced);
+        if let Ast::Type(ty) = replaced {
+            ty
+        } else {
+            panic!("Expected type, got {:?}", replaced);
+        }
+    }
+}
+
+fn lexer_rules() -> LexerRules {
+    santiago::lexer_rules!(
+        // Base combinators and jets
+        "DEFAULT" | "CONST"  = string "const";
+        "DEFAULT" | "NULLARY" = pattern "unit|iden|witness|jet_[a-z0-9_]*";
+        "DEFAULT" | "UNARY"   = pattern "injl|injr|take|drop|disconnect";
+        "DEFAULT" | "BINARY"  = pattern "case|comp|pair";
+        // Assertions
+        "DEFAULT" | "ASSERTL" = string "assertl";
+        "DEFAULT" | "ASSERTR" = string "assertr";
+        "DEFAULT" | "FAIL" = string "fail";
+        // Literals
+        "DEFAULT" | "_" = string "_";
+        "DEFAULT" | "LITERAL" = pattern r"0b[01]+|0x[0-9a-f]+";
+
+        // Symbols (expression names). Essentially any alphanumeric that does not
+        // start with a numbera and isn't a reserved symbol (i.e. one of the above)
+        // patterns. Dash, underscore and dot are also allowed anywhere in a symbol.
+        "DEFAULT" | "SYMBOL" = pattern r"[a-zA-Z_\-.'][0-9a-zA-Z_\-.']*";
+
+        // Type/arrow symbols
+        "DEFAULT" | "(" = string "(";
+        "DEFAULT" | ")" = string ")";
+        "DEFAULT" | "+" = string "+";
+        "DEFAULT" | "*" = string "*";
+        "DEFAULT" | "->" = string "->";
+        "DEFAULT" | ":" = string ":";
+        "DEFAULT" | "1" = string "1";
+        "DEFAULT" | "2" = string "2";
+        "DEFAULT" | "2EXP" = pattern "2\\^[1-9][0-9]*";
+
+        // Assignment
+        "DEFAULT" | ":=" = string ":=";
+
+        // CMR
+        "DEFAULT" | "CMRLIT" = pattern "#[a-fA-F0-9]{64}";
+        "DEFAULT" | "#{" = string "#{";
+        "DEFAULT" | "}" = string "}";
+
+        // Comments (single-line comments only).
+        "DEFAULT" | "LINE_COMMENT" = pattern r"--.*\n" => |lexer| lexer.skip();
+
+        // No whitespace is significant except to separate other tokens.
+        "DEFAULT" | "WS" = pattern r"\s" => |lexer| lexer.skip();
+    )
+}
+
+fn grammar<J: Jet + 'static>() -> Grammar<Ast<J>> {
+    santiago::grammar!(
+        "program" => empty => |_| Ast::Program(vec![]);
+        "program" => rules "line" "program" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            let line = toks[0].expect_line();
+            let prog = toks[1].expect_program();
+
+            let mut new_prog = Vec::with_capacity(1 + prog.len());
+            new_prog.push(line);
+            new_prog.extend(prog);
+            Ast::Program(new_prog)
+        };
+
+        "line" => rules "symbol" ":" "arrow" => |mut toks| Ast::from_2(
+            &mut toks,
+            Ast::expect_symbol,
+            Ast::expect_arrow,
+            |symb, arrow| Ast::Line(Line {
+                position: symb.1,
+                name: symb.0,
+                expression: None,
+                arrow,
+            })
+        );
+        "line" => rules "symbol" ":=" "expr" => |mut toks| Ast::from_2(
+            &mut toks,
+            Ast::expect_symbol,
+            Ast::expect_expression,
+            |symb, expr| Ast::Line(Line {
+                position: symb.1,
+                name: symb.0,
+                expression: Some(expr),
+                arrow: (None, None),
+            })
+        );
+        "line" => rules "symbol" ":=" "expr" ":" "arrow" => |mut toks| Ast::from_3(
+            &mut toks,
+            Ast::expect_symbol,
+            Ast::expect_expression,
+            Ast::expect_arrow,
+            |symb, expr, arrow| Ast::Line(Line {
+                position: symb.1,
+                name: symb.0,
+                expression: Some(expr),
+                arrow,
+            }),
+        );
+
+        "arrow" => rules "type" "->" "type" => |mut toks| Ast::from_2(
+            &mut toks,
+            Ast::expect_type,
+            Ast::expect_type,
+            Ast::Arrow,
+        );
+
+        "expr" => rules "symbol" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            assert_eq!(toks.len(), 1);
+            if let Ast::Symbol { value, position } = mem::replace(&mut toks[0], Ast::Replaced) {
+                Ast::Expression(Expression::reference(value, position))
+            } else {
+                unreachable!("expected string, got something else")
+            }
+        };
+        "expr" => rules "(" "expr" ")" => |toks| toks[1].clone();
+        "expr" => rules "nullary" => Ast::from_combinator;
+        "expr" => rules "unary" "expr" => Ast::from_combinator;
+        "expr" => rules "binary" "expr" "expr" => Ast::from_combinator;
+
+        // TODO should we allow CMRs as literals for constant words?
+        "expr" => rules "const" "literal" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            assert_eq!(toks.len(), 2);
+            let (data, bit_length, position) = toks[1].expect_literal();
+            let mut iter = BitIter::from(data);
+
+            if bit_length.count_ones() != 1 || bit_length > 1 << 32 {
+                return Ast::Error(ErrorSet::single(
+                    position,
+                    Error::BadWordLength { bit_length },
+                ));
+            }
+            let ty = types::Type::two_two_n(bit_length.trailing_zeros() as usize)
+                .final_data()
+                .unwrap();
+            // unwrap ok here since literally every sequence of bits is a valid
+            // value for the given type
+            let value = iter.read_value(&ty).unwrap();
+            Ast::Expression(Expression {
+                inner: ExprInner::Inline(node::Inner::Word(Arc::new(value))),
+                position,
+            })
+        };
+
+        "expr" => rules "assertl" "expr" "cmr" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            assert_eq!(toks.len(), 3);
+            let exp1 = toks[1].expect_expression();
+            let cmr2 = toks[2].expect_cmr();
+            Ast::Expression(Expression {
+                inner: ExprInner::AssertL(Arc::new(exp1), cmr2),
+                position: toks[0].expect_position(),
+            })
+        };
+        "expr" => rules "assertr" "cmr" "expr" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            assert_eq!(toks.len(), 3);
+            let cmr1 = toks[1].expect_cmr();
+            let exp2 = toks[2].expect_expression();
+            Ast::Expression(Expression {
+                inner: ExprInner::AssertR(cmr1, Arc::new(exp2)),
+                position: toks[0].expect_position(),
+            })
+        };
+
+        "expr" => rules "fail" "literal" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            assert_eq!(toks.len(), 2);
+            let (value, bit_length, position) = toks[1].expect_literal();
+            if bit_length < 128 {
+                Ast::Error(ErrorSet::single(
+                    position,
+                    Error::EntropyInsufficient { bit_length },
+                ))
+            } else if bit_length > 512 {
+                Ast::Error(ErrorSet::single(
+                    position,
+                    Error::EntropyTooMuch { bit_length },
+                ))
+            } else {
+                let mut entropy = [0; 64];
+                entropy[..value.len()].copy_from_slice(&value[..]);
+                let entropy = FailEntropy::from_byte_array(entropy);
+                Ast::Expression(Expression {
+                    inner: ExprInner::Inline(node::Inner::Fail(entropy)),
+                    position,
+                })
+            }
+        };
+
+        "cmr" => rules "#{" "expr" "}" => |mut toks| {
+            if let Some(e) = propagate_errors(&toks) { return e; }
+            assert_eq!(toks.len(), 3);
+            let exp = toks[1].expect_expression();
+            Ast::Cmr(AstCmr::Expr(Arc::new(exp)))
+        };
+        "cmr" => rules "CMRLIT";
+
+
+        "type" => rules "symbol" => |mut toks| Ast::from_1(
+            &mut toks,
+            Ast::expect_symbol,
+            |name| {
+                if name.0.as_ref() == "_" {
+                    Ast::Type(None)
+                } else {
+                    // Type names are stored as Strings, but we normally use Arc<str>
+                    // in the parser. So we need to do an extra conversion.
+                    Ast::Type(Some(Type::Name(name.0.as_ref().to_owned())))
+                }
+            },
+        );
+        "type" => rules "1";
+        "type" => rules "2";
+        "type" => rules "2EXP";
+        "type" => rules "(" "type" ")" => |mut toks| Ast::from_1(
+            &mut toks[1..2],
+            Ast::expect_type,
+            Ast::Type,
+        );
+        "type" => rules "type" "+" "type" => |mut toks| Ast::from_2(
+            &mut toks,
+            Ast::expect_type,
+            Ast::expect_type,
+            |t1, t2| Ast::Type(t1.zip(t2).map(|(t1, t2)| Type::Sum(Box::new(t1), Box::new(t2)))),
+        );
+        "type" => rules "type" "*" "type" => |mut toks| Ast::from_2(
+            &mut toks,
+            Ast::expect_type,
+            Ast::expect_type,
+            |t1, t2| Ast::Type(t1.zip(t2).map(|(t1, t2)| Type::Product(Box::new(t1), Box::new(t2)))),
+        );
+
+        // Turn lexemes into rules
+        "nullary" => lexemes "NULLARY" => Ast::from_combinator_lexeme;
+        "unary" => lexemes "UNARY" => Ast::from_combinator_lexeme;
+        "binary" => lexemes "BINARY" => Ast::from_combinator_lexeme;
+        "const" => lexemes "CONST" => Ast::from_dummy_lexeme;
+        "assertl" => lexemes "ASSERTL" => Ast::from_combinator_lexeme;
+        "assertr" => lexemes "ASSERTR" => Ast::from_combinator_lexeme;
+        "fail" => lexemes "FAIL" => Ast::from_combinator_lexeme;
+
+        "literal" => lexemes "LITERAL" => Ast::from_literal_lexeme;
+        "literal" => lexemes "_" => Ast::from_literal_lexeme;
+
+        "#{" => lexemes "#{" => Ast::from_dummy_lexeme;
+        "}" => lexemes "}" => Ast::from_dummy_lexeme;
+        "CMRLIT" => lexemes "CMRLIT" => Ast::from_cmr_literal_lexeme;
+
+        "symbol" => lexemes "_" => |lexemes| {
+            assert_eq!(lexemes.len(), 1);
+            Ast::Symbol {
+                value: Arc::from(lexemes[0].raw.as_str()),
+                position: (&lexemes[0].position).into(),
+            }
+        };
+        "symbol" => lexemes "SYMBOL" => |lexemes| {
+            assert_eq!(lexemes.len(), 1);
+            Ast::Symbol {
+                value: Arc::from(lexemes[0].raw.as_str()),
+                position: (&lexemes[0].position).into(),
+            }
+        };
+
+        "(" => lexemes "(" => Ast::from_dummy_lexeme;
+        ")" => lexemes ")" => Ast::from_dummy_lexeme;
+        "+" => lexemes "+" => Ast::from_dummy_lexeme;
+        "*" => lexemes "*" => Ast::from_dummy_lexeme;
+        ":" => lexemes ":" => Ast::from_dummy_lexeme;
+        "->" => lexemes "->" => Ast::from_dummy_lexeme;
+
+        "1" => lexemes "1" => Ast::from_type_lexeme;
+        "2" => lexemes "2" => Ast::from_type_lexeme;
+        "2EXP" => lexemes "2EXP" => Ast::from_type_lexeme;
+
+        ":=" => lexemes ":=" => Ast::from_dummy_lexeme;
+
+        "#" => lexemes "#" => Ast::from_dummy_lexeme;
+
+        // Define associativity rules for type constructors
+        Associativity::Left => rules "+";
+        Associativity::Left => rules "*";
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::jet::Core;
+
+    #[test]
+    fn fixed_vectors() {
+        // Single line
+        parse_line_vector::<Core>("a := b").unwrap();
+        // Bad lex
+        parse_line_vector::<Core>("?P<").unwrap_err();
+        // Witness
+        parse_line_vector::<Core>("U := witness").unwrap();
+        // Name with type
+        parse_line_vector::<Core>("U : T -> 1").unwrap();
+        parse_line_vector::<Core>("U : 2 -> 1").unwrap();
+        parse_line_vector::<Core>("U : 2^2 -> 1").unwrap();
+        parse_line_vector::<Core>("U : 2^512 -> 1").unwrap();
+        parse_line_vector::<Core>("U : (2^512) -> 1").unwrap();
+        parse_line_vector::<Core>("U : (2^512 * 2^512) -> 1").unwrap();
+        parse_line_vector::<Core>("U : 1 -> (2^512 * 2^512)").unwrap();
+        // Witness with type and expression
+        parse_line_vector::<Core>("U := witness : 1 -> 1").unwrap();
+        parse_line_vector::<Core>("U := witness : _ -> 1").unwrap();
+        parse_line_vector::<Core>("U := witness : 1 -> _").unwrap();
+        parse_line_vector::<Core>("U := witness : _ -> _").unwrap();
+        // Case with nested unit
+        parse_line_vector::<Core>("ABC := case unit injl DEF").unwrap();
+        // word hex
+        parse_line_vector::<Core>("U := const 0xabcd").unwrap();
+        // word bin
+        parse_line_vector::<Core>("U := const 0b0101001011111000").unwrap();
+
+        // asserts
+        parse_line_vector::<Core>(
+            "U := assertl unit #abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+        )
+        .unwrap();
+        parse_line_vector::<Core>("U := assertl unit #{comp iden iden}").unwrap();
+        parse_line_vector::<Core>(
+            "U := assertr #abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234 unit",
+        )
+        .unwrap();
+        parse_line_vector::<Core>("U := assertr #{comp iden iden} unit").unwrap();
+    }
+
+    #[test]
+    fn simple_program() {
+        parse_line_vector::<Core>(
+            "
+            v2 := unit : B -> 1                -- 62274a89
+            v1 := pair v2 v2 : B -> (1 * 1)    -- 822d5a17
+        ",
+        )
+        .unwrap();
+    }
+}

--- a/src/human_encoding/parse/mod.rs
+++ b/src/human_encoding/parse/mod.rs
@@ -1,0 +1,628 @@
+// Simplicity "Human-Readable" Language
+// Written in 2023 by
+//   Andrew Poelstra <simplicity@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Parsing
+
+mod ast;
+
+use crate::dag::{Dag, DagLike, InternalSharing};
+use crate::jet::Jet;
+use crate::node::{self, NoDisconnect, NoWitness};
+use crate::types::Type;
+use crate::Cmr;
+use std::collections::HashMap;
+use std::mem;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use super::named_node::{NamedCommitNode, NamedConstructNode, Namer};
+use super::Position;
+
+use super::{Error, ErrorSet};
+
+#[derive(Clone)]
+struct UnresolvedExpression<J: Jet> {
+    inner: UnresolvedInner<J>,
+    position: Position,
+}
+
+impl<J: Jet> UnresolvedExpression<J> {
+    fn from_name(name: Arc<str>, position: Position) -> Self {
+        UnresolvedExpression {
+            inner: UnresolvedInner::NoExpr {
+                name,
+                user_source_types: vec![],
+                user_target_types: vec![],
+            },
+            position,
+        }
+    }
+
+    fn from_inline_expression(expr_inner: ast::ExprInner<J>, position: Position) -> Self {
+        UnresolvedExpression {
+            inner: UnresolvedInner::Inline { expr_inner },
+            position,
+        }
+    }
+
+    fn add_expression(
+        &mut self,
+        expr_inner: ast::ExprInner<J>,
+        position: Position,
+    ) -> Result<(), ErrorSet> {
+        match self.inner {
+            UnresolvedInner::NoExpr {
+                ref name,
+                ref mut user_source_types,
+                ref mut user_target_types,
+            } => {
+                self.inner = UnresolvedInner::Named {
+                    name: Arc::clone(name),
+                    user_source_types: mem::take(user_source_types),
+                    user_target_types: mem::take(user_target_types),
+                    expr_inner,
+                };
+                Ok(())
+            }
+            UnresolvedInner::Inline { .. } => unreachable!(),
+            UnresolvedInner::Named { ref name, .. } => Err(ErrorSet::single(
+                position,
+                Error::NameRepeated(Arc::clone(name)),
+            )),
+        }
+    }
+
+    fn add_source_type(&mut self, ty: Type) {
+        match self.inner {
+            UnresolvedInner::NoExpr {
+                ref mut user_source_types,
+                ..
+            } => {
+                user_source_types.push(ty);
+            }
+            UnresolvedInner::Inline { .. } => unreachable!(),
+            UnresolvedInner::Named {
+                ref mut user_source_types,
+                ..
+            } => {
+                user_source_types.push(ty);
+            }
+        }
+    }
+
+    fn add_target_type(&mut self, ty: Type) {
+        match self.inner {
+            UnresolvedInner::NoExpr {
+                ref mut user_target_types,
+                ..
+            } => {
+                user_target_types.push(ty);
+            }
+            UnresolvedInner::Inline { .. } => unreachable!(),
+            UnresolvedInner::Named {
+                ref mut user_target_types,
+                ..
+            } => {
+                user_target_types.push(ty);
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+enum UnresolvedInner<J: Jet> {
+    NoExpr {
+        name: Arc<str>,
+        user_source_types: Vec<Type>,
+        user_target_types: Vec<Type>,
+    },
+    Inline {
+        expr_inner: ast::ExprInner<J>,
+    },
+    Named {
+        name: Arc<str>,
+        user_source_types: Vec<Type>,
+        user_target_types: Vec<Type>,
+        expr_inner: ast::ExprInner<J>,
+    },
+}
+
+struct ResolvedExpression<J: Jet> {
+    inner: ResolvedInner<J>,
+    position: Position,
+
+    name: Option<Arc<str>>,
+    user_source_types: Arc<[Type]>,
+    user_target_types: Arc<[Type]>,
+
+    in_degree: AtomicUsize,
+}
+
+enum ResolvedCmr<J: Jet> {
+    Expr(Arc<ResolvedExpression<J>>),
+    Literal(Cmr),
+}
+
+enum ResolvedInner<J: Jet> {
+    /// A reference to a missing expression
+    Missing { name: Arc<str> },
+    /// A reference to a name with no associated expression
+    NoExpr { name: Arc<str> },
+    /// A reference to another expression
+    Reference(Arc<ResolvedExpression<J>>),
+    /// A left assertion (referring to the CMR of an expression on the right)
+    AssertL(Arc<ResolvedExpression<J>>, ResolvedCmr<J>),
+    /// A right assertion (referring to the CMR of an expression on the left)
+    AssertR(ResolvedCmr<J>, Arc<ResolvedExpression<J>>),
+    /// An inline expression
+    Inline(node::Inner<Arc<ResolvedExpression<J>>, J, NoDisconnect, NoWitness>),
+}
+
+pub fn parse<J: Jet + 'static>(
+    program: &str,
+) -> Result<HashMap<Arc<str>, Arc<NamedCommitNode<J>>>, ErrorSet> {
+    let mut errors = ErrorSet::new();
+
+    // **
+    // Step 1: Read expressions into HashMap, checking for dupes and illegal names.
+    // **
+    let mut unresolved_map = HashMap::<Arc<str>, UnresolvedExpression<J>>::new();
+    for line in ast::parse_line_vector(program)? {
+        if line.name.as_ref() == "_" || line.name.starts_with("prim") {
+            errors.add(line.position, Error::NameIllegal(Arc::clone(&line.name)));
+            continue;
+        }
+
+        let entry =
+            unresolved_map
+                .entry(line.name.clone())
+                .or_insert(UnresolvedExpression::from_name(
+                    Arc::clone(&line.name),
+                    line.position,
+                ));
+
+        if let Some(expr) = line.expression {
+            if let Err(eset) = entry.add_expression(expr.inner, expr.position) {
+                errors.merge(&eset)
+            }
+        }
+        if let Some(ty) = line.arrow.0 {
+            entry.add_source_type(ty.reify());
+        }
+        if let Some(ty) = line.arrow.1 {
+            entry.add_target_type(ty.reify());
+        }
+    }
+
+    // **
+    // Step 2: Resolve every name.
+    // We need to manually recurse rather than using `dag::PostOrderIter` because
+    // we may have multiple disconnected components.
+    // **
+    let mut resolved_map =
+        HashMap::<Arc<str>, Arc<ResolvedExpression<J>>>::with_capacity(unresolved_map.len());
+
+    while let Some(name) = unresolved_map.keys().next() {
+        let name = Arc::clone(name);
+        let expr = unresolved_map.remove(&name).unwrap();
+
+        #[derive(Clone)]
+        struct StackItem<J: Jet> {
+            expr: UnresolvedExpression<J>,
+            name: Option<Arc<str>>,
+            done_children: bool,
+        }
+
+        // Stack of unresolved entries, which are named expressions from `resolved_map`
+        // as well as children of those named expressions (which themselves may be
+        // either named or inline).
+        let mut stack = vec![];
+        // Stack of resolved inline entries. Somewhat confusingly, when resolving inline
+        // expressions, we put them on the stack and use some careful accounting to make
+        // sure that they're popped in the right place. When resolving named expressions,
+        // we just stick the result into `resolved_map` and later refer to it by name.
+        //
+        // The reason we need to do both is that we are working with a "DAG forest" where
+        // named expressions may be accessible from multiple roots. This means that when
+        // we encounter a named expression, that expression might've already been resolved,
+        // and there is no "intrinsic" way to distinguish these cases. So tracking state
+        // using a stack would be pretty complicated.
+        //
+        // On the other hand, inline expressions do not have names or any other identifying
+        // characteristics except the order in which they appear. So for these we need to
+        // use the `inline_stack` to keep track of which ones we've already resolved..
+        let mut inline_stack: Vec<Arc<ResolvedExpression<J>>> = vec![];
+        stack.push(StackItem {
+            expr,
+            name: Some(Arc::clone(&name)),
+            done_children: false,
+        });
+
+        while let Some(mut stack_item) = stack.pop() {
+            // First, recurse on any children
+            if !stack_item.done_children {
+                stack_item.done_children = true;
+                stack.push(stack_item.clone());
+
+                let push_ast_expr = |stack: &mut Vec<_>, expr: &ast::Expression<_>| {
+                    stack.push(StackItem {
+                        expr: UnresolvedExpression::from_inline_expression(
+                            expr.inner.clone(),
+                            expr.position,
+                        ),
+                        name: None,
+                        done_children: false,
+                    })
+                };
+
+                match stack_item.expr.inner {
+                    UnresolvedInner::NoExpr { .. } => {}
+                    UnresolvedInner::Inline { ref expr_inner, .. }
+                    | UnresolvedInner::Named { ref expr_inner, .. } => match expr_inner {
+                        ast::ExprInner::Reference(ref ref_name) => {
+                            if let Some(child) = unresolved_map.remove(ref_name) {
+                                stack.push(StackItem {
+                                    expr: child,
+                                    name: Some(Arc::clone(ref_name)),
+                                    done_children: false,
+                                });
+                            }
+                        }
+                        ast::ExprInner::AssertL(ref left, ref cmr) => {
+                            push_ast_expr(&mut stack, left);
+                            if let ast::AstCmr::Expr(ref right) = cmr {
+                                push_ast_expr(&mut stack, right);
+                            }
+                        }
+                        ast::ExprInner::AssertR(ref cmr, ref right) => {
+                            if let ast::AstCmr::Expr(ref left) = cmr {
+                                push_ast_expr(&mut stack, left);
+                            }
+                            push_ast_expr(&mut stack, right);
+                        }
+                        ast::ExprInner::Inline(ref inner) => match inner.as_dag() {
+                            Dag::Nullary => {}
+                            Dag::Unary(child) => push_ast_expr(&mut stack, child),
+                            Dag::Binary(left, right) => {
+                                push_ast_expr(&mut stack, left);
+                                push_ast_expr(&mut stack, right);
+                            }
+                        },
+                    },
+                }
+                continue;
+            }
+
+            let mut convert_expr_inner = |expr_inner: &ast::ExprInner<J>| match expr_inner {
+                ast::ExprInner::Reference(ref ref_name) => {
+                    if let Some(referent) = resolved_map.get(ref_name) {
+                        referent.in_degree.fetch_add(1, Ordering::SeqCst);
+                        ResolvedInner::Reference(Arc::clone(referent))
+                    } else {
+                        ResolvedInner::Missing {
+                            name: Arc::clone(ref_name),
+                        }
+                    }
+                }
+                ast::ExprInner::AssertL(_, ref cmr) => {
+                    let left = inline_stack.pop().unwrap();
+                    left.in_degree.fetch_add(1, Ordering::SeqCst);
+
+                    let right = match cmr {
+                        ast::AstCmr::Expr(..) => {
+                            let right = inline_stack.pop().unwrap();
+                            right.in_degree.fetch_add(1, Ordering::SeqCst);
+                            ResolvedCmr::Expr(right)
+                        }
+                        ast::AstCmr::Literal(cmr) => ResolvedCmr::Literal(*cmr),
+                    };
+                    ResolvedInner::AssertL(left, right)
+                }
+                ast::ExprInner::AssertR(ref cmr, _) => {
+                    let left = match cmr {
+                        ast::AstCmr::Expr(..) => {
+                            let left = inline_stack.pop().unwrap();
+                            left.in_degree.fetch_add(1, Ordering::SeqCst);
+                            ResolvedCmr::Expr(left)
+                        }
+                        ast::AstCmr::Literal(cmr) => ResolvedCmr::Literal(*cmr),
+                    };
+
+                    let right = inline_stack.pop().unwrap();
+                    right.in_degree.fetch_add(1, Ordering::SeqCst);
+                    ResolvedInner::AssertR(left, right)
+                }
+                ast::ExprInner::Inline(ref inner) => ResolvedInner::Inline(
+                    inner
+                        .as_ref()
+                        .map(|_| {
+                            let child = inline_stack.pop().unwrap();
+                            child.in_degree.fetch_add(1, Ordering::SeqCst);
+                            child
+                        })
+                        .copy_disconnect()
+                        .copy_witness(),
+                ),
+            };
+
+            // Then, convert the node. At this point if we are missing any children
+            // it is because there was a resolution error, i.e. the expression
+            // references a child that doesn't exist.
+            let resolved: ResolvedExpression<J> = match stack_item.expr.inner {
+                UnresolvedInner::NoExpr {
+                    ref name,
+                    ref user_source_types,
+                    ref user_target_types,
+                } => ResolvedExpression {
+                    inner: ResolvedInner::NoExpr {
+                        name: Arc::clone(name),
+                    },
+                    position: stack_item.expr.position,
+                    name: Some(Arc::clone(name)),
+                    user_source_types: Arc::from(&user_source_types[..]),
+                    user_target_types: Arc::from(&user_target_types[..]),
+                    in_degree: AtomicUsize::new(0),
+                },
+                UnresolvedInner::Inline { ref expr_inner } => ResolvedExpression {
+                    inner: convert_expr_inner(expr_inner),
+                    position: stack_item.expr.position,
+                    name: None,
+                    user_source_types: Arc::from([]),
+                    user_target_types: Arc::from([]),
+                    in_degree: AtomicUsize::new(0),
+                },
+                UnresolvedInner::Named {
+                    ref expr_inner,
+                    ref name,
+                    ref user_source_types,
+                    ref user_target_types,
+                } => ResolvedExpression {
+                    inner: convert_expr_inner(expr_inner),
+                    position: stack_item.expr.position,
+                    name: Some(Arc::clone(name)),
+                    user_source_types: Arc::from(&user_source_types[..]),
+                    user_target_types: Arc::from(&user_target_types[..]),
+                    in_degree: AtomicUsize::new(0),
+                },
+            };
+
+            if let Some(name) = stack_item.name {
+                resolved_map.insert(name, Arc::new(resolved));
+            } else {
+                inline_stack.push(Arc::new(resolved));
+            }
+        }
+        assert!(inline_stack.is_empty());
+    }
+    drop(unresolved_map);
+
+    // ** Step 3: convert each DAG of names/expressions into a DAG of NamedNodes.
+    impl<'a, J: Jet> DagLike for &'a ResolvedExpression<J> {
+        type Node = ResolvedExpression<J>;
+        fn data(&self) -> &ResolvedExpression<J> {
+            self
+        }
+
+        fn as_dag_node(&self) -> Dag<Self> {
+            match self.inner {
+                ResolvedInner::Missing { .. } | ResolvedInner::NoExpr { .. } => Dag::Nullary,
+                ResolvedInner::Reference(ref child) => Dag::Unary(child),
+                ResolvedInner::AssertL(ref left, ResolvedCmr::Expr(ref right))
+                | ResolvedInner::AssertR(ResolvedCmr::Expr(ref left), ref right) => {
+                    Dag::Binary(left, right)
+                }
+                ResolvedInner::AssertL(ref child, ResolvedCmr::Literal(..))
+                | ResolvedInner::AssertR(ResolvedCmr::Literal(..), ref child) => Dag::Unary(child),
+                ResolvedInner::Inline(ref inner) => inner.as_dag().map(|node| &**node),
+            }
+        }
+    }
+
+    let mut roots = HashMap::<Arc<str>, Arc<NamedCommitNode<J>>>::new();
+    for (name, expr) in &resolved_map {
+        if expr.in_degree.load(Ordering::SeqCst) > 0 {
+            continue;
+        }
+
+        let mut namer = Namer::new();
+        let mut converted: Vec<Option<Arc<NamedConstructNode<J>>>> = vec![];
+        for data in expr.as_ref().post_order_iter::<InternalSharing>() {
+            let left = data
+                .left_index
+                .and_then(|idx| converted[idx].as_ref().map(Arc::clone));
+            let right = data
+                .right_index
+                .and_then(|idx| converted[idx].as_ref().map(Arc::clone));
+
+            let maybe_inner = match data.node.inner {
+                ResolvedInner::Missing { ref name, .. } => {
+                    errors.add(data.node.position, Error::NameMissing(Arc::clone(name)));
+                    None
+                }
+                ResolvedInner::NoExpr { ref name, .. } => {
+                    errors.add(data.node.position, Error::NameIncomplete(Arc::clone(name)));
+                    None
+                }
+                ResolvedInner::Reference(..) => {
+                    converted.push(left);
+                    continue;
+                }
+                ResolvedInner::AssertL(..) => left.zip(right).map(|(left, right)| {
+                    let cmr = right.cmr();
+                    node::Inner::AssertL(left, cmr)
+                }),
+                ResolvedInner::AssertR(..) => left.zip(right).map(|(left, right)| {
+                    let cmr = left.cmr();
+                    node::Inner::AssertR(cmr, right)
+                }),
+                ResolvedInner::Inline(ref inner) => inner
+                    .as_ref()
+                    .map_left_right(|_| left, |_| right)
+                    .copy_disconnect()
+                    .copy_witness()
+                    .transpose(),
+            };
+
+            let inner = match maybe_inner {
+                Some(inner) => inner,
+                None => {
+                    converted.push(None);
+                    continue;
+                }
+            };
+
+            let name = data
+                .node
+                .name
+                .as_ref()
+                .map(Arc::clone)
+                .unwrap_or_else(|| Arc::from(namer.assign_name(inner.as_ref()).as_str()));
+
+            let node = NamedConstructNode::new(
+                Arc::clone(&name),
+                data.node.position,
+                Arc::clone(&data.node.user_source_types),
+                Arc::clone(&data.node.user_target_types),
+                inner,
+            );
+
+            match node {
+                Ok(node) => {
+                    let node = Arc::new(node);
+                    converted.push(Some(node));
+                }
+                Err(e) => {
+                    errors.add(data.node.position, e);
+                    converted.push(None);
+                }
+            }
+        }
+
+        if let Some(Some(root)) = converted.pop() {
+            let finalized = if &**name == "main" {
+                root.finalize_types_main()
+            } else {
+                root.finalize_types_non_main()
+            };
+
+            match finalized {
+                Ok(root) => {
+                    roots.insert(Arc::clone(name), root);
+                }
+                Err(errs) => errors.merge(&errs),
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(roots)
+    } else {
+        Err(errors)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::jet::{Core, Jet};
+
+    fn assert_single_cmr<J: Jet>(s: &str, cmr: &str) {
+        match parse::<J>(s) {
+            Ok(forest) => {
+                assert_eq!(forest.len(), 1);
+                let main = &forest["main"];
+                assert_eq!(main.cmr().to_string(), cmr);
+            }
+            Err(errs) => {
+                println!("\nErrors:\n{}", errs);
+                panic!("Failed to parse program:\n{}", s);
+            }
+        }
+    }
+
+    fn error_contains<T>(res: Result<T, ErrorSet>, s: &str) {
+        match res {
+            Ok(_) => panic!("expected error, but result was Ok"),
+            Err(errs) => {
+                let e_msg = errs.to_string();
+                assert!(
+                    e_msg.contains(s),
+                    "Did not find search string {} in error string: {}",
+                    s,
+                    e_msg,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn errors() {
+        error_contains(
+            parse::<Core>("main := a"),
+            "name `a` is referred to but does not exist",
+        );
+        error_contains(
+            parse::<Core>("main := unit : 1 -> 2"),
+            "failed to apply bound `2` to existing bound `1`",
+        );
+        error_contains(
+            parse::<Core>("main := pair unit unit"),
+            "failed to apply bound `1 × 1` to existing bound `1`",
+        );
+    }
+
+    #[test]
+    fn simple_program() {
+        assert_single_cmr::<Core>(
+            "main := unit",
+            "62274a89833ece8ba5ff57b28118c0063d3d4a85dd25aae06f87617604402715",
+        );
+
+        assert_single_cmr::<Core>(
+            "
+                wit1 := witness : 1 -> 2^32
+                wit2 := witness : 1 -> 2^32
+
+                wits_are_equal := comp (pair wit1 wit2) jet_eq_32 : 1 -> 2
+                main := comp wits_are_equal jet_verify            : 1 -> 1
+            ",
+            "e552742731de7f5c3c83cd54176c0ca6acf6dbd3c37bef7da132eb06f3856d06",
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "elements")]
+    fn bip340_program() {
+        use crate::jet::Elements;
+
+        parse::<Elements>("main := unit").unwrap();
+
+        assert_single_cmr::<Elements>("
+                -- Witnesses
+                wit1 := witness : 1 -> 2^512
+
+                -- Constants
+                const1 := const 0xf9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90000000000000000000000000000000000000000000000000000000000000000 : 1 -> 2^512 -- ef40cb78
+
+                -- Program code
+                pr1 := pair const1 wit1    : 1 -> (2^512 * 2^512) -- 8080ed5e
+                jt2 := jet_bip_0340_verify : (2^512 * 2^512) -> 1 -- af924cbe
+
+                main := comp pr1 jt2       : 1 -> 1               -- 3f6422da
+            ",
+            "3f6422da75bf12565329872840d33adacbb49d49f2285a9f7133b79e034d8899",
+        );
+    }
+}

--- a/src/human_encoding/parse/mod.rs
+++ b/src/human_encoding/parse/mod.rs
@@ -641,6 +641,14 @@ mod tests {
     }
 
     #[test]
+    fn circular_program() {
+        error_contains(
+            parse::<Core>("main := comp main unit"),
+            "name `main` is referred to but does not exist",
+        );
+    }
+
+    #[test]
     #[cfg(feature = "elements")]
     fn bip340_program() {
         use crate::jet::Elements;


### PR DESCRIPTION
This uses the `santiago` parser generator, which requires rustc 1.58. Bump the MSRV to 1.58, though we will revert this later when we replace the generated parser with a more efficient ad-hoc one.

Since #152 added serialization, parsing gives us the ability to round-trip. So update many unit tests and add a fuzz test to test this.