### PR TITLE
[mega pr, do not merge] types: rewrite inference API to use a slab allocator for type bounds

### DIFF
--- a/jets-bench/benches/elements/data_structures.rs
+++ b/jets-bench/benches/elements/data_structures.rs
@@ -4,9 +4,8 @@
 use bitcoin::secp256k1;
 use elements::Txid;
 use rand::{thread_rng, RngCore};
-pub use simplicity::hashes::sha256;
 use simplicity::{
-    bitcoin, elements, hashes::Hash, hex::FromHex, types::Type, BitIter, Error, Value,
+    bitcoin, elements, hashes::Hash, hex::FromHex, types::{self, Type}, BitIter, Error, Value,
 };
 use std::sync::Arc;
 
@@ -57,7 +56,8 @@ pub fn var_len_buf_from_slice(v: &[u8], mut n: usize) -> Result<Arc<Value>, Erro
     assert!(n < 16);
     assert!(v.len() < (1 << (n + 1)));
     let mut iter = BitIter::new(v.iter().copied());
-    let types = Type::powers_of_two(n); // size n + 1
+    let ctx = types::Context::new();
+    let types = Type::powers_of_two(&ctx, n); // size n + 1
     let mut res = None;
     while n > 0 {
         let v = if v.len() >= (1 << (n + 1)) {

--- a/jets-bench/benches/elements/main.rs
+++ b/jets-bench/benches/elements/main.rs
@@ -93,8 +93,8 @@ impl ElementsBenchEnvType {
 }
 
 fn jet_arrow(jet: Elements) -> (Arc<types::Final>, Arc<types::Final>) {
-    let src_ty = jet.source_ty().to_type().final_data().unwrap();
-    let tgt_ty = jet.target_ty().to_type().final_data().unwrap();
+    let src_ty = jet.source_ty().to_final();
+    let tgt_ty = jet.target_ty().to_final();
     (src_ty, tgt_ty)
 }
 
@@ -302,7 +302,7 @@ fn bench(c: &mut Criterion) {
         let keypair = bitcoin::key::Keypair::new(&secp_ctx, &mut thread_rng());
         let xpk = bitcoin::key::XOnlyPublicKey::from_keypair(&keypair);
 
-        let msg = bitcoin::secp256k1::Message::from_slice(&rand::random::<[u8; 32]>()).unwrap();
+        let msg = bitcoin::secp256k1::Message::from_digest_slice(&rand::random::<[u8; 32]>()).unwrap();
         let sig = secp_ctx.sign_schnorr(&msg, &keypair);
         let xpk_value = Value::u256_from_slice(&xpk.0.serialize());
         let sig_value = Value::u512_from_slice(sig.as_ref());

--- a/src/bit_encoding/bitwriter.rs
+++ b/src/bit_encoding/bitwriter.rs
@@ -117,12 +117,13 @@ mod tests {
     use super::*;
     use crate::jet::Core;
     use crate::node::CoreConstructible;
+    use crate::types;
     use crate::ConstructNode;
     use std::sync::Arc;
 
     #[test]
     fn vec() {
-        let program = Arc::<ConstructNode<Core>>::unit();
+        let program = Arc::<ConstructNode<Core>>::unit(&types::Context::new());
         let _ = write_to_vec(|w| program.encode(w));
     }
 

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -428,14 +428,16 @@ impl<J: Jet> NamedConstructNode<J> {
                 if self.for_main {
                     // For `main`, only apply type ascriptions *after* inference has completely
                     // determined the type.
-                    let source_ty = types::Type::complete(Arc::clone(&commit_data.arrow().source));
+                    let source_ty =
+                        types::Type::complete(ctx, Arc::clone(&commit_data.arrow().source));
                     for ty in data.node.cached_data().user_source_types.as_ref() {
                         if let Err(e) = ctx.unify(&source_ty, ty, "binding source type annotation")
                         {
                             self.errors.add(data.node.position(), e);
                         }
                     }
-                    let target_ty = types::Type::complete(Arc::clone(&commit_data.arrow().target));
+                    let target_ty =
+                        types::Type::complete(ctx, Arc::clone(&commit_data.arrow().target));
                     for ty in data.node.cached_data().user_target_types.as_ref() {
                         if let Err(e) = ctx.unify(&target_ty, ty, "binding target type annotation")
                         {
@@ -460,7 +462,7 @@ impl<J: Jet> NamedConstructNode<J> {
 
         if for_main {
             let ctx = self.inference_context();
-            let unit_ty = types::Type::unit();
+            let unit_ty = types::Type::unit(ctx);
             if self.cached_data().user_source_types.is_empty() {
                 if let Err(e) = ctx.unify(
                     &self.arrow().source,

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -413,17 +413,13 @@ impl<J: Jet> NamedConstructNode<J> {
                 if self.for_main {
                     // For `main`, only apply type ascriptions *after* inference has completely
                     // determined the type.
-                    let source_bound =
-                        types::Bound::Complete(Arc::clone(&commit_data.arrow().source));
-                    let source_ty = types::Type::from(source_bound);
+                    let source_ty = types::Type::complete(Arc::clone(&commit_data.arrow().source));
                     for ty in data.node.cached_data().user_source_types.as_ref() {
                         if let Err(e) = source_ty.unify(ty, "binding source type annotation") {
                             self.errors.add(data.node.position(), e);
                         }
                     }
-                    let target_bound =
-                        types::Bound::Complete(Arc::clone(&commit_data.arrow().target));
-                    let target_ty = types::Type::from(target_bound);
+                    let target_ty = types::Type::complete(Arc::clone(&commit_data.arrow().target));
                     for ty in data.node.cached_data().user_target_types.as_ref() {
                         if let Err(e) = target_ty.unify(ty, "binding target type annotation") {
                             self.errors.add(data.node.position(), e);

--- a/src/human_encoding/parse/ast.rs
+++ b/src/human_encoding/parse/ast.rs
@@ -82,14 +82,14 @@ pub enum Type {
 
 impl Type {
     /// Convert to a Simplicity type
-    pub fn reify(self) -> types::Type {
+    pub fn reify(self, ctx: &types::Context) -> types::Type {
         match self {
-            Type::Name(s) => types::Type::free(s),
-            Type::One => types::Type::unit(),
-            Type::Two => types::Type::sum(types::Type::unit(), types::Type::unit()),
-            Type::Product(left, right) => types::Type::product(left.reify(), right.reify()),
-            Type::Sum(left, right) => types::Type::sum(left.reify(), right.reify()),
-            Type::TwoTwoN(n) => types::Type::two_two_n(n as usize), // cast OK as we are only using tiny numbers
+            Type::Name(s) => types::Type::free(ctx, s),
+            Type::One => types::Type::unit(ctx),
+            Type::Two => types::Type::sum(types::Type::unit(ctx), types::Type::unit(ctx)),
+            Type::Product(left, right) => types::Type::product(left.reify(ctx), right.reify(ctx)),
+            Type::Sum(left, right) => types::Type::sum(left.reify(ctx), right.reify(ctx)),
+            Type::TwoTwoN(n) => types::Type::two_two_n(ctx, n as usize), // cast OK as we are only using tiny numbers
         }
     }
 }

--- a/src/human_encoding/parse/ast.rs
+++ b/src/human_encoding/parse/ast.rs
@@ -86,9 +86,20 @@ impl Type {
         match self {
             Type::Name(s) => types::Type::free(ctx, s),
             Type::One => types::Type::unit(ctx),
-            Type::Two => types::Type::sum(types::Type::unit(ctx), types::Type::unit(ctx)),
-            Type::Product(left, right) => types::Type::product(left.reify(ctx), right.reify(ctx)),
-            Type::Sum(left, right) => types::Type::sum(left.reify(ctx), right.reify(ctx)),
+            Type::Two => {
+                let unit_ty = types::Type::unit(ctx);
+                types::Type::sum(ctx, unit_ty.shallow_clone(), unit_ty)
+            }
+            Type::Product(left, right) => {
+                let left = left.reify(ctx);
+                let right = right.reify(ctx);
+                types::Type::product(ctx, left, right)
+            }
+            Type::Sum(left, right) => {
+                let left = left.reify(ctx);
+                let right = right.reify(ctx);
+                types::Type::sum(ctx, left, right)
+            }
             Type::TwoTwoN(n) => types::Type::two_two_n(ctx, n as usize), // cast OK as we are only using tiny numbers
         }
     }

--- a/src/human_encoding/parse/ast.rs
+++ b/src/human_encoding/parse/ast.rs
@@ -633,9 +633,7 @@ fn grammar<J: Jet + 'static>() -> Grammar<Ast<J>> {
                     Error::BadWordLength { bit_length },
                 ));
             }
-            let ty = types::Type::two_two_n(bit_length.trailing_zeros() as usize)
-                .final_data()
-                .unwrap();
+            let ty = types::Final::two_two_n(bit_length.trailing_zeros() as usize);
             // unwrap ok here since literally every sequence of bits is a valid
             // value for the given type
             let value = iter.read_value(&ty).unwrap();

--- a/src/human_encoding/parse/mod.rs
+++ b/src/human_encoding/parse/mod.rs
@@ -181,6 +181,7 @@ pub fn parse<J: Jet + 'static>(
     program: &str,
 ) -> Result<HashMap<Arc<str>, Arc<NamedCommitNode<J>>>, ErrorSet> {
     let mut errors = ErrorSet::new();
+    let inference_context = types::Context::new();
     // **
     // Step 1: Read expressions into HashMap, checking for dupes and illegal names.
     // **
@@ -205,10 +206,10 @@ pub fn parse<J: Jet + 'static>(
             }
         }
         if let Some(ty) = line.arrow.0 {
-            entry.add_source_type(ty.reify());
+            entry.add_source_type(ty.reify(&inference_context));
         }
         if let Some(ty) = line.arrow.1 {
-            entry.add_target_type(ty.reify());
+            entry.add_target_type(ty.reify(&inference_context));
         }
     }
 
@@ -419,7 +420,6 @@ pub fn parse<J: Jet + 'static>(
     drop(unresolved_map);
 
     // ** Step 3: convert each DAG of names/expressions into a DAG of NamedNodes.
-    let inference_context = types::Context::new();
     let mut roots = HashMap::<Arc<str>, Arc<NamedCommitNode<J>>>::new();
     for (name, expr) in &resolved_map {
         if expr.in_degree.load(Ordering::SeqCst) > 0 {

--- a/src/human_encoding/parse/mod.rs
+++ b/src/human_encoding/parse/mod.rs
@@ -7,7 +7,7 @@ mod ast;
 use crate::dag::{Dag, DagLike, InternalSharing};
 use crate::jet::Jet;
 use crate::node;
-use crate::types::Type;
+use crate::types::{self, Type};
 use std::collections::HashMap;
 use std::mem;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -419,6 +419,7 @@ pub fn parse<J: Jet + 'static>(
     drop(unresolved_map);
 
     // ** Step 3: convert each DAG of names/expressions into a DAG of NamedNodes.
+    let inference_context = types::Context::new();
     let mut roots = HashMap::<Arc<str>, Arc<NamedCommitNode<J>>>::new();
     for (name, expr) in &resolved_map {
         if expr.in_degree.load(Ordering::SeqCst) > 0 {
@@ -485,6 +486,7 @@ pub fn parse<J: Jet + 'static>(
                 .unwrap_or_else(|| Arc::from(namer.assign_name(inner.as_ref()).as_str()));
 
             let node = NamedConstructNode::new(
+                &inference_context,
                 Arc::clone(&name),
                 data.node.position,
                 Arc::clone(&data.node.user_source_types),

--- a/src/jet/elements/tests.rs
+++ b/src/jet/elements/tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use crate::jet::elements::{ElementsEnv, ElementsUtxo};
 use crate::jet::Elements;
 use crate::node::{ConstructNode, JetConstructible};
+use crate::types;
 use crate::{BitMachine, Cmr, Value};
 use elements::secp256k1_zkp::Tweak;
 use elements::taproot::ControlBlock;
@@ -99,7 +100,7 @@ fn test_ffi_env() {
         BlockHash::all_zeros(),
     );
 
-    let prog = Arc::<ConstructNode<_>>::jet(Elements::LockTime);
+    let prog = Arc::<ConstructNode<_>>::jet(&types::Context::new(), Elements::LockTime);
     assert_eq!(
         BitMachine::test_exec(prog, &env).expect("executing"),
         Value::u32(100),

--- a/src/jet/mod.rs
+++ b/src/jet/mod.rs
@@ -93,18 +93,20 @@ pub trait Jet:
 mod tests {
     use crate::jet::Core;
     use crate::node::{ConstructNode, CoreConstructible, JetConstructible};
+    use crate::types;
     use crate::{BitMachine, Value};
     use std::sync::Arc;
 
     #[test]
     fn test_ffi_jet() {
+        let ctx = types::Context::new();
         let two_words = Arc::<ConstructNode<_>>::comp(
             &Arc::<ConstructNode<_>>::pair(
-                &Arc::<ConstructNode<_>>::const_word(Value::u32(2)),
-                &Arc::<ConstructNode<_>>::const_word(Value::u32(16)),
+                &Arc::<ConstructNode<_>>::const_word(&ctx, Value::u32(2)),
+                &Arc::<ConstructNode<_>>::const_word(&ctx, Value::u32(16)),
             )
             .unwrap(),
-            &Arc::<ConstructNode<_>>::jet(Core::Add32),
+            &Arc::<ConstructNode<_>>::jet(&ctx, Core::Add32),
         )
         .unwrap();
         assert_eq!(
@@ -118,9 +120,10 @@ mod tests {
 
     #[test]
     fn test_simple() {
+        let ctx = types::Context::new();
         let two_words = Arc::<ConstructNode<Core>>::pair(
-            &Arc::<ConstructNode<_>>::const_word(Value::u32(2)),
-            &Arc::<ConstructNode<_>>::const_word(Value::u16(16)),
+            &Arc::<ConstructNode<_>>::const_word(&ctx, Value::u32(2)),
+            &Arc::<ConstructNode<_>>::const_word(&ctx, Value::u16(16)),
         )
         .unwrap();
         assert_eq!(

--- a/src/jet/type_name.rs
+++ b/src/jet/type_name.rs
@@ -4,7 +4,7 @@
 //!
 //! Source and target types of jet nodes need to be specified manually.
 
-use crate::types::{Final, Type};
+use crate::types::{self, Final, Type};
 use std::cmp;
 use std::sync::Arc;
 
@@ -32,8 +32,8 @@ pub struct TypeName(pub &'static [u8]);
 
 impl TypeName {
     /// Convert the type name into a type.
-    pub fn to_type(&self) -> Type {
-        Type::complete(self.to_final())
+    pub fn to_type(&self, ctx: &types::Context) -> Type {
+        Type::complete(ctx, self.to_final())
     }
 
     /// Convert the type name into a finalized type.

--- a/src/merkle/amr.rs
+++ b/src/merkle/amr.rs
@@ -291,11 +291,13 @@ mod tests {
 
     use crate::jet::Core;
     use crate::node::{ConstructNode, JetConstructible};
+    use crate::types;
     use std::sync::Arc;
 
     #[test]
     fn fixed_amr() {
-        let node = Arc::<ConstructNode<_>>::jet(Core::Verify)
+        let ctx = types::Context::new();
+        let node = Arc::<ConstructNode<_>>::jet(&ctx, Core::Verify)
             .finalize_types_non_program()
             .unwrap();
         // Checked against C implementation

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -253,75 +253,108 @@ impl Cmr {
     ];
 }
 
-impl CoreConstructible for Cmr {
+/// Wrapper around a CMR which allows it to be constructed with the
+/// `*Constructible*` traits, allowing CMRs to be computed using the
+/// same generic construction code that nodes are.
+pub struct ConstructibleCmr {
+    pub cmr: Cmr,
+}
+
+impl CoreConstructible for ConstructibleCmr {
     fn iden() -> Self {
-        Cmr::iden()
+        ConstructibleCmr { cmr: Cmr::iden() }
     }
 
     fn unit() -> Self {
-        Cmr::unit()
+        ConstructibleCmr { cmr: Cmr::unit() }
     }
 
     fn injl(child: &Self) -> Self {
-        Cmr::injl(*child)
+        ConstructibleCmr {
+            cmr: Cmr::injl(child.cmr),
+        }
     }
 
     fn injr(child: &Self) -> Self {
-        Cmr::injl(*child)
+        ConstructibleCmr {
+            cmr: Cmr::injl(child.cmr),
+        }
     }
 
     fn take(child: &Self) -> Self {
-        Cmr::take(*child)
+        ConstructibleCmr {
+            cmr: Cmr::take(child.cmr),
+        }
     }
 
     fn drop_(child: &Self) -> Self {
-        Cmr::drop(*child)
+        ConstructibleCmr {
+            cmr: Cmr::drop(child.cmr),
+        }
     }
 
     fn comp(left: &Self, right: &Self) -> Result<Self, Error> {
-        Ok(Cmr::comp(*left, *right))
+        Ok(ConstructibleCmr {
+            cmr: Cmr::comp(left.cmr, right.cmr),
+        })
     }
 
     fn case(left: &Self, right: &Self) -> Result<Self, Error> {
-        Ok(Cmr::case(*left, *right))
+        Ok(ConstructibleCmr {
+            cmr: Cmr::case(left.cmr, right.cmr),
+        })
     }
 
     fn assertl(left: &Self, right: Cmr) -> Result<Self, Error> {
-        Ok(Cmr::case(*left, right))
+        Ok(ConstructibleCmr {
+            cmr: Cmr::case(left.cmr, right),
+        })
     }
 
     fn assertr(left: Cmr, right: &Self) -> Result<Self, Error> {
-        Ok(Cmr::case(left, *right))
+        Ok(ConstructibleCmr {
+            cmr: Cmr::case(left, right.cmr),
+        })
     }
 
     fn pair(left: &Self, right: &Self) -> Result<Self, Error> {
-        Ok(Cmr::pair(*left, *right))
+        Ok(ConstructibleCmr {
+            cmr: Cmr::pair(left.cmr, right.cmr),
+        })
     }
 
     fn fail(entropy: FailEntropy) -> Self {
-        Cmr::fail(entropy)
+        ConstructibleCmr {
+            cmr: Cmr::fail(entropy),
+        }
     }
 
     fn const_word(word: Arc<Value>) -> Self {
-        Cmr::const_word(&word)
+        ConstructibleCmr {
+            cmr: Cmr::const_word(&word),
+        }
     }
 }
 
-impl<X> DisconnectConstructible<X> for Cmr {
+impl<X> DisconnectConstructible<X> for ConstructibleCmr {
     fn disconnect(left: &Self, _right: &X) -> Result<Self, Error> {
-        Ok(Cmr::disconnect(*left))
+        Ok(ConstructibleCmr {
+            cmr: Cmr::disconnect(left.cmr),
+        })
     }
 }
 
-impl<W> WitnessConstructible<W> for Cmr {
+impl<W> WitnessConstructible<W> for ConstructibleCmr {
     fn witness(_witness: W) -> Self {
-        Cmr::witness()
+        ConstructibleCmr {
+            cmr: Cmr::witness(),
+        }
     }
 }
 
-impl<J: Jet> JetConstructible<J> for Cmr {
+impl<J: Jet> JetConstructible<J> for ConstructibleCmr {
     fn jet(jet: J) -> Self {
-        jet.cmr()
+        ConstructibleCmr { cmr: jet.cmr() }
     }
 }
 

--- a/src/merkle/tmr.rs
+++ b/src/merkle/tmr.rs
@@ -257,8 +257,10 @@ impl Tmr {
 
 #[cfg(test)]
 mod tests {
-    use super::super::bip340_iv;
     use super::*;
+
+    use crate::merkle::bip340_iv;
+    use crate::types;
 
     #[test]
     fn const_ivs() {
@@ -280,7 +282,7 @@ mod tests {
     #[allow(clippy::needless_range_loop)]
     fn const_powers_of_2() {
         let n = Tmr::POWERS_OF_TWO.len();
-        let types = crate::types::Type::powers_of_two(n);
+        let types = crate::types::Type::powers_of_two(&types::Context::new(), n);
         for i in 0..n {
             assert_eq!(Some(Tmr::POWERS_OF_TWO[i]), types[i].tmr());
         }

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -53,7 +53,7 @@ impl<J: Jet> ConstructNode<J> {
     /// Sets the source and target type of the node to unit
     pub fn set_arrow_to_program(&self) -> Result<(), types::Error> {
         let ctx = self.data.inference_context();
-        let unit_ty = types::Type::unit();
+        let unit_ty = types::Type::unit(ctx);
         ctx.unify(
             &self.arrow().source,
             &unit_ty,

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -52,13 +52,18 @@ impl<J: Jet> ConstructNode<J> {
 
     /// Sets the source and target type of the node to unit
     pub fn set_arrow_to_program(&self) -> Result<(), types::Error> {
+        let ctx = self.data.inference_context();
         let unit_ty = types::Type::unit();
-        self.arrow()
-            .source
-            .unify(&unit_ty, "setting root source to unit")?;
-        self.arrow()
-            .target
-            .unify(&unit_ty, "setting root target to unit")?;
+        ctx.unify(
+            &self.arrow().source,
+            &unit_ty,
+            "setting root source to unit",
+        )?;
+        ctx.unify(
+            &self.arrow().target,
+            &unit_ty,
+            "setting root target to unit",
+        )?;
         Ok(())
     }
 

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -165,16 +165,16 @@ impl<J: Jet> ConstructData<J> {
 }
 
 impl<J> CoreConstructible for ConstructData<J> {
-    fn iden() -> Self {
+    fn iden(inference_context: &types::Context) -> Self {
         ConstructData {
-            arrow: Arrow::iden(),
+            arrow: Arrow::iden(inference_context),
             phantom: PhantomData,
         }
     }
 
-    fn unit() -> Self {
+    fn unit(inference_context: &types::Context) -> Self {
         ConstructData {
-            arrow: Arrow::unit(),
+            arrow: Arrow::unit(inference_context),
             phantom: PhantomData,
         }
     }
@@ -242,18 +242,22 @@ impl<J> CoreConstructible for ConstructData<J> {
         })
     }
 
-    fn fail(entropy: FailEntropy) -> Self {
+    fn fail(inference_context: &types::Context, entropy: FailEntropy) -> Self {
         ConstructData {
-            arrow: Arrow::fail(entropy),
+            arrow: Arrow::fail(inference_context, entropy),
             phantom: PhantomData,
         }
     }
 
-    fn const_word(word: Arc<Value>) -> Self {
+    fn const_word(inference_context: &types::Context, word: Arc<Value>) -> Self {
         ConstructData {
-            arrow: Arrow::const_word(word),
+            arrow: Arrow::const_word(inference_context, word),
             phantom: PhantomData,
         }
+    }
+
+    fn inference_context(&self) -> &types::Context {
+        self.arrow.inference_context()
     }
 }
 
@@ -271,18 +275,18 @@ impl<J: Jet> DisconnectConstructible<Option<Arc<ConstructNode<J>>>> for Construc
 }
 
 impl<J> WitnessConstructible<NoWitness> for ConstructData<J> {
-    fn witness(witness: NoWitness) -> Self {
+    fn witness(inference_context: &types::Context, witness: NoWitness) -> Self {
         ConstructData {
-            arrow: Arrow::witness(witness),
+            arrow: Arrow::witness(inference_context, witness),
             phantom: PhantomData,
         }
     }
 }
 
 impl<J: Jet> JetConstructible<J> for ConstructData<J> {
-    fn jet(jet: J) -> Self {
+    fn jet(inference_context: &types::Context, jet: J) -> Self {
         ConstructData {
-            arrow: Arrow::jet(jet),
+            arrow: Arrow::jet(inference_context, jet),
             phantom: PhantomData,
         }
     }
@@ -295,7 +299,8 @@ mod tests {
 
     #[test]
     fn occurs_check_error() {
-        let iden = Arc::<ConstructNode<Core>>::iden();
+        let ctx = types::Context::new();
+        let iden = Arc::<ConstructNode<Core>>::iden(&ctx);
         let node = Arc::<ConstructNode<Core>>::disconnect(&iden, &Some(Arc::clone(&iden))).unwrap();
 
         assert!(matches!(
@@ -306,8 +311,9 @@ mod tests {
 
     #[test]
     fn occurs_check_2() {
+        let ctx = types::Context::new();
         // A more complicated occurs-check test that caused a deadlock in the past.
-        let iden = Arc::<ConstructNode<Core>>::iden();
+        let iden = Arc::<ConstructNode<Core>>::iden(&ctx);
         let injr = Arc::<ConstructNode<Core>>::injr(&iden);
         let pair = Arc::<ConstructNode<Core>>::pair(&injr, &iden).unwrap();
         let drop = Arc::<ConstructNode<Core>>::drop_(&pair);
@@ -326,8 +332,9 @@ mod tests {
 
     #[test]
     fn occurs_check_3() {
+        let ctx = types::Context::new();
         // A similar example that caused a slightly different deadlock in the past.
-        let wit = Arc::<ConstructNode<Core>>::witness(NoWitness);
+        let wit = Arc::<ConstructNode<Core>>::witness(&ctx, NoWitness);
         let drop = Arc::<ConstructNode<Core>>::drop_(&wit);
 
         let comp1 = Arc::<ConstructNode<Core>>::comp(&drop, &drop).unwrap();
@@ -353,7 +360,8 @@ mod tests {
 
     #[test]
     fn type_check_error() {
-        let unit = Arc::<ConstructNode<Core>>::unit();
+        let ctx = types::Context::new();
+        let unit = Arc::<ConstructNode<Core>>::unit(&ctx);
         let case = Arc::<ConstructNode<Core>>::case(&unit, &unit).unwrap();
 
         assert!(matches!(
@@ -364,26 +372,30 @@ mod tests {
 
     #[test]
     fn scribe() {
-        let unit = Arc::<ConstructNode<Core>>::unit();
+        // Ok to use same type inference context for all the below tests,
+        // since everything has concrete types and anyway we only care
+        // about CMRs, for which type inference is irrelevant.
+        let ctx = types::Context::new();
+        let unit = Arc::<ConstructNode<Core>>::unit(&ctx);
         let bit0 = Arc::<ConstructNode<Core>>::injl(&unit);
         let bit1 = Arc::<ConstructNode<Core>>::injr(&unit);
         let bits01 = Arc::<ConstructNode<Core>>::pair(&bit0, &bit1).unwrap();
 
         assert_eq!(
             unit.cmr(),
-            Arc::<ConstructNode<Core>>::scribe(&Value::Unit).cmr()
+            Arc::<ConstructNode<Core>>::scribe(&ctx, &Value::Unit).cmr()
         );
         assert_eq!(
             bit0.cmr(),
-            Arc::<ConstructNode<Core>>::scribe(&Value::u1(0)).cmr()
+            Arc::<ConstructNode<Core>>::scribe(&ctx, &Value::u1(0)).cmr()
         );
         assert_eq!(
             bit1.cmr(),
-            Arc::<ConstructNode<Core>>::scribe(&Value::u1(1)).cmr()
+            Arc::<ConstructNode<Core>>::scribe(&ctx, &Value::u1(1)).cmr()
         );
         assert_eq!(
             bits01.cmr(),
-            Arc::<ConstructNode<Core>>::scribe(&Value::u2(1)).cmr()
+            Arc::<ConstructNode<Core>>::scribe(&ctx, &Value::u2(1)).cmr()
         );
     }
 }

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -290,7 +290,8 @@ impl<J: Jet> RedeemNode<J> {
                 data: &PostOrderIterItem<&ConstructNode<J>>,
                 _: &NoWitness,
             ) -> Result<Arc<Value>, Self::Error> {
-                let target_ty = data.node.data.arrow().target.finalize()?;
+                let arrow = data.node.data.arrow();
+                let target_ty = arrow.target.finalize()?;
                 self.bits.read_value(&target_ty).map_err(Error::from)
             }
 

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -223,7 +223,10 @@ impl<J: Jet> RedeemNode<J> {
     /// Convert a [`RedeemNode`] back into a [`WitnessNode`]
     /// by loosening the finalized types, witness data and disconnected branches.
     pub fn to_witness_node(&self) -> Arc<WitnessNode<J>> {
-        struct ToWitness<J>(PhantomData<J>);
+        struct ToWitness<J> {
+            inference_context: types::Context,
+            phantom: PhantomData<J>,
+        }
 
         impl<J: Jet> Converter<Redeem<J>, Witness<J>> for ToWitness<J> {
             type Error = ();
@@ -258,12 +261,16 @@ impl<J: Jet> RedeemNode<J> {
                 let inner = inner
                     .map(|node| node.cached_data())
                     .map_witness(|maybe_value| maybe_value.clone());
-                Ok(WitnessData::from_inner(inner).expect("types are already finalized"))
+                Ok(WitnessData::from_inner(&self.inference_context, inner)
+                    .expect("types were already finalized"))
             }
         }
 
-        self.convert::<InternalSharing, _, _>(&mut ToWitness(PhantomData))
-            .unwrap()
+        self.convert::<InternalSharing, _, _>(&mut ToWitness {
+            inference_context: types::Context::new(),
+            phantom: PhantomData,
+        })
+        .unwrap()
     }
 
     /// Decode a Simplicity program from bits, including the witness data.

--- a/src/node/witness.rs
+++ b/src/node/witness.rs
@@ -206,7 +206,7 @@ impl<J: Jet> WitnessNode<J> {
         let pruned_self = self.prune_and_retype();
         // 2. Then, set the root arrow to 1->1
         let ctx = pruned_self.inference_context();
-        let unit_ty = types::Type::unit();
+        let unit_ty = types::Type::unit(ctx);
         ctx.unify(
             &pruned_self.arrow().source,
             &unit_ty,

--- a/src/node/witness.rs
+++ b/src/node/witness.rs
@@ -205,15 +205,18 @@ impl<J: Jet> WitnessNode<J> {
         // 1. First, prune everything that we can
         let pruned_self = self.prune_and_retype();
         // 2. Then, set the root arrow to 1->1
+        let ctx = pruned_self.inference_context();
         let unit_ty = types::Type::unit();
-        pruned_self
-            .arrow()
-            .source
-            .unify(&unit_ty, "setting root source to unit")?;
-        pruned_self
-            .arrow()
-            .target
-            .unify(&unit_ty, "setting root source to unit")?;
+        ctx.unify(
+            &pruned_self.arrow().source,
+            &unit_ty,
+            "setting root source to unit",
+        )?;
+        ctx.unify(
+            &pruned_self.arrow().target,
+            &unit_ty,
+            "setting root target to unit",
+        )?;
 
         // 3. Then attempt to convert the whole program to a RedeemNode.
         //    Despite all of the above this can still fail due to the

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -17,6 +17,7 @@ use crate::node::{
     ConstructNode, CoreConstructible, JetConstructible, NoWitness, WitnessConstructible,
 };
 use crate::policy::serialize::{self, AssemblyConstructible};
+use crate::types;
 use crate::{Cmr, CommitNode, FailEntropy};
 use crate::{SimplicityKey, ToXOnlyPubkey, Translator};
 
@@ -58,7 +59,7 @@ pub enum Policy<Pk: SimplicityKey> {
 
 impl<Pk: ToXOnlyPubkey> Policy<Pk> {
     /// Serializes the policy as a Simplicity fragment, with all witness nodes unpopulated.
-    fn serialize_no_witness<N>(&self) -> Option<N>
+    fn serialize_no_witness<N>(&self, inference_context: &types::Context) -> Option<N>
     where
         N: CoreConstructible
             + JetConstructible<Elements>
@@ -66,53 +67,60 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
             + AssemblyConstructible,
     {
         match *self {
-            Policy::Unsatisfiable(entropy) => Some(serialize::unsatisfiable(entropy)),
-            Policy::Trivial => Some(serialize::trivial()),
-            Policy::After(n) => Some(serialize::after(n)),
-            Policy::Older(n) => Some(serialize::older(n)),
-            Policy::Key(ref key) => Some(serialize::key(key, NoWitness)),
-            Policy::Sha256(ref hash) => Some(serialize::sha256::<Pk, _, _>(hash, NoWitness)),
+            Policy::Unsatisfiable(entropy) => {
+                Some(serialize::unsatisfiable(inference_context, entropy))
+            }
+            Policy::Trivial => Some(serialize::trivial(inference_context)),
+            Policy::After(n) => Some(serialize::after(inference_context, n)),
+            Policy::Older(n) => Some(serialize::older(inference_context, n)),
+            Policy::Key(ref key) => Some(serialize::key(inference_context, key, NoWitness)),
+            Policy::Sha256(ref hash) => Some(serialize::sha256::<Pk, _, _>(
+                inference_context,
+                hash,
+                NoWitness,
+            )),
             Policy::And {
                 ref left,
                 ref right,
             } => {
-                let left = left.serialize_no_witness()?;
-                let right = right.serialize_no_witness()?;
+                let left = left.serialize_no_witness(inference_context)?;
+                let right = right.serialize_no_witness(inference_context)?;
                 Some(serialize::and(&left, &right))
             }
             Policy::Or {
                 ref left,
                 ref right,
             } => {
-                let left = left.serialize_no_witness()?;
-                let right = right.serialize_no_witness()?;
+                let left = left.serialize_no_witness(inference_context)?;
+                let right = right.serialize_no_witness(inference_context)?;
                 Some(serialize::or(&left, &right, NoWitness))
             }
             Policy::Threshold(k, ref subs) => {
                 let k = u32::try_from(k).expect("can have k at most 2^32 in a threshold");
                 let subs = subs
                     .iter()
-                    .map(Self::serialize_no_witness)
+                    .map(|sub| sub.serialize_no_witness(inference_context))
                     .collect::<Option<Vec<N>>>()?;
                 let wits = iter::repeat(NoWitness)
                     .take(subs.len())
                     .collect::<Vec<NoWitness>>();
                 Some(serialize::threshold(k, &subs, &wits))
             }
-            Policy::Assembly(cmr) => N::assembly(cmr),
+            Policy::Assembly(cmr) => N::assembly(inference_context, cmr),
         }
     }
 
     /// Return the program commitment of the policy.
     pub fn commit(&self) -> Option<Arc<CommitNode<Elements>>> {
-        let construct: Arc<ConstructNode<Elements>> = self.serialize_no_witness()?;
+        let construct: Arc<ConstructNode<Elements>> =
+            self.serialize_no_witness(&types::Context::new())?;
         let commit = construct.finalize_types().expect("policy has sound types");
         Some(commit)
     }
 
     /// Return the CMR of the policy.
     pub fn cmr(&self) -> Cmr {
-        self.serialize_no_witness::<crate::merkle::cmr::ConstructibleCmr>()
+        self.serialize_no_witness::<crate::merkle::cmr::ConstructibleCmr>(&types::Context::new())
             .expect("CMR is defined for asm fragment")
             .cmr
     }

--- a/src/policy/ast.rs
+++ b/src/policy/ast.rs
@@ -112,8 +112,9 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
 
     /// Return the CMR of the policy.
     pub fn cmr(&self) -> Cmr {
-        self.serialize_no_witness()
+        self.serialize_no_witness::<crate::merkle::cmr::ConstructibleCmr>()
             .expect("CMR is defined for asm fragment")
+            .cmr
     }
 }
 

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -3,6 +3,7 @@
 //! Serialization of Policy as Simplicity
 
 use crate::jet::{Elements, Jet};
+use crate::merkle::cmr::ConstructibleCmr;
 use crate::node::{CoreConstructible, JetConstructible, WitnessConstructible};
 use crate::{Cmr, ConstructNode, ToXOnlyPubkey};
 use crate::{FailEntropy, Value};
@@ -14,13 +15,13 @@ use std::sync::Arc;
 pub trait AssemblyConstructible: Sized {
     /// Construct the assembly fragment with the given CMR.
     ///
-    /// The construction fails if the CMR alone is not enough information to construct the type.
+    /// The construction fails if the CMR alone is not enough information to construct the object.
     fn assembly(cmr: Cmr) -> Option<Self>;
 }
 
-impl AssemblyConstructible for Cmr {
+impl AssemblyConstructible for ConstructibleCmr {
     fn assembly(cmr: Cmr) -> Option<Self> {
-        Some(cmr)
+        Some(ConstructibleCmr { cmr })
     }
 }
 

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -74,133 +74,12 @@ impl Arrow {
         })
     }
 
-    /// Create a unification arrow for a fresh `unit` combinator
-    pub fn for_unit() -> Self {
+    /// Same as [`Self::clone`] but named to make it clearer that this is cheap
+    pub fn shallow_clone(&self) -> Self {
         Arrow {
-            source: Type::free(new_name("unit_src_")),
-            target: Type::unit(),
+            source: self.source.shallow_clone(),
+            target: self.target.shallow_clone(),
         }
-    }
-
-    /// Create a unification arrow for a fresh `iden` combinator
-    pub fn for_iden() -> Self {
-        // Throughout this module, when two types are the same, we reuse a
-        // pointer to them rather than creating distinct types and unifying
-        // them. This theoretically could lead to more confusing errors for
-        // the user during type inference, but in practice type inference
-        // is completely opaque and there's no harm in making it moreso.
-        let new = Type::free(new_name("iden_src_"));
-        Arrow {
-            source: new.shallow_clone(),
-            target: new,
-        }
-    }
-
-    /// Create a unification arrow for a fresh `witness` combinator
-    pub fn for_witness() -> Self {
-        Arrow {
-            source: Type::free(new_name("witness_src_")),
-            target: Type::free(new_name("witness_tgt_")),
-        }
-    }
-
-    /// Create a unification arrow for a fresh `fail` combinator
-    pub fn for_fail() -> Self {
-        Arrow {
-            source: Type::free(new_name("fail_src_")),
-            target: Type::free(new_name("fail_tgt_")),
-        }
-    }
-
-    /// Create a unification arrow for a fresh jet combinator
-    pub fn for_jet<J: Jet>(jet: J) -> Self {
-        Arrow {
-            source: jet.source_ty().to_type(),
-            target: jet.target_ty().to_type(),
-        }
-    }
-
-    /// Create a unification arrow for a fresh const-word combinator
-    pub fn for_const_word(word: &Value) -> Self {
-        let len = word.len();
-        assert!(len > 0, "Words must not be the empty bitstring");
-        assert!(len.is_power_of_two());
-        let depth = word.len().trailing_zeros();
-        Arrow {
-            source: Type::unit(),
-            target: Type::two_two_n(depth as usize),
-        }
-    }
-
-    /// Create a unification arrow for a fresh `injl` combinator
-    pub fn for_injl(child_arrow: &Arrow) -> Self {
-        Arrow {
-            source: child_arrow.source.shallow_clone(),
-            target: Type::sum(
-                child_arrow.target.shallow_clone(),
-                Type::free(new_name("injl_tgt_")),
-            ),
-        }
-    }
-
-    /// Create a unification arrow for a fresh `injr` combinator
-    pub fn for_injr(child_arrow: &Arrow) -> Self {
-        Arrow {
-            source: child_arrow.source.shallow_clone(),
-            target: Type::sum(
-                Type::free(new_name("injr_tgt_")),
-                child_arrow.target.shallow_clone(),
-            ),
-        }
-    }
-
-    /// Create a unification arrow for a fresh `take` combinator
-    pub fn for_take(child_arrow: &Arrow) -> Self {
-        Arrow {
-            source: Type::product(
-                child_arrow.source.shallow_clone(),
-                Type::free(new_name("take_src_")),
-            ),
-            target: child_arrow.target.shallow_clone(),
-        }
-    }
-
-    /// Create a unification arrow for a fresh `drop` combinator
-    pub fn for_drop(child_arrow: &Arrow) -> Self {
-        Arrow {
-            source: Type::product(
-                Type::free(new_name("drop_src_")),
-                child_arrow.source.shallow_clone(),
-            ),
-            target: child_arrow.target.shallow_clone(),
-        }
-    }
-
-    /// Create a unification arrow for a fresh `pair` combinator
-    pub fn for_pair(lchild_arrow: &Arrow, rchild_arrow: &Arrow) -> Result<Self, Error> {
-        lchild_arrow.source.unify(
-            &rchild_arrow.source,
-            "pair combinator: left source = right source",
-        )?;
-        Ok(Arrow {
-            source: lchild_arrow.source.shallow_clone(),
-            target: Type::product(
-                lchild_arrow.target.shallow_clone(),
-                rchild_arrow.target.shallow_clone(),
-            ),
-        })
-    }
-
-    /// Create a unification arrow for a fresh `comp` combinator
-    pub fn for_comp(lchild_arrow: &Arrow, rchild_arrow: &Arrow) -> Result<Self, Error> {
-        lchild_arrow.target.unify(
-            &rchild_arrow.source,
-            "comp combinator: left target = right source",
-        )?;
-        Ok(Arrow {
-            source: lchild_arrow.source.shallow_clone(),
-            target: rchild_arrow.target.shallow_clone(),
-        })
     }
 
     /// Create a unification arrow for a fresh `case` combinator
@@ -211,10 +90,7 @@ impl Arrow {
     ///
     /// If neither child is provided, this function will not raise an error; it
     /// is the responsibility of the caller to detect this case and error elsewhere.
-    pub fn for_case(
-        lchild_arrow: Option<&Arrow>,
-        rchild_arrow: Option<&Arrow>,
-    ) -> Result<Self, Error> {
+    fn for_case(lchild_arrow: Option<&Arrow>, rchild_arrow: Option<&Arrow>) -> Result<Self, Error> {
         let a = Type::free(new_name("case_a_"));
         let b = Type::free(new_name("case_b_"));
         let c = Type::free(new_name("case_c_"));
@@ -247,8 +123,8 @@ impl Arrow {
         })
     }
 
-    /// Create a unification arrow for a fresh `comp` combinator
-    pub fn for_disconnect(lchild_arrow: &Arrow, rchild_arrow: &Arrow) -> Result<Self, Error> {
+    /// Helper function to combine code for the two `DisconnectConstructible` impls for [`Arrow`].
+    fn for_disconnect(lchild_arrow: &Arrow, rchild_arrow: &Arrow) -> Result<Self, Error> {
         let a = Type::free(new_name("disconnect_a_"));
         let b = Type::free(new_name("disconnect_b_"));
         let c = rchild_arrow.source.shallow_clone();
@@ -272,43 +148,76 @@ impl Arrow {
             target: prod_b_d,
         })
     }
-
-    /// Same as [`Self::clone`] but named to make it clearer that this is cheap
-    pub fn shallow_clone(&self) -> Self {
-        Arrow {
-            source: self.source.shallow_clone(),
-            target: self.target.shallow_clone(),
-        }
-    }
 }
 
 impl CoreConstructible for Arrow {
     fn iden() -> Self {
-        Self::for_iden()
+        // Throughout this module, when two types are the same, we reuse a
+        // pointer to them rather than creating distinct types and unifying
+        // them. This theoretically could lead to more confusing errors for
+        // the user during type inference, but in practice type inference
+        // is completely opaque and there's no harm in making it moreso.
+        let new = Type::free(new_name("iden_src_"));
+        Arrow {
+            source: new.shallow_clone(),
+            target: new,
+        }
     }
 
     fn unit() -> Self {
-        Self::for_unit()
+        Arrow {
+            source: Type::free(new_name("unit_src_")),
+            target: Type::unit(),
+        }
     }
 
     fn injl(child: &Self) -> Self {
-        Self::for_injl(child)
+        Arrow {
+            source: child.source.shallow_clone(),
+            target: Type::sum(
+                child.target.shallow_clone(),
+                Type::free(new_name("injl_tgt_")),
+            ),
+        }
     }
 
     fn injr(child: &Self) -> Self {
-        Self::for_injr(child)
+        Arrow {
+            source: child.source.shallow_clone(),
+            target: Type::sum(
+                Type::free(new_name("injr_tgt_")),
+                child.target.shallow_clone(),
+            ),
+        }
     }
 
     fn take(child: &Self) -> Self {
-        Self::for_take(child)
+        Arrow {
+            source: Type::product(
+                child.source.shallow_clone(),
+                Type::free(new_name("take_src_")),
+            ),
+            target: child.target.shallow_clone(),
+        }
     }
 
     fn drop_(child: &Self) -> Self {
-        Self::for_drop(child)
+        Arrow {
+            source: Type::product(
+                Type::free(new_name("drop_src_")),
+                child.source.shallow_clone(),
+            ),
+            target: child.target.shallow_clone(),
+        }
     }
 
     fn comp(left: &Self, right: &Self) -> Result<Self, Error> {
-        Self::for_comp(left, right)
+        left.target
+            .unify(&right.source, "comp combinator: left target = right source")?;
+        Ok(Arrow {
+            source: left.source.shallow_clone(),
+            target: right.target.shallow_clone(),
+        })
     }
 
     fn case(left: &Self, right: &Self) -> Result<Self, Error> {
@@ -324,15 +233,30 @@ impl CoreConstructible for Arrow {
     }
 
     fn pair(left: &Self, right: &Self) -> Result<Self, Error> {
-        Self::for_pair(left, right)
+        left.source
+            .unify(&right.source, "pair combinator: left source = right source")?;
+        Ok(Arrow {
+            source: left.source.shallow_clone(),
+            target: Type::product(left.target.shallow_clone(), right.target.shallow_clone()),
+        })
     }
 
     fn fail(_: crate::FailEntropy) -> Self {
-        Self::for_fail()
+        Arrow {
+            source: Type::free(new_name("fail_src_")),
+            target: Type::free(new_name("fail_tgt_")),
+        }
     }
 
     fn const_word(word: Arc<Value>) -> Self {
-        Self::for_const_word(&word)
+        let len = word.len();
+        assert!(len > 0, "Words must not be the empty bitstring");
+        assert!(len.is_power_of_two());
+        let depth = word.len().trailing_zeros();
+        Arrow {
+            source: Type::unit(),
+            target: Type::two_two_n(depth as usize),
+        }
     }
 }
 
@@ -365,12 +289,18 @@ impl DisconnectConstructible<Option<&Arrow>> for Arrow {
 
 impl<J: Jet> JetConstructible<J> for Arrow {
     fn jet(jet: J) -> Self {
-        Self::for_jet(jet)
+        Arrow {
+            source: jet.source_ty().to_type(),
+            target: jet.target_ty().to_type(),
+        }
     }
 }
 
 impl<W> WitnessConstructible<W> for Arrow {
     fn witness(_: W) -> Self {
-        Self::for_witness()
+        Arrow {
+            source: Type::free(new_name("witness_src_")),
+            target: Type::free(new_name("witness_tgt_")),
+        }
     }
 }

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -18,7 +18,7 @@ use crate::node::{
     CoreConstructible, DisconnectConstructible, JetConstructible, NoDisconnect,
     WitnessConstructible,
 };
-use crate::types::{Bound, Context, Error, Final, Type};
+use crate::types::{Context, Error, Final, Type};
 use crate::{jet::Jet, Value};
 
 use super::variable::new_name;
@@ -123,17 +123,19 @@ impl Arrow {
 
         let target = Type::free(&ctx, String::new());
         if let Some(lchild_arrow) = lchild_arrow {
-            ctx.bind(
+            ctx.bind_product(
                 &lchild_arrow.source,
-                Bound::Product(a, c.shallow_clone()),
+                &a,
+                &c,
                 "case combinator: left source = A × C",
             )?;
             ctx.unify(&target, &lchild_arrow.target, "").unwrap();
         }
         if let Some(rchild_arrow) = rchild_arrow {
-            ctx.bind(
+            ctx.bind_product(
                 &rchild_arrow.source,
-                Bound::Product(b, c),
+                &b,
+                &c,
                 "case combinator: left source = B × C",
             )?;
             ctx.unify(
@@ -162,20 +164,20 @@ impl Arrow {
         let c = rchild_arrow.source.shallow_clone();
         let d = rchild_arrow.target.shallow_clone();
 
-        let prod_256_a = Bound::Product(Type::two_two_n(ctx, 8), a.shallow_clone());
-        let prod_b_c = Bound::Product(b.shallow_clone(), c);
-        let prod_b_d = Type::product(ctx, b, d);
-
-        ctx.bind(
+        ctx.bind_product(
             &lchild_arrow.source,
-            prod_256_a,
+            &Type::two_two_n(ctx, 8),
+            &a,
             "disconnect combinator: left source = 2^256 × A",
         )?;
-        ctx.bind(
+        ctx.bind_product(
             &lchild_arrow.target,
-            prod_b_c,
+            &b,
+            &c,
             "disconnect combinator: left target = B × C",
         )?;
+
+        let prod_b_d = Type::product(ctx, b, d);
 
         Ok(Arrow {
             source: a,

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -125,7 +125,7 @@ impl Arrow {
         if let Some(lchild_arrow) = lchild_arrow {
             ctx.bind(
                 &lchild_arrow.source,
-                Arc::new(Bound::Product(a, c.shallow_clone())),
+                Bound::Product(a, c.shallow_clone()),
                 "case combinator: left source = A × C",
             )?;
             ctx.unify(&target, &lchild_arrow.target, "").unwrap();
@@ -133,7 +133,7 @@ impl Arrow {
         if let Some(rchild_arrow) = rchild_arrow {
             ctx.bind(
                 &rchild_arrow.source,
-                Arc::new(Bound::Product(b, c)),
+                Bound::Product(b, c),
                 "case combinator: left source = B × C",
             )?;
             ctx.unify(
@@ -168,12 +168,12 @@ impl Arrow {
 
         ctx.bind(
             &lchild_arrow.source,
-            Arc::new(prod_256_a),
+            prod_256_a,
             "disconnect combinator: left source = 2^256 × A",
         )?;
         ctx.bind(
             &lchild_arrow.target,
-            Arc::new(prod_b_c),
+            prod_b_c,
             "disconnect combinator: left target = B × C",
         )?;
 

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -118,8 +118,8 @@ impl Arrow {
         let b = Type::free(&ctx, new_name("case_b_"));
         let c = Type::free(&ctx, new_name("case_c_"));
 
-        let sum_a_b = Type::sum(a.shallow_clone(), b.shallow_clone());
-        let prod_sum_a_b_c = Type::product(sum_a_b, c.shallow_clone());
+        let sum_a_b = Type::sum(&ctx, a.shallow_clone(), b.shallow_clone());
+        let prod_sum_a_b_c = Type::product(&ctx, sum_a_b, c.shallow_clone());
 
         let target = Type::free(&ctx, String::new());
         if let Some(lchild_arrow) = lchild_arrow {
@@ -164,7 +164,7 @@ impl Arrow {
 
         let prod_256_a = Bound::Product(Type::two_two_n(ctx, 8), a.shallow_clone());
         let prod_b_c = Bound::Product(b.shallow_clone(), c);
-        let prod_b_d = Type::product(b, d);
+        let prod_b_d = Type::product(ctx, b, d);
 
         ctx.bind(
             &lchild_arrow.source,
@@ -212,6 +212,7 @@ impl CoreConstructible for Arrow {
         Arrow {
             source: child.source.shallow_clone(),
             target: Type::sum(
+                &child.inference_context,
                 child.target.shallow_clone(),
                 Type::free(&child.inference_context, new_name("injl_tgt_")),
             ),
@@ -223,6 +224,7 @@ impl CoreConstructible for Arrow {
         Arrow {
             source: child.source.shallow_clone(),
             target: Type::sum(
+                &child.inference_context,
                 Type::free(&child.inference_context, new_name("injr_tgt_")),
                 child.target.shallow_clone(),
             ),
@@ -233,6 +235,7 @@ impl CoreConstructible for Arrow {
     fn take(child: &Self) -> Self {
         Arrow {
             source: Type::product(
+                &child.inference_context,
                 child.source.shallow_clone(),
                 Type::free(&child.inference_context, new_name("take_src_")),
             ),
@@ -244,6 +247,7 @@ impl CoreConstructible for Arrow {
     fn drop_(child: &Self) -> Self {
         Arrow {
             source: Type::product(
+                &child.inference_context,
                 Type::free(&child.inference_context, new_name("drop_src_")),
                 child.source.shallow_clone(),
             ),
@@ -287,7 +291,11 @@ impl CoreConstructible for Arrow {
         )?;
         Ok(Arrow {
             source: left.source.shallow_clone(),
-            target: Type::product(left.target.shallow_clone(), right.target.shallow_clone()),
+            target: Type::product(
+                &left.inference_context,
+                left.target.shallow_clone(),
+                right.target.shallow_clone(),
+            ),
             inference_context: left.inference_context.shallow_clone(),
         })
     }

--- a/src/types/context.rs
+++ b/src/types/context.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Type Inference Context
+//!
+//! When constructing a Simplicity program, you must first create a type inference
+//! context, in which type inference occurs incrementally during construction. Each
+//! leaf node (e.g. `unit` and `iden`) must explicitly refer to the type inference
+//! context, while combinator nodes (e.g. `comp`) infer the context from their
+//! children, raising an error if there are multiple children whose contexts don't
+//! match.
+//!
+//! This helps to prevent situations in which users attempt to construct multiple
+//! independent programs, but types in one program accidentally refer to types in
+//! the other.
+//!
+
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use super::Bound;
+
+/// Type inference context, or handle to a context.
+///
+/// Can be cheaply cloned with [`Context::shallow_clone`]. These clones will
+/// refer to the same underlying type inference context, and can be used as
+/// handles to each other. The derived [`Context::clone`] has the same effect.
+///
+/// There is currently no way to create an independent context with the same
+/// type inference variables (i.e. a deep clone). If you need this functionality,
+/// please file an issue.
+#[derive(Clone, Default)]
+pub struct Context {
+    slab: Arc<Mutex<Vec<Bound>>>,
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let id = Arc::as_ptr(&self.slab) as usize;
+        write!(f, "inference_ctx_{:08x}", id)
+    }
+}
+
+impl PartialEq for Context {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.slab, &other.slab)
+    }
+}
+impl Eq for Context {}
+
+impl Context {
+    /// Creates a new empty type inference context.
+    pub fn new() -> Self {
+        Context {
+            slab: Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    /// Creates a new handle to the context.
+    ///
+    /// This handle holds a reference to the underlying context and will keep
+    /// it alive. The context will only be dropped once all handles, including
+    /// the original context object, are dropped.
+    pub fn shallow_clone(&self) -> Self {
+        Self {
+            slab: Arc::clone(&self.slab),
+        }
+    }
+
+    /// Checks whether two inference contexts are equal, and returns an error if not.
+    pub fn check_eq(&self, other: &Self) -> Result<(), super::Error> {
+        if self == other {
+            Ok(())
+        } else {
+            Err(super::Error::InferenceContextMismatch)
+        }
+    }
+}

--- a/src/types/context.rs
+++ b/src/types/context.rs
@@ -15,12 +15,12 @@
 //!
 
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::dag::{Dag, DagLike};
 
 use super::bound_mutex::BoundMutex;
-use super::{Bound, Error, Final, Type};
+use super::{Bound, CompleteBound, Error, Final, Type};
 
 /// Type inference context, or handle to a context.
 ///
@@ -156,14 +156,24 @@ impl Context {
     ///
     /// Fails if the type has an existing incompatible bound.
     pub fn bind(&self, existing: &Type, new: Bound, hint: &'static str) -> Result<(), Error> {
-        existing.bind(new, hint)
+        let existing_root = existing.bound.root();
+        let lock = self.lock();
+        lock.bind(existing_root, new, hint)
     }
 
     /// Unify the type with another one.
     ///
     /// Fails if the bounds on the two types are incompatible
     pub fn unify(&self, ty1: &Type, ty2: &Type, hint: &'static str) -> Result<(), Error> {
-        ty1.unify(ty2, hint)
+        let lock = self.lock();
+        lock.unify(ty1, ty2, hint)
+    }
+
+    /// Locks the underlying slab mutex.
+    fn lock(&self) -> LockedContext {
+        LockedContext {
+            slab: self.slab.lock().unwrap(),
+        }
     }
 }
 
@@ -182,10 +192,6 @@ impl BoundRef {
             Arc::as_ptr(&ctx.slab),
             "bound was accessed from a type inference context that did not create it",
         );
-    }
-
-    pub fn bind(&self, bound: Bound, hint: &'static str) -> Result<(), Error> {
-        self.index.bind(bound, hint)
     }
 
     /// Creates an "occurs-check ID" which is just a copy of the [`BoundRef`]
@@ -238,4 +244,98 @@ pub struct OccursCheckId {
     // Will become an index into the context in a latter commit, but for
     // now we set it to an Arc<BoundMutex> to preserve semantics.
     index: *const BoundMutex,
+}
+
+/// Structure representing an inference context with its slab allocator mutex locked.
+///
+/// This type is never exposed outside of this module and should only exist
+/// ephemerally within function calls into this module.
+struct LockedContext<'ctx> {
+    slab: MutexGuard<'ctx, Vec<Bound>>,
+}
+
+impl<'ctx> LockedContext<'ctx> {
+    /// Unify the type with another one.
+    ///
+    /// Fails if the bounds on the two types are incompatible
+    fn unify(&self, existing: &Type, other: &Type, hint: &'static str) -> Result<(), Error> {
+        existing.bound.unify(&other.bound, |x_bound, y_bound| {
+            self.bind(x_bound, y_bound.index.get(), hint)
+        })
+    }
+
+    fn bind(&self, existing: BoundRef, new: Bound, hint: &'static str) -> Result<(), Error> {
+        let existing_bound = existing.index.get();
+        let bind_error = || Error::Bind {
+            existing_bound: existing_bound.shallow_clone(),
+            new_bound: new.shallow_clone(),
+            hint,
+        };
+
+        match (&existing_bound, &new) {
+            // Binding a free type to anything is a no-op
+            (_, Bound::Free(_)) => Ok(()),
+            // Free types are simply dropped and replaced by the new bound
+            (Bound::Free(_), _) => {
+                // Free means non-finalized, so set() is ok.
+                existing.index.set(new);
+                Ok(())
+            }
+            // Binding complete->complete shouldn't ever happen, but if so, we just
+            // compare the two types and return a pass/fail
+            (Bound::Complete(ref existing_final), Bound::Complete(ref new_final)) => {
+                if existing_final == new_final {
+                    Ok(())
+                } else {
+                    Err(bind_error())
+                }
+            }
+            // Binding an incomplete to a complete type requires recursion.
+            (Bound::Complete(complete), incomplete) | (incomplete, Bound::Complete(complete)) => {
+                match (complete.bound(), incomplete) {
+                    // A unit might match a Bound::Free(..) or a Bound::Complete(..),
+                    // and both cases were handled above. So this is an error.
+                    (CompleteBound::Unit, _) => Err(bind_error()),
+                    (
+                        CompleteBound::Product(ref comp1, ref comp2),
+                        Bound::Product(ref ty1, ref ty2),
+                    )
+                    | (CompleteBound::Sum(ref comp1, ref comp2), Bound::Sum(ref ty1, ref ty2)) => {
+                        let bound1 = ty1.bound.root();
+                        let bound2 = ty2.bound.root();
+                        self.bind(bound1, Bound::Complete(Arc::clone(comp1)), hint)?;
+                        self.bind(bound2, Bound::Complete(Arc::clone(comp2)), hint)
+                    }
+                    _ => Err(bind_error()),
+                }
+            }
+            (Bound::Sum(ref x1, ref x2), Bound::Sum(ref y1, ref y2))
+            | (Bound::Product(ref x1, ref x2), Bound::Product(ref y1, ref y2)) => {
+                self.unify(x1, y1, hint)?;
+                self.unify(x2, y2, hint)?;
+                // This type was not complete, but it may be after unification, giving us
+                // an opportunity to finaliize it. We do this eagerly to make sure that
+                // "complete" (no free children) is always equivalent to "finalized" (the
+                // bound field having variant Bound::Complete(..)), even during inference.
+                //
+                // It also gives the user access to more information about the type,
+                // prior to finalization.
+                if let (Some(data1), Some(data2)) = (y1.final_data(), y2.final_data()) {
+                    existing
+                        .index
+                        .set(Bound::Complete(if let Bound::Sum(..) = existing_bound {
+                            Final::sum(data1, data2)
+                        } else {
+                            Final::product(data1, data2)
+                        }));
+                }
+                Ok(())
+            }
+            (x, y) => Err(Error::Bind {
+                existing_bound: x.shallow_clone(),
+                new_bound: y.shallow_clone(),
+                hint,
+            }),
+        }
+    }
 }

--- a/src/types/context.rs
+++ b/src/types/context.rs
@@ -17,7 +17,7 @@
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
-use super::Bound;
+use super::{Bound, Error, Type};
 
 /// Type inference context, or handle to a context.
 ///
@@ -73,5 +73,20 @@ impl Context {
         } else {
             Err(super::Error::InferenceContextMismatch)
         }
+    }
+
+    /// Binds the type to a given bound. If this fails, attach the provided
+    /// hint to the error.
+    ///
+    /// Fails if the type has an existing incompatible bound.
+    pub fn bind(&self, existing: &Type, new: Arc<Bound>, hint: &'static str) -> Result<(), Error> {
+        existing.bind(new, hint)
+    }
+
+    /// Unify the type with another one.
+    ///
+    /// Fails if the bounds on the two types are incompatible
+    pub fn unify(&self, ty1: &Type, ty2: &Type, hint: &'static str) -> Result<(), Error> {
+        ty1.unify(ty2, hint)
     }
 }

--- a/src/types/context.rs
+++ b/src/types/context.rs
@@ -19,7 +19,6 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::dag::{Dag, DagLike};
 
-use super::bound_mutex::BoundMutex;
 use super::{Bound, CompleteBound, Error, Final, Type};
 
 /// Type inference context, or handle to a context.
@@ -60,9 +59,13 @@ impl Context {
 
     /// Helper function to allocate a bound and return a reference to it.
     fn alloc_bound(&self, bound: Bound) -> BoundRef {
+        let mut lock = self.lock();
+        lock.slab.push(bound);
+        let index = lock.slab.len() - 1;
+
         BoundRef {
             context: Arc::as_ptr(&self.slab),
-            index: Arc::new(BoundMutex::new(bound)),
+            index,
         }
     }
 
@@ -132,7 +135,8 @@ impl Context {
     /// Panics if passed a `BoundRef` that was not allocated by this context.
     pub fn get(&self, bound: &BoundRef) -> Bound {
         bound.assert_matches_context(self);
-        bound.index.get().shallow_clone()
+        let lock = self.lock();
+        lock.slab[bound.index].shallow_clone()
     }
 
     /// Reassigns a bound to a different bound.
@@ -147,8 +151,8 @@ impl Context {
     ///
     /// Also panics if passed a `BoundRef` that was not allocated by this context.
     pub fn reassign_non_complete(&self, bound: BoundRef, new: Bound) {
-        bound.assert_matches_context(self);
-        bound.index.set(new)
+        let mut lock = self.lock();
+        lock.reassign_non_complete(bound, new);
     }
 
     /// Binds the type to a given bound. If this fails, attach the provided
@@ -157,7 +161,7 @@ impl Context {
     /// Fails if the type has an existing incompatible bound.
     pub fn bind(&self, existing: &Type, new: Bound, hint: &'static str) -> Result<(), Error> {
         let existing_root = existing.bound.root();
-        let lock = self.lock();
+        let mut lock = self.lock();
         lock.bind(existing_root, new, hint)
     }
 
@@ -165,7 +169,7 @@ impl Context {
     ///
     /// Fails if the bounds on the two types are incompatible
     pub fn unify(&self, ty1: &Type, ty2: &Type, hint: &'static str) -> Result<(), Error> {
-        let lock = self.lock();
+        let mut lock = self.lock();
         lock.unify(ty1, ty2, hint)
     }
 
@@ -180,9 +184,7 @@ impl Context {
 #[derive(Debug, Clone)]
 pub struct BoundRef {
     context: *const Mutex<Vec<Bound>>,
-    // Will become an index into the context in a latter commit, but for
-    // now we set it to an Arc<BoundMutex> to preserve semantics.
-    index: Arc<BoundMutex>,
+    index: usize,
 }
 
 impl BoundRef {
@@ -200,7 +202,7 @@ impl BoundRef {
     pub fn occurs_check_id(&self) -> OccursCheckId {
         OccursCheckId {
             context: self.context,
-            index: Arc::as_ptr(&self.index),
+            index: self.index,
         }
     }
 }
@@ -211,13 +213,13 @@ impl super::PointerLike for BoundRef {
             self.context, other.context,
             "tried to compare two bounds from different inference contexts"
         );
-        Arc::ptr_eq(&self.index, &other.index)
+        self.index == other.index
     }
 
     fn shallow_clone(&self) -> Self {
         BoundRef {
             context: self.context,
-            index: Arc::clone(&self.index),
+            index: self.index,
         }
     }
 }
@@ -243,7 +245,7 @@ pub struct OccursCheckId {
     context: *const Mutex<Vec<Bound>>,
     // Will become an index into the context in a latter commit, but for
     // now we set it to an Arc<BoundMutex> to preserve semantics.
-    index: *const BoundMutex,
+    index: usize,
 }
 
 /// Structure representing an inference context with its slab allocator mutex locked.
@@ -255,17 +257,25 @@ struct LockedContext<'ctx> {
 }
 
 impl<'ctx> LockedContext<'ctx> {
+    fn reassign_non_complete(&mut self, bound: BoundRef, new: Bound) {
+        assert!(
+            !matches!(self.slab[bound.index], Bound::Complete(..)),
+            "tried to modify finalized type",
+        );
+        self.slab[bound.index] = new;
+    }
+
     /// Unify the type with another one.
     ///
     /// Fails if the bounds on the two types are incompatible
-    fn unify(&self, existing: &Type, other: &Type, hint: &'static str) -> Result<(), Error> {
+    fn unify(&mut self, existing: &Type, other: &Type, hint: &'static str) -> Result<(), Error> {
         existing.bound.unify(&other.bound, |x_bound, y_bound| {
-            self.bind(x_bound, y_bound.index.get(), hint)
+            self.bind(x_bound, self.slab[y_bound.index].shallow_clone(), hint)
         })
     }
 
-    fn bind(&self, existing: BoundRef, new: Bound, hint: &'static str) -> Result<(), Error> {
-        let existing_bound = existing.index.get();
+    fn bind(&mut self, existing: BoundRef, new: Bound, hint: &'static str) -> Result<(), Error> {
+        let existing_bound = self.slab[existing.index].shallow_clone();
         let bind_error = || Error::Bind {
             existing_bound: existing_bound.shallow_clone(),
             new_bound: new.shallow_clone(),
@@ -278,7 +288,7 @@ impl<'ctx> LockedContext<'ctx> {
             // Free types are simply dropped and replaced by the new bound
             (Bound::Free(_), _) => {
                 // Free means non-finalized, so set() is ok.
-                existing.index.set(new);
+                self.reassign_non_complete(existing, new);
                 Ok(())
             }
             // Binding complete->complete shouldn't ever happen, but if so, we just
@@ -320,14 +330,17 @@ impl<'ctx> LockedContext<'ctx> {
                 //
                 // It also gives the user access to more information about the type,
                 // prior to finalization.
-                if let (Some(data1), Some(data2)) = (y1.final_data(), y2.final_data()) {
-                    existing
-                        .index
-                        .set(Bound::Complete(if let Bound::Sum(..) = existing_bound {
-                            Final::sum(data1, data2)
+                let y1_bound = &self.slab[y1.bound.root().index];
+                let y2_bound = &self.slab[y2.bound.root().index];
+                if let (Bound::Complete(data1), Bound::Complete(data2)) = (y1_bound, y2_bound) {
+                    self.reassign_non_complete(
+                        existing,
+                        Bound::Complete(if let Bound::Sum(..) = existing_bound {
+                            Final::sum(Arc::clone(data1), Arc::clone(data2))
                         } else {
-                            Final::product(data1, data2)
-                        }));
+                            Final::product(Arc::clone(data1), Arc::clone(data2))
+                        }),
+                    );
                 }
                 Ok(())
             }

--- a/src/types/context.rs
+++ b/src/types/context.rs
@@ -162,7 +162,11 @@ impl Context {
     pub fn bind(&self, existing: &Type, new: Bound, hint: &'static str) -> Result<(), Error> {
         let existing_root = existing.bound.root();
         let mut lock = self.lock();
-        lock.bind(existing_root, new, hint)
+        lock.bind(existing_root, new).map_err(|e| Error::Bind {
+            existing_bound: e.existing,
+            new_bound: e.new,
+            hint,
+        })
     }
 
     /// Unify the type with another one.
@@ -170,7 +174,11 @@ impl Context {
     /// Fails if the bounds on the two types are incompatible
     pub fn unify(&self, ty1: &Type, ty2: &Type, hint: &'static str) -> Result<(), Error> {
         let mut lock = self.lock();
-        lock.unify(ty1, ty2, hint)
+        lock.unify(ty1, ty2).map_err(|e| Error::Bind {
+            existing_bound: e.existing,
+            new_bound: e.new,
+            hint,
+        })
     }
 
     /// Locks the underlying slab mutex.
@@ -248,6 +256,11 @@ pub struct OccursCheckId {
     index: usize,
 }
 
+struct BindError {
+    existing: Bound,
+    new: Bound,
+}
+
 /// Structure representing an inference context with its slab allocator mutex locked.
 ///
 /// This type is never exposed outside of this module and should only exist
@@ -268,18 +281,17 @@ impl<'ctx> LockedContext<'ctx> {
     /// Unify the type with another one.
     ///
     /// Fails if the bounds on the two types are incompatible
-    fn unify(&mut self, existing: &Type, other: &Type, hint: &'static str) -> Result<(), Error> {
+    fn unify(&mut self, existing: &Type, other: &Type) -> Result<(), BindError> {
         existing.bound.unify(&other.bound, |x_bound, y_bound| {
-            self.bind(x_bound, self.slab[y_bound.index].shallow_clone(), hint)
+            self.bind(x_bound, self.slab[y_bound.index].shallow_clone())
         })
     }
 
-    fn bind(&mut self, existing: BoundRef, new: Bound, hint: &'static str) -> Result<(), Error> {
+    fn bind(&mut self, existing: BoundRef, new: Bound) -> Result<(), BindError> {
         let existing_bound = self.slab[existing.index].shallow_clone();
-        let bind_error = || Error::Bind {
-            existing_bound: existing_bound.shallow_clone(),
-            new_bound: new.shallow_clone(),
-            hint,
+        let bind_error = || BindError {
+            existing: existing_bound.shallow_clone(),
+            new: new.shallow_clone(),
         };
 
         match (&existing_bound, &new) {
@@ -313,16 +325,16 @@ impl<'ctx> LockedContext<'ctx> {
                     | (CompleteBound::Sum(ref comp1, ref comp2), Bound::Sum(ref ty1, ref ty2)) => {
                         let bound1 = ty1.bound.root();
                         let bound2 = ty2.bound.root();
-                        self.bind(bound1, Bound::Complete(Arc::clone(comp1)), hint)?;
-                        self.bind(bound2, Bound::Complete(Arc::clone(comp2)), hint)
+                        self.bind(bound1, Bound::Complete(Arc::clone(comp1)))?;
+                        self.bind(bound2, Bound::Complete(Arc::clone(comp2)))
                     }
                     _ => Err(bind_error()),
                 }
             }
             (Bound::Sum(ref x1, ref x2), Bound::Sum(ref y1, ref y2))
             | (Bound::Product(ref x1, ref x2), Bound::Product(ref y1, ref y2)) => {
-                self.unify(x1, y1, hint)?;
-                self.unify(x2, y2, hint)?;
+                self.unify(x1, y1)?;
+                self.unify(x2, y2)?;
                 // This type was not complete, but it may be after unification, giving us
                 // an opportunity to finaliize it. We do this eagerly to make sure that
                 // "complete" (no free children) is always equivalent to "finalized" (the
@@ -344,10 +356,9 @@ impl<'ctx> LockedContext<'ctx> {
                 }
                 Ok(())
             }
-            (x, y) => Err(Error::Bind {
-                existing_bound: x.shallow_clone(),
-                new_bound: y.shallow_clone(),
-                hint,
+            (x, y) => Err(BindError {
+                existing: x.shallow_clone(),
+                new: y.shallow_clone(),
             }),
         }
     }

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -12,7 +12,6 @@
 //!
 
 use crate::dag::{Dag, DagLike, NoSharing};
-use crate::types::{Bound, Type};
 use crate::Tmr;
 
 use std::sync::Arc;
@@ -163,7 +162,7 @@ impl Final {
     ///
     /// The type is precomputed and fast to access.
     pub fn two_two_n(n: usize) -> Arc<Self> {
-        super::precomputed::nth_power_of_2(n).final_data().unwrap()
+        super::precomputed::nth_power_of_2(n)
     }
 
     /// Create the sum of the given `left` and `right` types.
@@ -224,12 +223,6 @@ impl Final {
             CompleteBound::Product(left, right) => Some((left.as_ref(), right.as_ref())),
             _ => None,
         }
-    }
-}
-
-impl From<Arc<Final>> for Type {
-    fn from(value: Arc<Final>) -> Self {
-        Type::from(Bound::Complete(value))
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -397,20 +397,20 @@ pub struct Type {
 
 impl Type {
     /// Return an unbound type with the given name
-    pub fn free(name: String) -> Self {
+    pub fn free(_: &Context, name: String) -> Self {
         Type::from(Bound::free(name))
     }
 
     /// Create the unit type.
-    pub fn unit() -> Self {
+    pub fn unit(_: &Context) -> Self {
         Type::from(Bound::unit())
     }
 
     /// Create the type `2^(2^n)` for the given `n`.
     ///
     /// The type is precomputed and fast to access.
-    pub fn two_two_n(n: usize) -> Self {
-        Self::complete(precomputed::nth_power_of_2(n))
+    pub fn two_two_n(ctx: &Context, n: usize) -> Self {
+        Self::complete(ctx, precomputed::nth_power_of_2(n))
     }
 
     /// Create the sum of the given `left` and `right` types.
@@ -424,7 +424,7 @@ impl Type {
     }
 
     /// Create a complete type.
-    pub fn complete(final_data: Arc<Final>) -> Self {
+    pub fn complete(_: &Context, final_data: Arc<Final>) -> Self {
         Type::from(Bound::Complete(final_data))
     }
 
@@ -561,10 +561,10 @@ impl Type {
     }
 
     /// Return a vector containing the types 2^(2^i) for i from 0 to n-1.
-    pub fn powers_of_two(n: usize) -> Vec<Self> {
+    pub fn powers_of_two(ctx: &Context, n: usize) -> Vec<Self> {
         let mut ret = Vec::with_capacity(n);
 
-        let unit = Type::unit();
+        let unit = Type::unit(ctx);
         let mut two = Type::sum(unit.shallow_clone(), unit);
         for _ in 0..n {
             ret.push(two.shallow_clone());

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -392,7 +392,7 @@ impl DagLike for Arc<Bound> {
 pub struct Type {
     /// A set of constraints, which maintained by the union-bound algorithm and
     /// is progressively tightened as type inference proceeds.
-    bound: UbElement<bound_mutex::BoundMutex>,
+    bound: UbElement<Arc<bound_mutex::BoundMutex>>,
 }
 
 impl Type {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -402,7 +402,7 @@ impl Type {
     ///
     /// The type is precomputed and fast to access.
     pub fn two_two_n(n: usize) -> Self {
-        precomputed::nth_power_of_2(n)
+        Self::complete(precomputed::nth_power_of_2(n))
     }
 
     /// Create the sum of the given `left` and `right` types.
@@ -413,6 +413,11 @@ impl Type {
     /// Create the product of the given `left` and `right` types.
     pub fn product(left: Self, right: Self) -> Self {
         Type::from(Bound::product(left, right))
+    }
+
+    /// Create a complete type.
+    pub fn complete(final_data: Arc<Final>) -> Self {
+        Type::from(Bound::Complete(final_data))
     }
 
     /// Clones the `Type`.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -414,12 +414,12 @@ impl Type {
     }
 
     /// Create the sum of the given `left` and `right` types.
-    pub fn sum(left: Self, right: Self) -> Self {
+    pub fn sum(_: &Context, left: Self, right: Self) -> Self {
         Type::from(Bound::sum(left, right))
     }
 
     /// Create the product of the given `left` and `right` types.
-    pub fn product(left: Self, right: Self) -> Self {
+    pub fn product(_: &Context, left: Self, right: Self) -> Self {
         Type::from(Bound::product(left, right))
     }
 
@@ -565,10 +565,10 @@ impl Type {
         let mut ret = Vec::with_capacity(n);
 
         let unit = Type::unit(ctx);
-        let mut two = Type::sum(unit.shallow_clone(), unit);
+        let mut two = Type::sum(ctx, unit.shallow_clone(), unit);
         for _ in 0..n {
             ret.push(two.shallow_clone());
-            two = Type::product(two.shallow_clone(), two);
+            two = Type::product(ctx, two.shallow_clone(), two);
         }
         ret
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -440,7 +440,7 @@ impl Type {
     /// hint to the error.
     ///
     /// Fails if the type has an existing incompatible bound.
-    pub fn bind(&self, bound: Arc<Bound>, hint: &'static str) -> Result<(), Error> {
+    fn bind(&self, bound: Arc<Bound>, hint: &'static str) -> Result<(), Error> {
         let root = self.bound.root();
         root.bind(bound, hint)
     }
@@ -448,7 +448,7 @@ impl Type {
     /// Unify the type with another one.
     ///
     /// Fails if the bounds on the two types are incompatible
-    pub fn unify(&self, other: &Self, hint: &'static str) -> Result<(), Error> {
+    fn unify(&self, other: &Self, hint: &'static str) -> Result<(), Error> {
         self.bound.unify(&other.bound, |x_bound, y_bound| {
             x_bound.bind(y_bound.get(), hint)
         })

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -148,45 +148,6 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-mod bound_mutex {
-    use super::Bound;
-    use std::fmt;
-    use std::sync::Mutex;
-
-    /// Source or target type of a Simplicity expression
-    pub struct BoundMutex {
-        /// The type's status according to the union-bound algorithm.
-        inner: Mutex<Bound>,
-    }
-
-    impl fmt::Debug for BoundMutex {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            self.get().fmt(f)
-        }
-    }
-
-    impl BoundMutex {
-        pub fn new(bound: Bound) -> Self {
-            BoundMutex {
-                inner: Mutex::new(bound),
-            }
-        }
-
-        pub fn get(&self) -> Bound {
-            self.inner.lock().unwrap().shallow_clone()
-        }
-
-        pub fn set(&self, new: Bound) {
-            let mut lock = self.inner.lock().unwrap();
-            assert!(
-                !matches!(*lock, Bound::Complete(..)),
-                "tried to modify finalized type",
-            );
-            *lock = new;
-        }
-    }
-}
-
 /// The state of a [`Type`] based on all constraints currently imposed on it.
 #[derive(Clone, Debug)]
 pub enum Bound {


### PR DESCRIPTION
Our existing type inference engine assumes a "global" set of type bounds, which has two bad consequences: one is that if you are constructing multiple programs, there is no way to "firewall" their type bounds so that you cannot accidentally combine type variables from one program with type variables from another. You just need to be careful. The other consequence is that if you construct infinitely sized types, which are represented as a reference cycle, the existing inference engine will leak memory.

A third issue, though I am unsure whether it leads to actual bugs, is that the type inference engine can only lock data at the granularity of individual type bounds, meaning that multi-step parts of type inference are not done atomically, and if you try to construct a program in a multithreaded context, it is possible that strange/unexpected things will happen.

To avoid this, it is better that each program under construction has an independent "type inference context" which holds a slab allocator. When the context is dropped, which happens when the initial constructed context and all the program nodes that reference it are dropped, it deallocates all the type bounds in one shot, rather than chasing Arcs and failing to notice cycles.

This is a 2000-line diff but the vast majority of the changes are "API-only" stuff where I was moving types around and threading new parameters through dozens or hundreds of call sites. I did my best to break everything up into commits such that the big-diff commits don't do much of anything and the real changes happen in the small-diff ones to make review easier.

Builds on #227.

This does **not** fix #226 although it sets the stage for "checkpointing" the type inference context, which should allow a reasonably-efficient way to undo changes when things go wrong.