### PR TITLE
ci: add windows/macos to clippy to reproduce compilation error on windows 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,9 +136,10 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
           - stable
     steps:
@@ -156,4 +157,3 @@ jobs:
         with:
           command: clippy
           args: --all-targets -- --deny warnings
-


### PR DESCRIPTION
this PR adds windows and macos to the clippy job to reproduce the compilation failure in #186 

~~also fixes some clippy warns/errs~~