### PR TITLE
Introduce typed holes; improve disconnect support in human-readable encoding

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,6 +19,7 @@ jobs:
 c_rust_merkle,
 decode_natural,
 decode_program,
+parse_human,
         ]
     steps:
       - name: Install test dependencies

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -27,3 +27,7 @@ path = "fuzz_targets/decode_natural.rs"
 [[bin]]
 name = "decode_program"
 path = "fuzz_targets/decode_program.rs"
+
+[[bin]]
+name = "parse_human"
+path = "fuzz_targets/parse_human.rs"

--- a/fuzz/fuzz_targets/parse_human.rs
+++ b/fuzz/fuzz_targets/parse_human.rs
@@ -1,0 +1,66 @@
+// Rust Simplicity Library
+// Written in 2023 by
+//   Andrew Poelstra <apoelstra@blockstream.com>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use std::str;
+use honggfuzz::fuzz;
+use simplicity::jet::Elements;
+use simplicity::human_encoding::Forest;
+
+fn do_test(data: &[u8]) {
+    let s = match str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    if let Ok(program) = Forest::<Elements>::parse(s) {
+        let reserialize= program.string_serialize();
+        let round_trip = Forest::<Elements>::parse(&reserialize).unwrap();
+        assert_eq!(program, round_trip);
+    }
+}
+
+fn main() {
+    loop {
+        fuzz!(|data| {
+            do_test(data);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn extend_vec_from_hex(hex: &str, out: &mut Vec<u8>) {
+        let mut b = 0;
+        for (idx, c) in hex.as_bytes().iter().enumerate() {
+            b <<= 4;
+            match *c {
+                b'A'..=b'F' => b |= c - b'A' + 10,
+                b'a'..=b'f' => b |= c - b'a' + 10,
+                b'0'..=b'9' => b |= c - b'0',
+                _ => panic!("Bad hex"),
+            }
+            if (idx & 1) == 1 {
+                out.push(b);
+                b = 0;
+            }
+        }
+    }
+
+    #[test]
+    fn duplicate_crash() {
+        let mut a = Vec::new();
+        extend_vec_from_hex("00", &mut a);
+        super::do_test(&a);
+    }
+}

--- a/simpcli/example_programs/bip340.simpl
+++ b/simpcli/example_programs/bip340.simpl
@@ -1,0 +1,12 @@
+-- Witnesses
+sig1 := witness : 1 -> 2^512
+
+-- Constants
+const1 := const 0xf9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f90000000000000000000000000000000000000000000000000000000000000000 : 1 -> 2^512 -- f254d6e9
+
+-- Program code
+pr1 := pair const1 sig1  : 1 -> (2^512 * 2^512)   -- 31ae2960
+jt2 := jet_bip_0340_verify : (2^512 * 2^512) -> 1 -- af924cbe
+
+main := comp pr1 jt2       : 1 -> 1               -- 7bc56cb1
+

--- a/simpcli/example_programs/eq-plus-one.simpl
+++ b/simpcli/example_programs/eq-plus-one.simpl
@@ -1,0 +1,8 @@
+-- Program which demands two 32-bit witnesses, the first one == the second + 1
+wit1 := comp iden witness : 1 -> 2^32
+wit2 := comp iden witness : 1 -> 2^32
+
+wit_diff := comp (comp (pair wit1 wit2) jet_subtract_32) (drop iden) : 1 -> 2^32
+diff_is_one := comp (pair wit_diff jet_one_32) jet_eq_32             : 1 -> 2
+main := comp diff_is_one jet_verify                                  : 1 -> 1
+

--- a/simpcli/example_programs/fixpoint.simpl
+++ b/simpcli/example_programs/fixpoint.simpl
@@ -1,0 +1,32 @@
+
+-- Witnesses
+-- IMR: [none]
+wit_input := witness
+
+-- All jets have source type 1; but to use the `pair` combinator we want one
+-- with source type 2^256. To get this, we compose it with unit.
+sha256_init : 2^256 -> _
+sha256_init := comp unit jet_sha_256_ctx_8_init
+
+-- Using this, we can write a self-contained "take 32 bytes and compute their
+-- sha2 hash" function.
+-- IMR: 8e341445...
+sha256 : 2^256 -> 2^256
+sha256 := comp
+    comp
+        pair sha256_init iden
+        jet_sha_256_ctx_8_add_32
+    jet_sha_256_ctx_8_finalize
+
+-- Check eq
+assert_fixpoint : 2^256 -> 1
+assert_fixpoint := comp
+    comp
+        pair (comp iden sha256) iden
+        jet_eq_256
+    jet_verify
+
+-- IMR: [none]
+main := comp wit_input assert_fixpoint
+
+

--- a/simpcli/example_programs/twowit.simpl
+++ b/simpcli/example_programs/twowit.simpl
@@ -1,0 +1,14 @@
+--
+-- Attempts to reuse a witness name.
+--
+-- By uncommenting wit2 and replacing one of the wit1 references with wit2,
+-- it'll work...but is it what you intended?
+--
+
+wit1 := witness : 1 -> 2^32
+--wit2 := witness : 1 -> 2^32
+wit_tuple := pair wit1 wit1 : 1 -> 2^64
+
+check_eq := comp wit_tuple jet_eq_32
+main := comp check_eq jet_verify
+

--- a/simpcli/src/main.rs
+++ b/simpcli/src/main.rs
@@ -29,6 +29,7 @@ fn usage(process_name: &str) {
     eprintln!("Usage:");
     eprintln!("  {} assemble <filename>", process_name);
     eprintln!("  {} disassemble <base64>", process_name);
+    eprintln!("  {} relabel <base64>", process_name);
     eprintln!();
     eprintln!("For commands which take an optional expression, the default value is \"main\".");
     eprintln!();
@@ -43,6 +44,7 @@ fn invalid_usage(process_name: &str) -> Result<(), String> {
 enum Command {
     Assemble,
     Disassemble,
+    Relabel,
     Help,
 }
 
@@ -52,6 +54,7 @@ impl FromStr for Command {
         match s {
             "assemble" => Ok(Command::Assemble),
             "disassemble" => Ok(Command::Disassemble),
+            "relabel" => Ok(Command::Relabel),
             "help" => Ok(Command::Help),
             x => Err(format!("unknown command {}", x)),
         }
@@ -63,6 +66,7 @@ impl Command {
         match *self {
             Command::Assemble => false,
             Command::Disassemble => false,
+            Command::Relabel => false,
             Command::Help => false,
         }
     }
@@ -151,6 +155,10 @@ fn main() -> Result<(), String> {
             let commit = CommitNode::decode(&mut iter)
                 .map_err(|e| format!("failed to decode program: {}", e))?;
             let prog = Forest::<DefaultJet>::from_program(commit);
+            println!("{}", prog.string_serialize());
+        }
+        Command::Relabel => {
+            let prog = parse_file(&first_arg)?;
             println!("{}", prog.string_serialize());
         }
         Command::Help => unreachable!(),

--- a/src/human_encoding/error.rs
+++ b/src/human_encoding/error.rs
@@ -172,6 +172,7 @@ impl error::Error for ErrorSet {
             Error::EntropyInsufficient { .. } => None,
             Error::EntropyTooMuch { .. } => None,
             Error::HoleAtCommitTime { .. } => None,
+            Error::HoleFilledAtCommitTime => None,
             Error::NameIllegal(_) => None,
             Error::NameIncomplete(_) => None,
             Error::NameMissing(_) => None,
@@ -250,6 +251,9 @@ pub enum Error {
         name: Arc<str>,
         arrow: types::arrow::Arrow,
     },
+    /// When converting to a `CommitNode`, a disconnect node had an actual node rather
+    /// than a hole.
+    HoleFilledAtCommitTime,
     /// An expression name was not allowed to be used as a name.
     NameIllegal(Arc<str>),
     /// An expression was given a type, but no actual expression was provided.
@@ -310,6 +314,9 @@ impl fmt::Display for Error {
                 "unfilled hole ?{} at commitment time; type arrow {}",
                 name, arrow
             ),
+            Error::HoleFilledAtCommitTime => {
+                f.write_str("disconnect node has a non-hole child at commit time")
+            }
             Error::NameIllegal(ref s) => {
                 write!(f, "name `{}` is not allowed in this context", s)
             }

--- a/src/human_encoding/error.rs
+++ b/src/human_encoding/error.rs
@@ -171,6 +171,7 @@ impl error::Error for ErrorSet {
             Error::BadWordLength { .. } => None,
             Error::EntropyInsufficient { .. } => None,
             Error::EntropyTooMuch { .. } => None,
+            Error::HoleAtCommitTime { .. } => None,
             Error::NameIllegal(_) => None,
             Error::NameIncomplete(_) => None,
             Error::NameMissing(_) => None,
@@ -243,6 +244,12 @@ pub enum Error {
     EntropyInsufficient { bit_length: usize },
     /// A "fail" node was provided with more than 512 bits of entropy
     EntropyTooMuch { bit_length: usize },
+    /// When converting to a `CommitNode`, there were unfilled holes which prevent
+    /// us from knowing the whole program.
+    HoleAtCommitTime {
+        name: Arc<str>,
+        arrow: types::arrow::Arrow,
+    },
     /// An expression name was not allowed to be used as a name.
     NameIllegal(Arc<str>),
     /// An expression was given a type, but no actual expression was provided.
@@ -294,6 +301,14 @@ impl fmt::Display for Error {
                 f,
                 "fail node has too much entropy ({} bits, max 512)",
                 bit_length
+            ),
+            Error::HoleAtCommitTime {
+                ref name,
+                ref arrow,
+            } => write!(
+                f,
+                "unfilled hole ?{} at commitment time; type arrow {}",
+                name, arrow
             ),
             Error::NameIllegal(ref s) => {
                 write!(f, "name `{}` is not allowed in this context", s)

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -141,6 +141,7 @@ impl<J: Jet> Forest<J> {
         let mut witness_lines = vec![];
         let mut const_lines = vec![];
         let mut program_lines = vec![];
+        let mut disc_idx = 0;
         // Pass 1: compute string data for every node
         for root in self.roots.values() {
             for data in root.as_ref().post_order_iter::<MaxSharing<_>>() {
@@ -165,6 +166,9 @@ impl<J: Jet> Forest<J> {
                 } else if let node::Inner::AssertL(_, cmr) = node.inner() {
                     expr_str.push_str(" #");
                     expr_str.push_str(&cmr.to_string());
+                } else if let node::Inner::Disconnect(_, node::NoDisconnect) = node.inner() {
+                    expr_str.push_str(&format!(" ?disc_expr_{}", disc_idx));
+                    disc_idx += 1;
                 }
 
                 let arrow = node.arrow();

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -66,6 +66,30 @@ impl From<santiago::lexer::Position> for Position {
     }
 }
 
+/// For named construct nodes, we abuse the `witness` combinator to support typed holes.
+///
+/// We do this because `witness` nodes have free source and target arrows, and
+/// allow us to store arbitrary data in them using the generic witness type of
+/// the node. Holes are characterized entirely by their source and target type,
+/// just like witnesses, and are labelled by their name.
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum WitnessOrHole {
+    /// This witness is an actual witness combinator (with no witness data attached,
+    /// that comes later)
+    Witness,
+    /// This is a typed hole, with the given name.
+    TypedHole(Arc<str>),
+}
+
+impl WitnessOrHole {
+    pub fn shallow_clone(&self) -> Self {
+        match self {
+            WitnessOrHole::Witness => WitnessOrHole::Witness,
+            WitnessOrHole::TypedHole(name) => WitnessOrHole::TypedHole(Arc::clone(name)),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Forest<J: Jet> {
     roots: HashMap<Arc<str>, Arc<NamedCommitNode<J>>>,

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -175,11 +175,13 @@ impl<J: Jet> Forest<J> {
                 let arrow_str = format!(": {} -> {}", arrow.source, arrow.target).replace('×', "*"); // for human-readable encoding stick with ASCII
 
                 // All witnesses have the same CMR so don't bother printing it
-                let cmr_str = if let node::Inner::Witness(..) = node.inner() {
+                let cmr_str = /*if let node::Inner::Witness(..) = node.inner() {
                     String::new()
-                } else {
-                    format!("-- cmr {:.8}...", node.cmr())
-                };
+                } else { */
+                    format!("-- cmr {}...", node.cmr())
+                    + &format!("  -- imr {}...", node.imr().as_ref().map(ToString::to_string).unwrap_or("???".to_string()))
+//                };
+;
 
                 let print = Print {
                     expr_str,

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -22,7 +22,7 @@ use crate::node::{self, Commit, CommitData, CommitNode, Converter, NoDisconnect,
 use crate::node::{Construct, ConstructData, Constructible};
 use crate::types;
 use crate::types::arrow::{Arrow, FinalArrow};
-use crate::{BitWriter, Cmr};
+use crate::{BitWriter, Cmr, Imr};
 
 use std::io;
 use std::marker::PhantomData;
@@ -68,6 +68,11 @@ impl<J: Jet> NamedCommitNode<J> {
     /// Accessor for the node's name
     pub fn name(&self) -> &Arc<str> {
         &self.cached_data().name
+    }
+
+    /// Accessor for the node's name
+    pub fn imr(&self) -> Option<Imr> {
+        self.cached_data().internal.imr()
     }
 
     /// Accessor for the node's type arrow

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -71,6 +71,11 @@ impl<J: Jet> CommitData<J> {
         &self.arrow
     }
 
+    /// Accessor for the node's IMR, if known
+    pub fn imr(&self) -> Option<Imr> {
+        self.imr
+    }
+
     /// Helper function to compute a cached AMR
     fn incomplete_amr(
         inner: Inner<&Arc<Self>, J, &NoDisconnect, &NoWitness>,

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -281,7 +281,7 @@ impl<C, J: Clone, X, W> Inner<C, J, X, W> {
     }
 }
 
-impl<C, J, X: Disconnectable<C>, W> Inner<C, J, X, W> {
+impl<C, J, X: Disconnectable<C>, W> Inner<Arc<C>, J, X, W> {
     /// Collapse the node information to a `Dag`
     pub fn as_dag(&self) -> Dag<&C> {
         match self {


### PR DESCRIPTION
This introduces the notion of "typed holes" which can be used as placeholders in the text encoding of Simplicity. It uses these holes for disconnect, so that at commitment time users can set their right children to placeholders. The old behavior, which allowed putting a complete expression into `disconnect` that wouldn't be committed to, was dangerous.