### PR TITLE
build(windows): fix windows compilation errors

### DIFF
--- a/simplicity-sys/build.rs
+++ b/simplicity-sys/build.rs
@@ -42,6 +42,7 @@ fn main() {
     let include = simplicity_path.join("include");
 
     cc::Build::new()
+        .std("c11")
         .flag_if_supported("-fno-inline-functions")
         .files(files)
         .files(test_files)


### PR DESCRIPTION
fixes windows compilation errors

upstream fixes for simplicity-sys are at BlockstreamResearch/simplicity#213