### PR TITLE
Cap maximum depth of incomplete type display

### DIFF
--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -300,7 +300,7 @@ mod tests {
 
         assert!(matches!(
             node.finalize_types_non_program(),
-            Err(crate::Error::Type(types::Error::OccursCheck)),
+            Err(crate::Error::Type(types::Error::OccursCheck { .. })),
         ));
     }
 
@@ -320,7 +320,7 @@ mod tests {
 
         assert!(matches!(
             comp2.finalize_types_non_program(),
-            Err(crate::Error::Type(types::Error::OccursCheck)),
+            Err(crate::Error::Type(types::Error::OccursCheck { .. })),
         ));
     }
 
@@ -347,7 +347,7 @@ mod tests {
 
         assert!(matches!(
             comp8.finalize_types_non_program(),
-            Err(crate::Error::Type(types::Error::OccursCheck)),
+            Err(crate::Error::Type(types::Error::OccursCheck { .. })),
         ));
     }
 

--- a/src/node/display.rs
+++ b/src/node/display.rs
@@ -46,7 +46,7 @@ where
     &'a Node<M>: DagLike,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for data in self.0.verbose_pre_order_iter::<NoSharing>() {
+        for data in self.0.verbose_pre_order_iter::<NoSharing>(None) {
             match data.n_children_yielded {
                 1 => match data.node.inner() {
                     Inner::Comp(..) => f.write_str("; ")?,

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -77,7 +77,7 @@ impl fmt::Debug for Final {
 impl fmt::Display for Final {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut skipping: Option<Tmr> = None;
-        for data in self.verbose_pre_order_iter::<NoSharing>() {
+        for data in self.verbose_pre_order_iter::<NoSharing>(None) {
             if let Some(skip) = skipping {
                 if data.is_complete && data.node.tmr == skip {
                     skipping = None;

--- a/src/value.rs
+++ b/src/value.rs
@@ -339,7 +339,7 @@ impl fmt::Debug for Value {
 
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for data in self.verbose_pre_order_iter::<NoSharing>() {
+        for data in self.verbose_pre_order_iter::<NoSharing>(None) {
             match data.node {
                 Value::Unit => {
                     if data.n_children_yielded == 0


### PR DESCRIPTION
This limit may still be too high -- I think you can output a 2^64 sized type which will wreck any terminal. But at least it's finite now.

Every instance of `_iter` methods called on an incomplete type (in the types/ module anyway) now has a maximum depth on it, which should eliminate all the places where we might loop forever with incomplete types.

Fixes #177