### PR TITLE
Update jets script

### DIFF
--- a/update_jets.sh
+++ b/update_jets.sh
@@ -34,6 +34,7 @@ cabal exec GenRustJets
 cd "$RUST_DIR"
 mv "${C_DIR}/jets_ffi.rs" "./simplicity-sys/src/c_jets/jets_ffi.rs"
 mv "${C_DIR}/jets_wrapper.rs" "./simplicity-sys/src/c_jets/jets_wrapper.rs"
+mv "${C_DIR}/jets_wrapper.c" "./simplicity-sys/depend/jets_wrapper.c"
 
 mv "${C_DIR}/core.rs" "./src/jet/init/"
 mv "${C_DIR}/bitcoin.rs" "./src/jet/init/"

--- a/update_jets.sh
+++ b/update_jets.sh
@@ -32,7 +32,6 @@ cabal build -j8
 cabal exec GenRustJets
 
 cd "$RUST_DIR"
-# TODO: Change the name on Haskell side
 mv "${C_DIR}/jets_ffi.rs" "./simplicity-sys/src/c_jets/jets_ffi.rs"
 mv "${C_DIR}/jets_wrapper.rs" "./simplicity-sys/src/c_jets/jets_wrapper.rs"
 


### PR DESCRIPTION
Update the update jets script to handle wrapped jets.

Simplify the update jets script to use the currently checked-out version of libsimplicity instead of fiddling with git checkout. This might be controversial? The change makes my life easier. It might also break existing CI.