### PR TITLE
Fix Linux

### DIFF
--- a/simplicity-sys/Cargo.toml
+++ b/simplicity-sys/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-cc = "1.0"
+cc = "1.0.83"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
`master` currently fails to build on Linux. Our CI didn't catch this.

# Current status

The `cc` dependency of `rust-simplicity-sys` needed to be updated. Now the tests run on my machine. I suspect that our CI automatically used the latest version of `cc` so this bug stayed undetected.

# Questions

@apoelstra does your CI run?