### PR TITLE
Policy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bitcoin = { version = "0.30.0", optional = true }
+bitcoin-miniscript = { package = "miniscript", version = "10.0" }
 byteorder = "1.3"
 elements = { version = "0.22.0", optional = true }
 hashes = { package = "bitcoin_hashes", version = "0.12" }

--- a/jets-bench/benches/elements/env.rs
+++ b/jets-bench/benches/elements/env.rs
@@ -28,12 +28,12 @@ pub enum EnvSampling {
 
 impl EnvSampling {
     /// Obtain a random environment without any annex
-    pub fn env(&self) -> ElementsEnv {
+    pub fn env(&self) -> ElementsEnv<Arc<Transaction>> {
         self.env_with_annex(None)
     }
 
     /// Obtains a env with annex
-    pub fn env_with_annex(&self, annex: Option<Vec<u8>>) -> ElementsEnv {
+    pub fn env_with_annex(&self, annex: Option<Vec<u8>>) -> ElementsEnv<Arc<Transaction>> {
         let ((txin, spent_utxo), n_in, n_out) = match self {
             EnvSampling::Null => return null_env(),
             EnvSampling::Issuance(n_in, n_out) => (txin_utils::issuance(), n_in, n_out),
@@ -81,7 +81,7 @@ fn env_with_spent_utxos(
     tx: Transaction,
     utxos: Vec<ElementsUtxo>,
     annex: Option<Vec<u8>>,
-) -> ElementsEnv {
+) -> ElementsEnv<Arc<Transaction>> {
     let ctrl_blk: [u8; 33] = [
         0xc0, 0xeb, 0x04, 0xb6, 0x8e, 0x9a, 0x26, 0xd1, 0x16, 0x04, 0x6c, 0x76, 0xe8, 0xff, 0x47,
         0x33, 0x2f, 0xb7, 0x1d, 0xda, 0x90, 0xff, 0x4b, 0xef, 0x53, 0x70, 0xf2, 0x52, 0x26, 0xd3,
@@ -98,7 +98,7 @@ fn env_with_spent_utxos(
     )
 }
 
-fn null_env() -> ElementsEnv {
+fn null_env() -> ElementsEnv<Arc<Transaction>> {
     let tx = Transaction {
         version: u32::default(),
         lock_time: LockTime::ZERO,

--- a/jets-bench/benches/elements/main.rs
+++ b/jets-bench/benches/elements/main.rs
@@ -59,7 +59,7 @@ enum ElementsBenchEnvType {
 }
 
 impl ElementsBenchEnvType {
-    fn env(&self) -> ElementsEnv {
+    fn env(&self) -> ElementsEnv<Arc<elements::Transaction>> {
         let n_in = NUM_TX_INPUTS;
         let n_out = NUM_TX_OUTPUTS;
         let env_sampler = match self {

--- a/src/jet/init/elements.rs
+++ b/src/jet/init/elements.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 use std::{fmt, str};
 use crate::jet::elements::ElementsEnv;
 use simplicity_sys::CElementsTxEnv;
+use std::sync::Arc;
 
 /// Elements jet family
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
@@ -313,7 +314,7 @@ pub enum Elements {
 
 impl Jet for Elements {
 
-    type Environment = ElementsEnv;
+    type Environment = ElementsEnv<Arc<elements::Transaction>>;
     type CJetEnvironment = CElementsTxEnv;
 
     fn c_jet_env<'env>(&self, env: &'env Self::Environment) -> &'env Self::CJetEnvironment {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,12 @@ pub use crate::value::Value;
 pub use simplicity_sys as ffi;
 use std::fmt;
 
+/// Return the version of Simplicity leaves inside a tap tree.
+#[cfg(feature = "elements")]
+pub fn leaf_version() -> elements::taproot::LeafVersion {
+    elements::taproot::LeafVersion::from_u8(0xbe).expect("constant leaf version")
+}
+
 /// Error type for simplicity
 #[non_exhaustive]
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,9 @@ pub use bit_encoding::BitWriter;
 pub use bit_encoding::{BitIter, EarlyEndOfStreamError};
 
 #[cfg(feature = "elements")]
-pub use crate::policy::{Policy, Preimage32, Satisfier, SimplicityKey, ToXOnlyPubkey, Translator};
+pub use crate::policy::{
+    sighash, Policy, Preimage32, Satisfier, SimplicityKey, ToXOnlyPubkey, Translator,
+};
 
 pub use crate::bit_machine::BitMachine;
 pub use crate::encode::{encode_natural, encode_value, encode_witness};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use bit_encoding::BitWriter;
 pub use bit_encoding::{BitIter, EarlyEndOfStreamError};
 
 #[cfg(feature = "elements")]
-pub use crate::policy::{Policy, SimplicityKey, ToXOnlyPubkey, Translator};
+pub use crate::policy::{Policy, Preimage32, Satisfier, SimplicityKey, ToXOnlyPubkey, Translator};
 
 pub use crate::bit_machine::BitMachine;
 pub use crate::encode::{encode_natural, encode_value, encode_witness};

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -37,7 +37,7 @@ use super::serialize;
 /// given a witness.
 ///
 /// Furthermore, the policy can be normalized and is amenable to semantic analysis.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Policy<Pk: SimplicityKey> {
     /// Unsatisfiable
     Unsatisfiable(FailEntropy),

--- a/src/policy/key.rs
+++ b/src/policy/key.rs
@@ -1,3 +1,4 @@
+use bitcoin_miniscript::{MiniscriptKey, ToPublicKey};
 use elements::bitcoin::key::XOnlyPublicKey;
 use hashes::sha256;
 use std::fmt::{Debug, Display};
@@ -8,8 +9,8 @@ pub trait SimplicityKey: Clone + Eq + Ord + Debug + Display + std::hash::Hash {
     type Sha256: Clone + Eq + Ord + Display + Debug + std::hash::Hash;
 }
 
-impl SimplicityKey for XOnlyPublicKey {
-    type Sha256 = sha256::Hash;
+impl<Pk: MiniscriptKey> SimplicityKey for Pk {
+    type Sha256 = <Pk as MiniscriptKey>::Sha256;
 }
 
 /// Public key which can be converted to a (x-only) public key which can be used in Simplicity.
@@ -21,13 +22,13 @@ pub trait ToXOnlyPubkey: SimplicityKey {
     fn to_sha256(hash: &Self::Sha256) -> sha256::Hash;
 }
 
-impl ToXOnlyPubkey for XOnlyPublicKey {
+impl<Pk: ToPublicKey> ToXOnlyPubkey for Pk {
     fn to_x_only_pubkey(&self) -> XOnlyPublicKey {
-        *self
+        <Pk as ToPublicKey>::to_x_only_pubkey(self)
     }
 
     fn to_sha256(hash: &Self::Sha256) -> sha256::Hash {
-        *hash
+        <Pk as ToPublicKey>::to_sha256(hash)
     }
 }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -30,6 +30,7 @@ mod error;
 mod key;
 mod satisfy;
 mod serialize;
+pub mod sighash;
 
 pub use ast::Policy;
 pub use error::Error;

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -28,9 +28,10 @@
 mod ast;
 mod error;
 mod key;
-pub mod satisfy;
+mod satisfy;
 mod serialize;
 
 pub use ast::Policy;
 pub use error::Error;
 pub use key::{SimplicityKey, ToXOnlyPubkey, Translator};
+pub use satisfy::{Preimage32, Satisfier};

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -249,7 +249,9 @@ mod tests {
         }
     }
 
-    fn get_satisfier(env: &ElementsEnv) -> PolicySatisfier<XOnlyPublicKey> {
+    fn get_satisfier(
+        env: &ElementsEnv<Arc<elements::Transaction>>,
+    ) -> PolicySatisfier<XOnlyPublicKey> {
         let mut preimages = HashMap::new();
 
         for i in 0..3 {
@@ -283,7 +285,10 @@ mod tests {
         }
     }
 
-    fn execute_successful(program: Arc<RedeemNode<Elements>>, env: &ElementsEnv) {
+    fn execute_successful(
+        program: Arc<RedeemNode<Elements>>,
+        env: &ElementsEnv<Arc<elements::Transaction>>,
+    ) {
         let mut mac = BitMachine::for_program(&program);
         assert!(mac.exec(&program, env).is_ok());
     }

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -255,7 +255,12 @@ mod tests {
     use hashes::{sha256, Hash};
     use std::sync::Arc;
 
-    fn compile(policy: Policy<XOnlyPublicKey>) -> (Arc<ConstructNode<Elements>>, ElementsEnv) {
+    fn compile(
+        policy: Policy<XOnlyPublicKey>,
+    ) -> (
+        Arc<ConstructNode<Elements>>,
+        ElementsEnv<Arc<elements::Transaction>>,
+    ) {
         let commit = policy.serialize_no_witness();
         let env = ElementsEnv::dummy();
 
@@ -265,7 +270,7 @@ mod tests {
     fn execute_successful(
         commit: &ConstructNode<Elements>,
         witness: Vec<Value>,
-        env: &ElementsEnv,
+        env: &ElementsEnv<Arc<elements::Transaction>>,
     ) -> bool {
         let finalized = commit
             .finalize_types()

--- a/src/policy/sighash.rs
+++ b/src/policy/sighash.rs
@@ -1,0 +1,94 @@
+use std::borrow::Borrow;
+use std::ops::Deref;
+
+use hashes::sha256;
+
+use crate::jet::elements::ElementsUtxo;
+use crate::Cmr;
+
+pub struct SighashCache<T: Deref<Target = elements::Transaction>> {
+    tx: T,
+    fallback: elements::sighash::SigHashCache<T>,
+}
+
+impl<T: Deref<Target = elements::Transaction> + Clone> SighashCache<T> {
+    pub fn new(tx: T) -> Self {
+        Self {
+            tx: tx.clone(),
+            fallback: elements::sighash::SigHashCache::new(tx),
+        }
+    }
+
+    pub fn taproot_key_spend_signature_hash<O>(
+        &mut self,
+        input_index: usize,
+        prevouts: &elements::sighash::Prevouts<O>,
+        sighash_type: elements::sighash::SchnorrSigHashType,
+        genesis_hash: elements::BlockHash,
+    ) -> Result<elements::taproot::TapSighashHash, elements::sighash::Error>
+    where
+        O: Borrow<elements::TxOut>,
+    {
+        self.fallback.taproot_key_spend_signature_hash(
+            input_index,
+            prevouts,
+            sighash_type,
+            genesis_hash,
+        )
+    }
+
+    pub fn taproot_script_spend_signature_hash<S, O>(
+        &mut self,
+        input_index: usize,
+        prevouts: &elements::sighash::Prevouts<O>,
+        leaf_hash: S,
+        sighash_type: elements::sighash::SchnorrSigHashType,
+        genesis_hash: elements::BlockHash,
+    ) -> Result<elements::taproot::TapSighashHash, elements::sighash::Error>
+    where
+        S: Into<elements::taproot::TapLeafHash>,
+        O: Borrow<elements::TxOut>,
+    {
+        self.fallback.taproot_script_spend_signature_hash(
+            input_index,
+            prevouts,
+            leaf_hash,
+            sighash_type,
+            genesis_hash,
+        )
+    }
+
+    pub fn simplicity_spend_signature_hash<O>(
+        &mut self,
+        input_index: usize,
+        prevouts: &elements::sighash::Prevouts<O>,
+        script_cmr: Cmr,
+        control_block: elements::taproot::ControlBlock,
+        genesis_hash: elements::BlockHash,
+    ) -> Result<sha256::Hash, elements::sighash::Error>
+    where
+        O: Borrow<elements::TxOut>,
+    {
+        let all = match prevouts {
+            elements::sighash::Prevouts::All(prevouts) => *prevouts,
+            _ => return Err(elements::sighash::Error::PrevoutKind),
+        };
+        let utxos: Vec<_> = all
+            .iter()
+            .map(|o| ElementsUtxo::from(O::borrow(o).clone()))
+            .collect();
+
+        let simplicity_env = crate::jet::elements::ElementsEnv::new(
+            self.tx.clone(),
+            utxos,
+            input_index as u32,
+            script_cmr,
+            control_block,
+            None,
+            genesis_hash,
+        );
+        let simplicity_sighash = simplicity_env.c_tx_env().sighash_all();
+
+        Ok(simplicity_sighash)
+    }
+}


### PR DESCRIPTION
Adds fixes to make Policy work with Miniscript, descriptors and the Simplicity wallet.

The only controversial change should be the implementation of Simplicity key traits for every Miniscript key. This introduces a diamond pattern: rust-miniscript → rust-simplicity → elements-miniscript and rust-miniscript → elements-miniscript. The situation is not ideal, but it avoids violating the orphan rule that caused us so much trouble.

In particular we need to convert `elements_miniscript::Satisfier` (with Miniscript keys) into `simplicity::Satisfier` (with Simplicity keys). We could make `elements_miniscript::Satisfier` a subtrait of simplicity::Satisfier, but we would have to do that for every generic implementation of `elements_miniscript::Satisfier`. We would need to copy code to rust-simplicity and implement `simplicity::Satisfier` for nonsensical types such as `HashMap<Pk, ElementsSig>`.

The diamond pattern seems like a good solution that will work until we have a better architecture. It allows us to use Miniscript and Simplicity keys interchangeably, while all the messy Simplicity details stay inside rust-simplicity.