### PR TITLE
update rust-bitcoin to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = [ "bitcoin", "elements" ]
+default = ["bitcoin", "elements"]
 test-utils = ["simplicity-sys/test-utils"]
 serde = ["actual-serde", "bitcoin/serde", "elements/serde"]
 
@@ -16,18 +16,22 @@ name = "simplicity"
 path = "src/lib.rs"
 
 [dependencies]
-bitcoin = { version = "0.30.0", optional = true }
-bitcoin-miniscript = { package = "miniscript", version = "10.0" }
+bitcoin = { version = "0.31.0", optional = true }
+bitcoin-miniscript = { package = "miniscript", version = "11.0.0" }
 byteorder = "1.3"
-elements = { version = "0.23.0", optional = true }
-hashes = { package = "bitcoin_hashes", version = "0.12" }
+elements = { version = "0.24.0", optional = true }
+hashes = { package = "bitcoin_hashes", version = "0.13" }
 hex = { package = "hex-conservative", version = "0.1.1" }
 santiago = "1.3"
 simplicity-sys = { version = "0.1.0", path = "./simplicity-sys" }
-actual-serde = { package = "serde", version = "1.0.103", features = ["derive"], optional = true }
+actual-serde = { package = "serde", version = "1.0.103", features = [
+    "derive",
+], optional = true }
 
 [dev-dependencies]
-simplicity-sys = { version = "0.1.0", path = "./simplicity-sys", features = ["test-utils"] }
+simplicity-sys = { version = "0.1.0", path = "./simplicity-sys", features = [
+    "test-utils",
+] }
 
 [workspace]
 members = ["simpcli", "simplicity-sys"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,9 +12,6 @@ cargo-fuzz = true
 honggfuzz = { version = "0.5.55", default-features = false }
 simplicity = { path = ".." }
 
-[patch.crates-io.bitcoin_hashes]
-git = "https://github.com/apoelstra/rust-bitcoin"
-tag = "2023-07--0.30.1-with-fuzzcfg"
 
 [[bin]]
 name = "c_rust_merkle"

--- a/jets-bench/benches/elements/main.rs
+++ b/jets-bench/benches/elements/main.rs
@@ -299,7 +299,7 @@ fn bench(c: &mut Criterion) {
 
     fn bip_0340() -> Arc<Value> {
         let secp_ctx = bitcoin::secp256k1::Secp256k1::new();
-        let keypair = bitcoin::key::KeyPair::new(&secp_ctx, &mut thread_rng());
+        let keypair = bitcoin::key::Keypair::new(&secp_ctx, &mut thread_rng());
         let xpk = bitcoin::key::XOnlyPublicKey::from_keypair(&keypair);
 
         let msg = bitcoin::secp256k1::Message::from_slice(&rand::random::<[u8; 32]>()).unwrap();
@@ -323,7 +323,7 @@ fn bench(c: &mut Criterion) {
 
     fn check_sig_verify() -> Arc<Value> {
         let secp_ctx = bitcoin::secp256k1::Secp256k1::signing_only();
-        let keypair = bitcoin::key::KeyPair::new(&secp_ctx, &mut thread_rng());
+        let keypair = bitcoin::key::Keypair::new(&secp_ctx, &mut thread_rng());
         let xpk = bitcoin::key::XOnlyPublicKey::from_keypair(&keypair);
 
         let msg = [0xab; 64];

--- a/simplicity-sys/Cargo.toml
+++ b/simplicity-sys/Cargo.toml
@@ -10,7 +10,7 @@ cc = "1.0"
 
 [dependencies]
 libc = "0.2"
-hashes = { package = "bitcoin_hashes", version = "0.12" }
+hashes = { package = "bitcoin_hashes", version = "0.13" }
 
 [features]
 test-utils = []

--- a/src/jet/bitcoin/environment.rs
+++ b/src/jet/bitcoin/environment.rs
@@ -29,7 +29,7 @@ impl Default for BitcoinEnv {
     fn default() -> Self {
         // FIXME: Review and check if the defaults make sense
         BitcoinEnv::new(bitcoin::Transaction {
-            version: 2,
+            version: bitcoin::transaction::Version::TWO,
             lock_time: absolute::LockTime::ZERO,
             input: vec![],
             output: vec![],

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -128,9 +128,9 @@ macro_rules! impl_midstate_wrapper {
         }
 
         impl std::str::FromStr for $wrapper {
-            type Err = hashes::hex::Error;
+            type Err = hashes::hex::HexToArrayError;
 
-            fn from_str(s: &str) -> Result<Self, hashes::hex::Error> {
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
                 let x: [u8; 32] = hashes::hex::FromHex::from_hex(s)?;
                 Ok($wrapper(Midstate::from_byte_array(x)))
             }

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -230,7 +230,7 @@ mod tests {
     use crate::node::{CoreConstructible, JetConstructible, SimpleFinalizer, WitnessConstructible};
     use crate::policy::serialize;
     use crate::{BitMachine, FailEntropy, SimplicityKey};
-    use elements::bitcoin::key::{KeyPair, XOnlyPublicKey};
+    use elements::bitcoin::key::{Keypair, XOnlyPublicKey};
     use elements::secp256k1_zkp;
     use hashes::{sha256, Hash};
     use std::collections::HashMap;
@@ -286,7 +286,7 @@ mod tests {
         let mut signatures = HashMap::new();
 
         for _ in 0..3 {
-            let keypair = KeyPair::new(&secp, &mut rng);
+            let keypair = Keypair::new(&secp, &mut rng);
             let xonly = keypair.x_only_public_key().0;
 
             let sighash = env.c_tx_env().sighash_all();

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -303,7 +303,7 @@ mod tests {
 
         let sighash = env.c_tx_env().sighash_all();
         let secp = secp256k1_zkp::Secp256k1::new();
-        let keypair = secp256k1_zkp::KeyPair::new(&secp, &mut secp256k1_zkp::rand::rngs::OsRng);
+        let keypair = secp256k1_zkp::Keypair::new(&secp, &mut secp256k1_zkp::rand::rngs::OsRng);
         let message = secp256k1_zkp::Message::from(sighash);
         let signature = keypair.sign_schnorr(message);
 


### PR DESCRIPTION
Since elements-miniscript depends on rust-simplicity and keystone depends on both rust-elements and elements-miniscript we need this to try out https://github.com/ElementsProject/rust-elements/pull/188

Not mergeable yet, since it requires rust-elements release to remove the patch section