### PR TITLE
Policy asm fragment

### DIFF
--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -12,8 +12,14 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
+use std::sync::Arc;
+
 use crate::impl_midstate_wrapper;
 use crate::jet::Jet;
+use crate::node::{
+    CoreConstructible, DisconnectConstructible, JetConstructible, WitnessConstructible,
+};
+use crate::types::Error;
 use crate::{FailEntropy, Tmr, Value};
 use hashes::sha256::Midstate;
 use simplicity_sys::ffi::bounded::cost_overhead;
@@ -259,6 +265,78 @@ impl Cmr {
             0x10, 0x43, 0x24, 0xee, 0x39, 0x1b, 0xff, 0x9d,
         ])),
     ];
+}
+
+impl CoreConstructible for Cmr {
+    fn iden() -> Self {
+        Cmr::iden()
+    }
+
+    fn unit() -> Self {
+        Cmr::unit()
+    }
+
+    fn injl(child: &Self) -> Self {
+        Cmr::injl(*child)
+    }
+
+    fn injr(child: &Self) -> Self {
+        Cmr::injl(*child)
+    }
+
+    fn take(child: &Self) -> Self {
+        Cmr::take(*child)
+    }
+
+    fn drop_(child: &Self) -> Self {
+        Cmr::drop(*child)
+    }
+
+    fn comp(left: &Self, right: &Self) -> Result<Self, Error> {
+        Ok(Cmr::comp(*left, *right))
+    }
+
+    fn case(left: &Self, right: &Self) -> Result<Self, Error> {
+        Ok(Cmr::case(*left, *right))
+    }
+
+    fn assertl(left: &Self, right: Cmr) -> Result<Self, Error> {
+        Ok(Cmr::case(*left, right))
+    }
+
+    fn assertr(left: Cmr, right: &Self) -> Result<Self, Error> {
+        Ok(Cmr::case(left, *right))
+    }
+
+    fn pair(left: &Self, right: &Self) -> Result<Self, Error> {
+        Ok(Cmr::pair(*left, *right))
+    }
+
+    fn fail(entropy: FailEntropy) -> Self {
+        Cmr::fail(entropy)
+    }
+
+    fn const_word(word: Arc<Value>) -> Self {
+        Cmr::const_word(&word)
+    }
+}
+
+impl<X> DisconnectConstructible<X> for Cmr {
+    fn disconnect(left: &Self, _right: &X) -> Result<Self, Error> {
+        Ok(Cmr::disconnect(*left))
+    }
+}
+
+impl<W> WitnessConstructible<W> for Cmr {
+    fn witness(_witness: W) -> Self {
+        Cmr::witness()
+    }
+}
+
+impl<J: Jet> JetConstructible<J> for Cmr {
+    fn jet(jet: J) -> Self {
+        jet.cmr()
+    }
 }
 
 #[cfg(test)]

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -77,7 +77,7 @@ impl<Pk: SimplicityKey> Policy<Pk> {
             Policy::After(n) => serialize::after(n),
             Policy::Older(n) => serialize::older(n),
             Policy::Key(ref key) => serialize::key(key, NoWitness),
-            Policy::Sha256(ref hash) => serialize::sha256::<_, Pk>(hash, NoWitness),
+            Policy::Sha256(ref hash) => serialize::sha256::<Pk, _, _>(hash, NoWitness),
             Policy::And {
                 ref left,
                 ref right,

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -89,7 +89,7 @@ impl<Pk: ToXOnlyPubkey> Satisfier<Pk> for elements::LockTime {
 }
 
 impl<Pk: ToXOnlyPubkey> Policy<Pk> {
-    pub fn satisfy_internal<S: Satisfier<Pk>>(
+    fn satisfy_internal<S: Satisfier<Pk>>(
         &self,
         satisfier: &S,
     ) -> Result<Arc<WitnessNode<Elements>>, Error> {

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -90,7 +90,7 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
                 super::serialize::key(key, sig_wit)
             }
             Policy::After(n) => {
-                let node = super::serialize::after(n);
+                let node = super::serialize::after::<Arc<_>>(n);
                 let height = Height::from_consensus(n).expect("timelock is valid");
                 if satisfier.check_after(elements::LockTime::Blocks(height)) {
                     node
@@ -99,7 +99,7 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
                 }
             }
             Policy::Older(n) => {
-                let node = super::serialize::older(n);
+                let node = super::serialize::older::<Arc<_>>(n);
                 if satisfier.check_older(elements::Sequence((n).into())) {
                     node
                 } else {
@@ -110,7 +110,7 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
                 let preimage_wit = satisfier
                     .lookup_sha256(hash)
                     .map(|preimage| Arc::new(Value::u256_from_slice(preimage.as_ref())));
-                super::serialize::sha256::<_, Pk>(hash, preimage_wit)
+                super::serialize::sha256::<Pk, _, _>(hash, preimage_wit)
             }
             Policy::And {
                 ref left,

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -308,10 +308,8 @@ mod tests {
 
         assert!(policy.satisfy(&satisfier).is_err());
 
-        let commit = policy.serialize_no_witness();
+        let commit = policy.commit().expect("no asm");
         let program = commit
-            .finalize_types()
-            .expect("finalize types")
             .finalize(&mut SimpleFinalizer::new(std::iter::empty()))
             .expect("finalize");
         let mut mac = BitMachine::for_program(&program);

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -74,7 +74,7 @@ where
     N::comp(&const_n, &check_lock_distance).expect("consistent types")
 }
 
-fn compute_sha256<N>(witness256: &N) -> N
+pub fn compute_sha256<N>(witness256: &N) -> N
 where
     N: CoreConstructible + JetConstructible<Elements>,
 {
@@ -86,7 +86,7 @@ where
     N::comp(&digest_ctx, &finalize).expect("consistent types")
 }
 
-fn verify_bexp<N>(input: &N, bexp: &N) -> N
+pub fn verify_bexp<N>(input: &N, bexp: &N) -> N
 where
     N: CoreConstructible + JetConstructible<Elements>,
 {
@@ -117,7 +117,7 @@ where
     N::comp(left, right).expect("consistent types")
 }
 
-fn selector<N, W>(witness_bit: W) -> N
+pub fn selector<N, W>(witness_bit: W) -> N
 where
     N: CoreConstructible + WitnessConstructible<W>,
 {
@@ -141,7 +141,7 @@ where
 /// child: 1 → 1
 ///
 /// summand(child): 1 → 2^32
-fn thresh_summand<N, W>(child: &N, witness_bit: W) -> N
+pub fn thresh_summand<N, W>(child: &N, witness_bit: W) -> N
 where
     N: CoreConstructible + WitnessConstructible<W>,
 {
@@ -169,7 +169,7 @@ where
 /// acc: 1 → 2^32, summand: 1 → 2^32
 ///
 /// add(sum, summand): 1 → 2^32
-fn thresh_add<N>(sum: &N, summand: &N) -> N
+pub fn thresh_add<N>(sum: &N, summand: &N) -> N
 where
     N: CoreConstructible + JetConstructible<Elements>,
 {
@@ -191,7 +191,7 @@ where
 }
 
 /// verify(sum): 1 → 1
-fn thresh_verify<N>(sum: &N, k: u32) -> N
+pub fn thresh_verify<N>(sum: &N, k: u32) -> N
 where
     N: CoreConstructible + JetConstructible<Elements>,
 {

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -15,7 +15,6 @@
 //! Serialization of Policy as Simplicity
 
 use crate::jet::Elements;
-use crate::node::{self, Node};
 use crate::node::{CoreConstructible, JetConstructible, WitnessConstructible};
 use crate::ToXOnlyPubkey;
 use crate::{FailEntropy, Value};
@@ -23,211 +22,194 @@ use crate::{FailEntropy, Value};
 use std::convert::TryFrom;
 use std::sync::Arc;
 
-pub type ArcNode<N> = Arc<Node<N>>;
-
-pub fn unsatisfiable<N>(entropy: FailEntropy) -> ArcNode<N>
+pub fn unsatisfiable<N>(entropy: FailEntropy) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible,
+    N: CoreConstructible,
 {
-    ArcNode::fail(entropy)
+    N::fail(entropy)
 }
 
-pub fn trivial<N>() -> ArcNode<N>
+pub fn trivial<N>() -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible,
+    N: CoreConstructible,
 {
-    ArcNode::unit()
+    N::unit()
 }
 
-pub fn key<N, Pk>(key: &Pk, witness: N::Witness) -> ArcNode<N>
+pub fn key<Pk, N, W>(key: &Pk, witness: W) -> N
 where
     Pk: ToXOnlyPubkey,
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<W>,
 {
     let key_value = Arc::new(Value::u256_from_slice(&key.to_x_only_pubkey().serialize()));
-    let const_key = ArcNode::const_word(key_value);
-    let sighash_all = ArcNode::jet(Elements::SigAllHash);
-    let pair_key_msg = ArcNode::pair(&const_key, &sighash_all).expect("consistent types");
-    let witness = ArcNode::witness(witness);
-    let pair_key_msg_sig = ArcNode::pair(&pair_key_msg, &witness).expect("consistent types");
-    let bip_0340_verify = ArcNode::jet(Elements::Bip0340Verify);
+    let const_key = N::const_word(key_value);
+    let sighash_all = N::jet(Elements::SigAllHash);
+    let pair_key_msg = N::pair(&const_key, &sighash_all).expect("consistent types");
+    let witness = N::witness(witness);
+    let pair_key_msg_sig = N::pair(&pair_key_msg, &witness).expect("consistent types");
+    let bip_0340_verify = N::jet(Elements::Bip0340Verify);
 
-    ArcNode::comp(&pair_key_msg_sig, &bip_0340_verify).expect("consistent types")
+    N::comp(&pair_key_msg_sig, &bip_0340_verify).expect("consistent types")
 }
 
-pub fn after<N>(n: u32) -> ArcNode<N>
+pub fn after<N>(n: u32) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
+    N: CoreConstructible + JetConstructible<Elements>,
 {
     let n_value = Arc::new(Value::u32(n));
-    let const_n = ArcNode::const_word(n_value);
-    let check_lock_height = ArcNode::jet(Elements::CheckLockHeight);
+    let const_n = N::const_word(n_value);
+    let check_lock_height = N::jet(Elements::CheckLockHeight);
 
-    ArcNode::comp(&const_n, &check_lock_height).expect("consistent types")
+    N::comp(&const_n, &check_lock_height).expect("consistent types")
 }
 
-pub fn older<N>(n: u16) -> ArcNode<N>
+pub fn older<N>(n: u16) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
+    N: CoreConstructible + JetConstructible<Elements>,
 {
     let n_value = Arc::new(Value::u16(n));
-    let const_n = ArcNode::const_word(n_value);
-    let check_lock_distance = ArcNode::jet(Elements::CheckLockDistance);
+    let const_n = N::const_word(n_value);
+    let check_lock_distance = N::jet(Elements::CheckLockDistance);
 
-    ArcNode::comp(&const_n, &check_lock_distance).expect("consistent types")
+    N::comp(&const_n, &check_lock_distance).expect("consistent types")
 }
 
-fn compute_sha256<N>(witness256: &ArcNode<N>) -> ArcNode<N>
+fn compute_sha256<N>(witness256: &N) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
+    N: CoreConstructible + JetConstructible<Elements>,
 {
-    let ctx = ArcNode::jet(Elements::Sha256Ctx8Init);
-    let pair_ctx_witness = ArcNode::pair(&ctx, witness256).expect("consistent types");
-    let add256 = ArcNode::jet(Elements::Sha256Ctx8Add32);
-    let digest_ctx = ArcNode::comp(&pair_ctx_witness, &add256).expect("consistent types");
-    let finalize = ArcNode::jet(Elements::Sha256Ctx8Finalize);
-    ArcNode::comp(&digest_ctx, &finalize).expect("consistent types")
+    let ctx = N::jet(Elements::Sha256Ctx8Init);
+    let pair_ctx_witness = N::pair(&ctx, witness256).expect("consistent types");
+    let add256 = N::jet(Elements::Sha256Ctx8Add32);
+    let digest_ctx = N::comp(&pair_ctx_witness, &add256).expect("consistent types");
+    let finalize = N::jet(Elements::Sha256Ctx8Finalize);
+    N::comp(&digest_ctx, &finalize).expect("consistent types")
 }
 
-fn verify_bexp<N>(input: &ArcNode<N>, bexp: &ArcNode<N>) -> ArcNode<N>
+fn verify_bexp<N>(input: &N, bexp: &N) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements>,
+    N: CoreConstructible + JetConstructible<Elements>,
 {
-    let computed_bexp = ArcNode::comp(input, bexp).expect("consistent types");
-    let verify = ArcNode::jet(Elements::Verify);
-    ArcNode::comp(&computed_bexp, &verify).expect("consistent types")
+    let computed_bexp = N::comp(input, bexp).expect("consistent types");
+    let verify = N::jet(Elements::Verify);
+    N::comp(&computed_bexp, &verify).expect("consistent types")
 }
 
-pub fn sha256<N, Pk>(hash: &Pk::Sha256, witness: N::Witness) -> ArcNode<N>
+pub fn sha256<Pk, N, W>(hash: &Pk::Sha256, witness: W) -> N
 where
     Pk: ToXOnlyPubkey,
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<W>,
 {
     let hash_value = Arc::new(Value::u256_from_slice(Pk::to_sha256(hash).as_ref()));
-    let const_hash = ArcNode::const_word(hash_value);
-    let witness256 = ArcNode::witness(witness);
+    let const_hash = N::const_word(hash_value);
+    let witness256 = N::witness(witness);
     let computed_hash = compute_sha256(&witness256);
-    let pair_hash_computed_hash =
-        ArcNode::pair(&const_hash, &computed_hash).expect("consistent types");
-    let eq256 = ArcNode::jet(Elements::Eq256);
+    let pair_hash_computed_hash = N::pair(&const_hash, &computed_hash).expect("consistent types");
+    let eq256 = N::jet(Elements::Eq256);
 
     verify_bexp(&pair_hash_computed_hash, &eq256)
 }
 
-pub fn and<N>(left: &ArcNode<N>, right: &ArcNode<N>) -> ArcNode<N>
+pub fn and<N>(left: &N, right: &N) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible,
+    N: CoreConstructible,
 {
-    ArcNode::comp(left, right).expect("consistent types")
+    N::comp(left, right).expect("consistent types")
 }
 
-fn selector<N>(witness_bit: N::Witness) -> ArcNode<N>
+fn selector<N, W>(witness_bit: W) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + WitnessConstructible<W>,
 {
-    let witness = ArcNode::witness(witness_bit);
-    let unit = ArcNode::unit();
-    ArcNode::pair(&witness, &unit).expect("consistent types")
+    let witness = N::witness(witness_bit);
+    let unit = N::unit();
+    N::pair(&witness, &unit).expect("consistent types")
 }
 
-pub fn or<N>(left: &ArcNode<N>, right: &ArcNode<N>, witness_bit: N::Witness) -> ArcNode<N>
+pub fn or<N, W>(left: &N, right: &N, witness_bit: W) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + WitnessConstructible<W>,
 {
-    let drop_left = ArcNode::drop_(left);
-    let drop_right = ArcNode::drop_(right);
-    let case_left_right = ArcNode::case(&drop_left, &drop_right).expect("consistent types");
+    let drop_left = N::drop_(left);
+    let drop_right = N::drop_(right);
+    let case_left_right = N::case(&drop_left, &drop_right).expect("consistent types");
     let selector = selector(witness_bit);
 
-    ArcNode::comp(&selector, &case_left_right).expect("consistent types")
+    N::comp(&selector, &case_left_right).expect("consistent types")
 }
 
 /// child: 1 → 1
 ///
 /// summand(child): 1 → 2^32
-fn thresh_summand<N>(child: &ArcNode<N>, witness_bit: N::Witness) -> ArcNode<N>
+fn thresh_summand<N, W>(child: &N, witness_bit: W) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + WitnessConstructible<W>,
 {
     // 1 → 2 x 1
     let selector = selector(witness_bit);
 
     // 1 → 2^32
-    let const_one = ArcNode::const_word(Arc::new(Value::u32(1)));
+    let const_one = N::const_word(Arc::new(Value::u32(1)));
     // 1 → 2^32
-    let child_one = ArcNode::comp(child, &const_one).expect("consistent types");
+    let child_one = N::comp(child, &const_one).expect("consistent types");
     // 1 → 2^32
-    let const_zero = ArcNode::const_word(Arc::new(Value::u32(0)));
+    let const_zero = N::const_word(Arc::new(Value::u32(0)));
 
     // 1 × 1 → 2^32
-    let drop_left = ArcNode::drop_(&const_zero);
+    let drop_left = N::drop_(&const_zero);
     // 1 × 1 → 2^32
-    let drop_right = ArcNode::drop_(&child_one);
+    let drop_right = N::drop_(&child_one);
     // 2 x 1 → 2^32
-    let child_one_or_zero = ArcNode::case(&drop_left, &drop_right).expect("consistent types");
+    let child_one_or_zero = N::case(&drop_left, &drop_right).expect("consistent types");
 
     // 1 → 2^32
-    ArcNode::comp(&selector, &child_one_or_zero).expect("consistent types")
+    N::comp(&selector, &child_one_or_zero).expect("consistent types")
 }
 
 /// acc: 1 → 2^32, summand: 1 → 2^32
 ///
 /// add(sum, summand): 1 → 2^32
-fn thresh_add<N>(sum: &ArcNode<N>, summand: &ArcNode<N>) -> ArcNode<N>
+fn thresh_add<N>(sum: &N, summand: &N) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + JetConstructible<Elements>,
 {
     // 1 → 2^32 × 2^32
-    let pair_sum_summand = ArcNode::pair(sum, summand).expect("consistent types");
+    let pair_sum_summand = N::pair(sum, summand).expect("consistent types");
     // 2^32 × 2^32 → 2 × 2^32
-    let add32 = ArcNode::jet(Elements::Add32);
+    let add32 = N::jet(Elements::Add32);
     // 1 → 2 x 2^32
-    let full_sum = ArcNode::comp(&pair_sum_summand, &add32).expect("consistent types");
+    let full_sum = N::comp(&pair_sum_summand, &add32).expect("consistent types");
     // 2^32 → 2^32
-    let iden = ArcNode::iden();
+    let iden = N::iden();
     // 2 × 2^32 → 2^32
-    let drop_iden = ArcNode::drop_(&iden);
+    let drop_iden = N::drop_(&iden);
 
     // Discard the overflow bit.
     // FIXME: enforce that sum of weights is less than 2^32
     // 1 → 2^32
-    ArcNode::comp(&full_sum, &drop_iden).expect("consistent types")
+    N::comp(&full_sum, &drop_iden).expect("consistent types")
 }
 
 /// verify(sum): 1 → 1
-fn thresh_verify<N>(sum: &ArcNode<N>, k: u32) -> ArcNode<N>
+fn thresh_verify<N>(sum: &N, k: u32) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + JetConstructible<Elements>,
 {
     // 1 → 2^32
-    let const_k = ArcNode::const_word(Arc::new(Value::u32(k)));
+    let const_k = N::const_word(Arc::new(Value::u32(k)));
     // 1 → 2^32 × 2^32
-    let pair_k_sum = ArcNode::pair(&const_k, sum).expect("consistent types");
+    let pair_k_sum = N::pair(&const_k, sum).expect("consistent types");
     // 2^32 × 2^32 → 2
-    let eq32 = ArcNode::jet(Elements::Eq32);
+    let eq32 = N::jet(Elements::Eq32);
 
     // 1 → 1
     verify_bexp(&pair_k_sum, &eq32)
 }
 
-pub fn threshold<N>(k: u32, subs: &[ArcNode<N>], witness_bits: &[N::Witness]) -> ArcNode<N>
+pub fn threshold<N, W>(k: u32, subs: &[N], witness_bits: &[W]) -> N
 where
-    N: node::Marker,
-    ArcNode<N>: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<N::Witness>,
+    N: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<W>,
+    W: Clone,
 {
     let n = u32::try_from(subs.len()).expect("can have at most 2^32 children in a threshold");
     assert!(k <= n, "threshold must be <= number of children");

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -14,13 +14,33 @@
 
 //! Serialization of Policy as Simplicity
 
-use crate::jet::Elements;
+use crate::jet::{Elements, Jet};
 use crate::node::{CoreConstructible, JetConstructible, WitnessConstructible};
-use crate::ToXOnlyPubkey;
+use crate::{Cmr, ConstructNode, ToXOnlyPubkey};
 use crate::{FailEntropy, Value};
 
 use std::convert::TryFrom;
 use std::sync::Arc;
+
+/// Constructors for the assembly fragment.
+pub trait AssemblyConstructible: Sized {
+    /// Construct the assembly fragment with the given CMR.
+    ///
+    /// The construction fails if the CMR alone is not enough information to construct the type.
+    fn assembly(cmr: Cmr) -> Option<Self>;
+}
+
+impl AssemblyConstructible for Cmr {
+    fn assembly(cmr: Cmr) -> Option<Self> {
+        Some(cmr)
+    }
+}
+
+impl<J: Jet> AssemblyConstructible for Arc<ConstructNode<J>> {
+    fn assembly(_cmr: Cmr) -> Option<Self> {
+        None
+    }
+}
 
 pub fn unsatisfiable<N>(entropy: FailEntropy) -> N
 where


### PR DESCRIPTION
This commit adds the assembly (asm) fragment to Policy, which allows us to include arbitrary Simplicity programs. The Policy includes just the CMR. It is the Satisfier's responsibility to provide a matching satisfied program at spending time. 

One of the challenges is that Policy with asm fragments does not have a serialization at commitment time. This why we introduce separate getters for the CMR and the program commitment.