### PR TITLE
Typed value

### DIFF
--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -257,14 +257,14 @@ impl BitMachine {
                     self.copy(size_a);
                 }
                 node::Inner::InjL(left) => {
-                    let (b, _c) = ip.arrow().target.split_sum().unwrap();
+                    let (b, _c) = ip.arrow().target.as_sum().unwrap();
                     let padl_b_c = ip.arrow().target.bit_width() - b.bit_width() - 1;
                     self.write_bit(false);
                     self.skip(padl_b_c);
                     call_stack.push(CallStack::Goto(left));
                 }
                 node::Inner::InjR(left) => {
-                    let (_b, c) = ip.arrow().target.split_sum().unwrap();
+                    let (_b, c) = ip.arrow().target.as_sum().unwrap();
                     let padr_b_c = ip.arrow().target.bit_width() - c.bit_width() - 1;
                     self.write_bit(true);
                     self.skip(padr_b_c);
@@ -305,7 +305,7 @@ impl BitMachine {
                 }
                 node::Inner::Take(left) => call_stack.push(CallStack::Goto(left)),
                 node::Inner::Drop(left) => {
-                    let size_a = ip.arrow().source.split_product().unwrap().0.bit_width();
+                    let size_a = ip.arrow().source.as_product().unwrap().0.bit_width();
                     self.fwd(size_a);
                     call_stack.push(CallStack::Back(size_a));
                     call_stack.push(CallStack::Goto(left));
@@ -313,8 +313,8 @@ impl BitMachine {
                 node::Inner::Case(..) | node::Inner::AssertL(..) | node::Inner::AssertR(..) => {
                     let choice_bit = self.read[self.read.len() - 1].peek_bit(&self.data);
 
-                    let (sum_a_b, _c) = ip.arrow().source.split_product().unwrap();
-                    let (a, b) = sum_a_b.split_sum().unwrap();
+                    let (sum_a_b, _c) = ip.arrow().source.as_product().unwrap();
+                    let (a, b) = sum_a_b.as_sum().unwrap();
                     let size_a = a.bit_width();
                     let size_b = b.bit_width();
 

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -201,9 +201,12 @@ impl BitMachine {
         if !input.is_of_type(&self.source_ty) {
             return Err(ExecutionError::InputWrongType(self.source_ty.clone()));
         }
-        self.new_frame(input.len());
-        self.write_value(input);
-        self.move_frame();
+        // Unit value doesn't need extra frame
+        if !input.is_empty() {
+            self.new_frame(input.len());
+            self.write_value(input);
+            self.move_frame();
+        }
         Ok(())
     }
 

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -239,16 +239,14 @@ impl BitMachine {
             }
         }
 
+        if self.read.is_empty() != self.source_ty.is_empty() {
+            return Err(ExecutionError::InputWrongType(self.source_ty.clone()));
+        }
+
         let mut ip = program;
         let mut call_stack = vec![];
         let mut iterations = 0u64;
 
-        let input_width = ip.arrow().source.bit_width();
-        // TODO: convert into crate::Error
-        assert!(
-            self.read.is_empty() || input_width > 0,
-            "Program requires a non-empty input to execute",
-        );
         let output_width = ip.arrow().target.bit_width();
         if output_width > 0 {
             self.new_frame(output_width);

--- a/src/merkle/amr.rs
+++ b/src/merkle/amr.rs
@@ -48,7 +48,7 @@ impl Amr {
     /// Produce a CMR for an injl combinator
     pub fn injl(ty: &FinalArrow, child: Amr) -> Self {
         let a = &ty.source;
-        let (b, c) = ty.target.split_sum().unwrap();
+        let (b, c) = ty.target.as_sum().unwrap();
         Self::INJL_IV
             .update(a.tmr().into(), b.tmr().into())
             .update(c.tmr().into(), child)
@@ -57,7 +57,7 @@ impl Amr {
     /// Produce a CMR for an injr combinator
     pub fn injr(ty: &FinalArrow, child: Amr) -> Self {
         let a = &ty.source;
-        let (b, c) = ty.target.split_sum().unwrap();
+        let (b, c) = ty.target.as_sum().unwrap();
         Self::INJR_IV
             .update(a.tmr().into(), b.tmr().into())
             .update(c.tmr().into(), child)
@@ -65,7 +65,7 @@ impl Amr {
 
     /// Produce a CMR for a take combinator
     pub fn take(ty: &FinalArrow, child: Amr) -> Self {
-        let (a, b) = ty.source.split_product().unwrap();
+        let (a, b) = ty.source.as_sum().unwrap();
         let c = &ty.target;
         Self::TAKE_IV
             .update(a.tmr().into(), b.tmr().into())
@@ -74,7 +74,7 @@ impl Amr {
 
     /// Produce a CMR for a drop combinator
     pub fn drop(ty: &FinalArrow, child: Amr) -> Self {
-        let (a, b) = ty.source.split_product().unwrap();
+        let (a, b) = ty.source.as_product().unwrap();
         let c = &ty.target;
         Self::DROP_IV
             .update(a.tmr().into(), b.tmr().into())
@@ -93,8 +93,8 @@ impl Amr {
     }
 
     fn case_helper(iv: Amr, ty: &FinalArrow, left: Amr, right: Amr) -> Self {
-        let (sum_a_b, c) = ty.source.split_product().unwrap();
-        let (a, b) = sum_a_b.split_sum().unwrap();
+        let (sum_a_b, c) = ty.source.as_product().unwrap();
+        let (a, b) = sum_a_b.as_sum().unwrap();
         let d = &ty.target;
         iv.update(a.tmr().into(), b.tmr().into())
             .update(c.tmr().into(), d.tmr().into())
@@ -136,7 +136,7 @@ impl Amr {
     /// Produce a CMR for a disconnect combinator
     pub fn disconnect(ty: &FinalArrow, right_arrow: &FinalArrow, left: Amr, right: Amr) -> Self {
         let a = &ty.source;
-        let (b, d) = ty.target.split_product().unwrap();
+        let (b, d) = ty.target.as_product().unwrap();
         let c = &right_arrow.source;
         Self::DISCONNECT_IV
             .update(a.tmr().into(), b.tmr().into())

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -196,23 +196,23 @@ impl Final {
         &self.bound
     }
 
-    /// Returns whether this is the unit type
+    /// Check if the type is a unit.
     pub fn is_unit(&self) -> bool {
         self.bound == CompleteBound::Unit
     }
 
-    /// Return both children, if the type is a sum type
-    pub fn split_sum(&self) -> Option<(Arc<Self>, Arc<Self>)> {
+    /// Access the inner types of a sum type.
+    pub fn as_sum(&self) -> Option<(&Self, &Self)> {
         match &self.bound {
-            CompleteBound::Sum(left, right) => Some((left.clone(), right.clone())),
+            CompleteBound::Sum(left, right) => Some((left.as_ref(), right.as_ref())),
             _ => None,
         }
     }
 
-    /// Return both children, if the type is a product type
-    pub fn split_product(&self) -> Option<(Arc<Self>, Arc<Self>)> {
+    /// Access the inner types of a product type.
+    pub fn as_product(&self) -> Option<(&Self, &Self)> {
         match &self.bound {
-            CompleteBound::Product(left, right) => Some((left.clone(), right.clone())),
+            CompleteBound::Product(left, right) => Some((left.as_ref(), right.as_ref())),
             _ => None,
         }
     }

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -191,6 +191,12 @@ impl Final {
         self.bit_width
     }
 
+    /// Check if the type is a nested product of units.
+    /// In this case, values contain no information.
+    pub fn is_empty(&self) -> bool {
+        self.bit_width() == 0
+    }
+
     /// Accessor for the type bound
     pub fn bound(&self) -> &CompleteBound {
         &self.bound

--- a/src/value.rs
+++ b/src/value.rs
@@ -91,6 +91,35 @@ impl Value {
             .count()
     }
 
+    /// Check if the value is a unit.
+    pub fn is_unit(&self) -> bool {
+        matches!(self, Value::Unit)
+    }
+
+    /// Access the inner value of a left sum value.
+    pub fn as_left(&self) -> Option<&Self> {
+        match self {
+            Value::SumL(inner) => Some(inner.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Access the inner value of a right sum value.
+    pub fn as_right(&self) -> Option<&Self> {
+        match self {
+            Value::SumR(inner) => Some(inner.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Access the inner values of a product value.
+    pub fn as_product(&self) -> Option<(&Self, &Self)> {
+        match self {
+            Value::Prod(left, right) => Some((left.as_ref(), right.as_ref())),
+            _ => None,
+        }
+    }
+
     /// Encode a single bit as a value. Will panic if the input is out of range
     pub fn u1(n: u8) -> Arc<Self> {
         match n {

--- a/src/value.rs
+++ b/src/value.rs
@@ -368,6 +368,7 @@ impl fmt::Display for Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::jet::type_name::TypeName;
 
     #[test]
     fn value_display() {
@@ -376,5 +377,24 @@ mod tests {
         assert_eq!(Value::u1(0).to_string(), "0",);
         assert_eq!(Value::u1(1).to_string(), "1",);
         assert_eq!(Value::u4(6).to_string(), "((0,1),(1,0))",);
+    }
+
+    #[test]
+    fn is_of_type() {
+        let value_typename = [
+            (Value::unit(), TypeName(b"1")),
+            (Value::sum_l(Value::unit()), TypeName(b"+11")),
+            (Value::sum_r(Value::unit()), TypeName(b"+11")),
+            (Value::sum_l(Value::unit()), TypeName(b"+1h")),
+            (Value::sum_r(Value::unit()), TypeName(b"+h1")),
+            (Value::prod(Value::unit(), Value::unit()), TypeName(b"*11")),
+            (Value::u8(u8::MAX), TypeName(b"c")),
+            (Value::u64(u64::MAX), TypeName(b"l")),
+        ];
+
+        for (value, typename) in value_typename {
+            let ty = typename.to_final();
+            assert!(value.is_of_type(ty.as_ref()));
+        }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -84,12 +84,17 @@ impl Value {
         Arc::new(Value::Prod(left, right))
     }
 
-    #[allow(clippy::len_without_is_empty)]
     /// The length, in bits, of the value when encoded in the Bit Machine
     pub fn len(&self) -> usize {
         self.pre_order_iter::<NoSharing>()
             .filter(|inner| matches!(inner, Value::SumL(_) | Value::SumR(_)))
             .count()
+    }
+
+    /// Check if the value is a nested product of units.
+    /// In this case, the value contains no information.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Check if the value is a unit.


### PR DESCRIPTION
Add type checker to values and use it in the Bit Machine. This is particularly useful for running expressions with non-unit input types.