### PR TITLE
Enable _FORTIFY_SOURCE

### DIFF
--- a/simplicity-sys/build.rs
+++ b/simplicity-sys/build.rs
@@ -44,6 +44,7 @@ fn main() {
     cc::Build::new()
         .std("c11")
         .flag_if_supported("-fno-inline-functions")
+        .opt_level(2)
         .files(files)
         .files(test_files)
         .file(Path::new("depend/wrapper.c"))


### PR DESCRIPTION
Fixes #197.

I couldn't find a way to disable _FORTIFY_SOURCE.

Maybe the compile time is not affected too badly by the increased optimization level of the C code. At least the C code doesn't change a lot.