### PR TITLE
Construct Types

### DIFF
--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -149,8 +149,8 @@ impl<'a> DagLike for &'a Final {
 }
 
 impl Final {
-    /// (Non-public) constructor for the final data of the unit type
-    pub(crate) fn unit() -> Arc<Self> {
+    /// Create the unit type.
+    pub fn unit() -> Arc<Self> {
         Arc::new(Final {
             bound: CompleteBound::Unit,
             bit_width: 0,
@@ -163,8 +163,8 @@ impl Final {
         super::precomputed::nth_power_of_2(n).final_data().unwrap()
     }
 
-    /// (Non-public) constructor for the final data of a sum type
-    pub(crate) fn sum(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {
+    /// Create the sum of the given `left` and `right` types.
+    pub fn sum(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {
         Arc::new(Final {
             tmr: Tmr::sum(left.tmr, right.tmr),
             bit_width: 1 + cmp::max(left.bit_width, right.bit_width),
@@ -172,8 +172,8 @@ impl Final {
         })
     }
 
-    /// (Non-public) constructor for the final data of a product type
-    pub(crate) fn product(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {
+    /// Create the product of the given `left` and `right` types.
+    pub fn product(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {
         Arc::new(Final {
             tmr: Tmr::product(left.tmr, right.tmr),
             bit_width: left.bit_width + right.bit_width,

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -158,7 +158,9 @@ impl Final {
         })
     }
 
-    /// Return a precomputed copy of 2^(2^n), for given n.
+    /// Create the type `2^(2^n)` for the given `n`.
+    ///
+    /// The type is precomputed and fast to access.
     pub fn two_two_n(n: usize) -> Arc<Self> {
         super::precomputed::nth_power_of_2(n).final_data().unwrap()
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -371,24 +371,26 @@ impl Type {
         Type::from(Bound::free(name))
     }
 
-    /// Return a unit type.
+    /// Create the unit type.
     pub fn unit() -> Self {
         Type::from(Bound::unit())
     }
 
-    /// Return a precomputed copy of 2^(2^n), for given n.
+    /// Create the type `2^(2^n)` for the given `n`.
+    ///
+    /// The type is precomputed and fast to access.
     pub fn two_two_n(n: usize) -> Self {
         precomputed::nth_power_of_2(n)
     }
 
-    /// Return the sum of the given two types.
-    pub fn sum(a: Self, b: Self) -> Self {
-        Type::from(Bound::sum(a, b))
+    /// Create the sum of the given `left` and `right` types.
+    pub fn sum(left: Self, right: Self) -> Self {
+        Type::from(Bound::sum(left, right))
     }
 
-    /// Return the product of the given two types.
-    pub fn product(a: Self, b: Self) -> Self {
-        Type::from(Bound::product(a, b))
+    /// Create the product of the given `left` and `right` types.
+    pub fn product(left: Self, right: Self) -> Self {
+        Type::from(Bound::product(left, right))
     }
 
     /// Clones the `Type`.


### PR DESCRIPTION
Make the constructors for `Final` public and update documentation.

I would like these constructors to return `Self` instead of `Arc<Self>`, because then the caller can choose how he wants to save the returned value. However, we would need to change the union bound code for that, which seems too invasive for now.