### PR TITLE
Finalize human encoding

### DIFF
--- a/src/human_encoding/error.rs
+++ b/src/human_encoding/error.rs
@@ -57,6 +57,11 @@ impl ErrorSet {
         self.errors.iter().next().map(|(a, b)| (*a, &b[0]))
     }
 
+    /// Return an iterator over the errors in the error set.
+    pub fn iter(&self) -> impl Iterator<Item = &Error> {
+        self.errors.values().flatten()
+    }
+
     /// Constructs a new error set with a single error in it.
     pub fn single<P: Into<Position>, E: Into<Error>>(position: P, err: E) -> Self {
         let mut errors = BTreeMap::default();

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -291,4 +291,36 @@ mod tests {
             Err(error) => panic!("Unexpected error {}", error),
         }
     }
+
+    #[test]
+    fn to_witness_node_pruned_witness() {
+        let s = "
+            wit1 := witness
+            wit2 := witness
+            main := comp (pair wit1 unit) case unit wit2
+        ";
+        let forest = Forest::<Core>::parse(s).unwrap();
+        let mut witness = HashMap::new();
+        witness.insert(Arc::from("wit1"), Value::u1(0));
+
+        match forest.to_witness_node(&witness).finalize() {
+            Ok(_) => {}
+            Err(e) => panic!("Unexpected error {}", e),
+        }
+
+        witness.insert(Arc::from("wit1"), Value::u1(1));
+
+        match forest.to_witness_node(&witness).finalize() {
+            Ok(_) => {}
+            Err(Error::IncompleteFinalization) => {}
+            Err(e) => panic!("Unexpected error {}", e),
+        }
+
+        witness.insert(Arc::from("wit2"), Value::unit());
+
+        match forest.to_witness_node(&witness).finalize() {
+            Ok(_) => {}
+            Err(e) => panic!("Unexpected error {}", e),
+        }
+    }
 }

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -28,7 +28,7 @@ mod serialize;
 use crate::dag::{DagLike, MaxSharing};
 use crate::jet::Jet;
 use crate::node::{self, CommitNode};
-use crate::{Cmr, Imr};
+use crate::{Cmr, Imr, Value, WitnessNode};
 
 use std::collections::HashMap;
 use std::str;
@@ -217,5 +217,10 @@ impl<J: Jet> Forest<J> {
             ret += &print_lines(&program_lines, true /* add a blank line before main */);
         }
         ret
+    }
+
+    pub fn to_witness_node(&self, witness: &HashMap<Arc<str>, Arc<Value>>) -> Arc<WitnessNode<J>> {
+        let main = self.roots.get("main").expect("main always exists");
+        main.to_witness_node(witness, self.roots())
     }
 }

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -275,4 +275,20 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn to_witness_node_unfilled_hole() {
+        let s = "
+            wit1 := witness
+            main := comp wit1 comp disconnect iden ?dis2 unit
+        ";
+        let forest = Forest::<Core>::parse(s).unwrap();
+        let witness = HashMap::new();
+
+        match forest.to_witness_node(&witness).finalize() {
+            Ok(_) => panic!("Duplicate witness names should fail"),
+            Err(Error::IncompleteFinalization) => {}
+            Err(error) => panic!("Unexpected error {}", error),
+        }
+    }
 }

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -252,4 +252,27 @@ mod tests {
             Err(error) => panic!("Unexpected error {}", error),
         }
     }
+
+    #[test]
+    fn parse_duplicate_witness_in_disconnected_branch() {
+        let s = "
+            wit1 := witness
+            main := comp wit1 comp disconnect iden ?dis2 unit
+
+            wit1 := witness
+            dis2 := wit1
+        ";
+
+        match Forest::<Core>::parse(s) {
+            Ok(_) => panic!("Duplicate witness names should fail"),
+            Err(set) => {
+                let errors: Vec<_> = set.iter().collect();
+                assert_eq!(1, errors.len());
+                match errors[0] {
+                    super::error::Error::NameRepeated { .. } => {}
+                    error => panic!("Unexpected error {}", error),
+                }
+            }
+        }
+    }
 }

--- a/src/human_encoding/parse/ast.rs
+++ b/src/human_encoding/parse/ast.rs
@@ -361,8 +361,8 @@ impl<J: Jet> Ast<J> {
         if &lexemes[0].raw[..2] == "0x" {
             let bit_length = s.len() * 4;
             let mut data = Vec::with_capacity((s.len() + 1) / 2);
-            for idx in (0..s.len() / 2).map(|n| n * 2) {
-                data.push(u8::from_str_radix(&s[idx..idx + 1], 16).unwrap());
+            for idx in (0..s.len()).step_by(2) {
+                data.push(u8::from_str_radix(&s[idx..idx + 2], 16).unwrap());
             }
             if s.len() % 2 == 1 {
                 data.push(u8::from_str_radix(&s[s.len() - 1..], 16).unwrap() << 4);

--- a/src/human_encoding/parse/mod.rs
+++ b/src/human_encoding/parse/mod.rs
@@ -687,7 +687,7 @@ mod tests {
 
                 main := comp pr1 jt2       : 1 -> 1               -- 3f6422da
             ",
-            "32d98c39b2913f789f044255a1a26d3ac818fb3df1e286cb6eaea503e5042f87",
+            "dacbdfcf64122edf8efda2b34fe353cac4424dd455a9204fc92af258b465bbc4",
         );
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,3 +14,29 @@ macro_rules! decode_bits {
         }
     };
 }
+
+#[macro_export]
+macro_rules! impl_serde_string {
+    ($name:ident) => {
+        #[cfg(feature = "serde")]
+        impl serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
+
+        #[cfg(feature = "serde")]
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                <$name as std::str::FromStr>::from_str(&s).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -197,5 +197,7 @@ macro_rules! impl_midstate_wrapper {
                 self.0.to_byte_array()
             }
         }
+
+        impl_serde_string!($wrapper);
     };
 }


### PR DESCRIPTION
This PR adds methods to convert a `NamedCommitNode` (parsed from text) into a `WitnessNode` with populated witness nodes and populated disconnected branches. This can be finalized into a `RedeemNode` for spending.

A hash map from names to values provides the witness data. This can be obtained from a JSON file.

The disconnected branches come from the forest of Simplicity expressions that are already parsed from the text file. The witness hash map covers the main program and (recursively) all its disconnected expressions. All expressions share a name space and must use unique node names.