### PR TITLE
Expressive human

### DIFF
--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -208,15 +208,23 @@ impl<J: Jet> Forest<J> {
         ret
     }
 
-    /// Convert the forest into a witness node.
-    ///
-    /// Succeeds if the forest contains a "main" root and returns `None` otherwise.
+    /// Convert the main root of the forest into a witness node, if the root exists.
     pub fn to_witness_node(
         &self,
         witness: &HashMap<Arc<str>, Arc<Value>>,
     ) -> Option<Arc<WitnessNode<J>>> {
-        let main = self.roots.get("main")?;
-        Some(main.to_witness_node(witness, self.roots()))
+        self.to_witness_node_expression(witness, "main")
+    }
+
+    /// Convert the given root of the forest into a witness node, if the root exists.
+    pub fn to_witness_node_expression(
+        &self,
+        witness: &HashMap<Arc<str>, Arc<Value>>,
+        root: &str,
+    ) -> Option<Arc<WitnessNode<J>>> {
+        self.roots
+            .get(root)
+            .map(|commit| commit.to_witness_node(witness, self.roots()))
     }
 }
 

--- a/src/node/witness.rs
+++ b/src/node/witness.rs
@@ -197,16 +197,21 @@ impl<J: Jet> WitnessNode<J> {
 
         // 1. First, prune everything that we can
         let pruned_self = self.prune_and_retype();
+
         // 2. Then, set the root arrow to 1->1
         let unit_ty = types::Type::unit();
-        pruned_self
-            .arrow()
-            .source
-            .unify(&unit_ty, "setting root source to unit")?;
-        pruned_self
-            .arrow()
-            .target
-            .unify(&unit_ty, "setting root source to unit")?;
+        if pruned_self.arrow().source.final_data().is_none() {
+            pruned_self
+                .arrow()
+                .source
+                .unify(&unit_ty, "setting root source to unit")?;
+        }
+        if pruned_self.arrow().target.final_data().is_none() {
+            pruned_self
+                .arrow()
+                .target
+                .unify(&unit_ty, "setting root source to unit")?;
+        }
 
         // 3. Then attempt to convert the whole program to a RedeemNode.
         //    Despite all of the above this can still fail due to the


### PR DESCRIPTION
Finalize expressions (including non-programs) from the human encoding.

The finalization on master forces the root node to be 1→ 1.

The finalization of this PR allows root nodes whose type A → B is fixed by constraints inside the expression.

## Todo

- [ ] Move the expression finalization into a separate "dangerous" method
- [ ] Resolve free variables in root type to unit (in case the root type is not fully fixed)