### PR TITLE
Update license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "simplicity"
 version = "0.1.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
+license = "CC0-1.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/fuzz/fuzz_targets/c_rust_merkle.rs
+++ b/fuzz/fuzz_targets/c_rust_merkle.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/decode_natural.rs
+++ b/fuzz/fuzz_targets/decode_natural.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/decode_program.rs
+++ b/fuzz/fuzz_targets/decode_program.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use honggfuzz::fuzz;
 

--- a/fuzz/fuzz_targets/parse_human.rs
+++ b/fuzz/fuzz_targets/parse_human.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use std::str;
 use honggfuzz::fuzz;

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::jet::Jet;
 use crate::Value;

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Bit Iterator functionality
 //!

--- a/src/bit_encoding/bitwriter.rs
+++ b/src/bit_encoding/bitwriter.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use std::io;
 

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Decoding
 //!

--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Encoding
 //!

--- a/src/bit_encoding/mod.rs
+++ b/src/bit_encoding/mod.rs
@@ -1,18 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <rust-simplicity@wpsoftware.net>
-//   Christian Lewe <clewe@blockstream.com>
-//   Sanket Kanjalkar <sanket1729@gmail.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! The Simplicity Bit Encoding
 //!

--- a/src/bit_machine/frame.rs
+++ b/src/bit_machine/frame.rs
@@ -1,17 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//   Sanket Kanjalkar <sanket1729@gmail.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Simplicity Frame
 //!

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Simplicity Execution
 //!

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! General DAG iteration utilities
 

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -1,18 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <rust-simplicity@wpsoftware.net>
-//   Christian Lewe <clewe@blockstream.com>
-//   Sanket Kanjalkar <sanket1729@gmail.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! The Simplicity Human-Readable Encoding
 //!

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Human-readable Nodes
 

--- a/src/jet/bitcoin/environment.rs
+++ b/src/jet/bitcoin/environment.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use bitcoin::absolute;
 

--- a/src/jet/bitcoin/mod.rs
+++ b/src/jet/bitcoin/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 mod environment;
 

--- a/src/jet/elements/environment.rs
+++ b/src/jet/elements/environment.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//   Sanket kanjalkar <sanket1729@gmail.com>
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::merkle::cmr::Cmr;
 use elements::confidential;

--- a/src/jet/elements/mod.rs
+++ b/src/jet/elements/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 mod c_env;
 mod environment;

--- a/src/jet/init/mod.rs
+++ b/src/jet/init/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Jet initialization
 //!

--- a/src/jet/mod.rs
+++ b/src/jet/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Simplicity jets
 //!

--- a/src/jet/type_name.rs
+++ b/src/jet/type_name.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Manual type specification
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 #![allow(
     // we use `bool` to represent bits and frequentely assert_eq against them

--- a/src/merkle/amr.rs
+++ b/src/merkle/amr.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::impl_midstate_wrapper;
 use crate::jet::Jet;

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use std::sync::Arc;
 

--- a/src/merkle/imr.rs
+++ b/src/merkle/imr.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::impl_midstate_wrapper;
 use crate::jet::Jet;

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Merkle roots
 //!

--- a/src/merkle/tmr.rs
+++ b/src/merkle/tmr.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2022 by
-//   Christian Lewe <clewe@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::impl_midstate_wrapper;
 use hashes::sha256::Midstate;

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::dag::{DagLike, MaxSharing, NoSharing, PostOrderIterItem};
 use crate::jet::Jet;

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::dag::{InternalSharing, PostOrderIterItem};
 use crate::encode;

--- a/src/node/convert.rs
+++ b/src/node/convert.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Node Conversion
 //!

--- a/src/node/disconnect.rs
+++ b/src/node/disconnect.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Disconnect Nodes
 //!

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use super::{Disconnectable, FailEntropy};
 use crate::dag::Dag;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Simplicity Program Nodes
 //!

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::analysis::NodeBounds;
 use crate::dag::{DagLike, InternalSharing, MaxSharing, PostOrderIterItem};

--- a/src/node/witness.rs
+++ b/src/node/witness.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 use crate::dag::{InternalSharing, PostOrderIterItem};
 use crate::jet::Jet;

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Types Arrows
 //!

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Finalized (Complete) Type Data
 //!

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Types and Type Inference
 //!

--- a/src/types/precomputed.rs
+++ b/src/types/precomputed.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Precomputed Types
 //!

--- a/src/types/union_bound.rs
+++ b/src/types/union_bound.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! The Union-Bound Algorithm
 //!

--- a/src/types/variable.rs
+++ b/src/types/variable.rs
@@ -1,16 +1,4 @@
-// Rust Simplicity Library
-// Written in 2023 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! Names for type variables
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,17 +1,4 @@
-// Rust Simplicity Library
-// Written in 2020 by
-//   Andrew Poelstra <apoelstra@blockstream.com>
-//   Sanket Kanjalkar <sanket1729@gmail.com>
-//
-// To the extent possible under law, the author(s) have dedicated all
-// copyright and related and neighboring rights to this software to
-// the public domain worldwide. This software is distributed without
-// any warranty.
-//
-// You should have received a copy of the CC0 Public Domain Dedication
-// along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-//
+// SPDX-License-Identifier: CC0-1.0
 
 //! # Simplicity values
 //!


### PR DESCRIPTION
Make the CC0 license explicit in Cargo and on Github. Shorten the license header in each file.