### PR TITLE
types: introduce `TypeInner` making `Type` the only public "incomplete Simplicity type" type

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,7 +39,7 @@ parse_human,
       - name: fuzz
         run: |
           echo "Using RUSTFLAGS $RUSTFLAGS"
-          cd fuzz && ./fuzz.sh "${{ matrix.fuzz_target }}"
+          cd fuzz && cargo update && cargo update -p cc --precise 1.0.83 && ./fuzz.sh "${{ matrix.fuzz_target }}"
       - run: echo "${{ matrix.fuzz_target }}" >executed_${{ matrix.fuzz_target }}
       - uses: actions/upload-artifact@v3
         with:

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -22,7 +22,7 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-simplicity-lang = { path = ".." }
+simplicity-lang = { path = "..", features = ["test-utils"] }
 EOF
 
 for targetFile in $(listTargetFiles); do
@@ -75,7 +75,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
       - name: fuzz
         run: |
           echo "Using RUSTFLAGS \$RUSTFLAGS"
-          cd fuzz && ./fuzz.sh "\${{ matrix.fuzz_target }}"
+          cd fuzz && cargo update && cargo update -p cc --precise 1.0.83 && ./fuzz.sh "\${{ matrix.fuzz_target }}"
       - run: echo "\${{ matrix.fuzz_target }}" >executed_\${{ matrix.fuzz_target }}
       - uses: actions/upload-artifact@v3
         with:

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -18,7 +18,7 @@ use crate::node::{
     CoreConstructible, DisconnectConstructible, JetConstructible, NoDisconnect,
     WitnessConstructible,
 };
-use crate::types::{Bound, Context, Error, Final, Type};
+use crate::types::{Context, Error, Final, Type};
 use crate::{jet::Jet, Value};
 
 use super::variable::new_name;
@@ -123,17 +123,19 @@ impl Arrow {
 
         let target = Type::free(&ctx, String::new());
         if let Some(lchild_arrow) = lchild_arrow {
-            ctx.bind(
+            ctx.bind_product(
                 &lchild_arrow.source,
-                Bound::Product(a, c.shallow_clone()),
+                &a,
+                &c,
                 "case combinator: left source = A × C",
             )?;
             ctx.unify(&target, &lchild_arrow.target, "").unwrap();
         }
         if let Some(rchild_arrow) = rchild_arrow {
-            ctx.bind(
+            ctx.bind_product(
                 &rchild_arrow.source,
-                Bound::Product(b, c),
+                &b,
+                &c,
                 "case combinator: left source = B × C",
             )?;
             ctx.unify(
@@ -162,20 +164,20 @@ impl Arrow {
         let c = rchild_arrow.source.shallow_clone();
         let d = rchild_arrow.target.shallow_clone();
 
-        let prod_256_a = Bound::Product(Type::two_two_n(ctx, 8), a.shallow_clone());
-        let prod_b_c = Bound::Product(b.shallow_clone(), c);
-        let prod_b_d = Type::product(ctx, b, d);
-
-        ctx.bind(
+        ctx.bind_product(
             &lchild_arrow.source,
-            prod_256_a,
+            &Type::two_two_n(ctx, 8),
+            &a,
             "disconnect combinator: left source = 2^256 × A",
         )?;
-        ctx.bind(
+        ctx.bind_product(
             &lchild_arrow.target,
-            prod_b_c,
+            &b,
+            &c,
             "disconnect combinator: left target = B × C",
         )?;
+
+        let prod_b_d = Type::product(ctx, b, d);
 
         Ok(Arrow {
             source: a,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -189,22 +189,6 @@ impl Bound {
     pub fn shallow_clone(&self) -> Bound {
         self.clone()
     }
-
-    fn sum(a: Type, b: Type) -> Self {
-        if let (Some(adata), Some(bdata)) = (a.final_data(), b.final_data()) {
-            Bound::Complete(Final::sum(adata, bdata))
-        } else {
-            Bound::Sum(a, b)
-        }
-    }
-
-    fn product(a: Type, b: Type) -> Self {
-        if let (Some(adata), Some(bdata)) = (a.final_data(), b.final_data()) {
-            Bound::Complete(Final::product(adata, bdata))
-        } else {
-            Bound::Product(a, b)
-        }
-    }
 }
 
 /// Source or target type of a Simplicity expression.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -224,18 +224,12 @@ pub struct Type {
 impl Type {
     /// Return an unbound type with the given name
     pub fn free(ctx: &Context, name: String) -> Self {
-        Type {
-            ctx: ctx.shallow_clone(),
-            bound: UbElement::new(ctx.alloc_free(name)),
-        }
+        Self::wrap_bound(ctx, ctx.alloc_free(name))
     }
 
     /// Create the unit type.
     pub fn unit(ctx: &Context) -> Self {
-        Type {
-            ctx: ctx.shallow_clone(),
-            bound: UbElement::new(ctx.alloc_unit()),
-        }
+        Self::wrap_bound(ctx, ctx.alloc_unit())
     }
 
     /// Create the type `2^(2^n)` for the given `n`.
@@ -247,25 +241,24 @@ impl Type {
 
     /// Create the sum of the given `left` and `right` types.
     pub fn sum(ctx: &Context, left: Self, right: Self) -> Self {
-        Type {
-            ctx: ctx.shallow_clone(),
-            bound: UbElement::new(ctx.alloc_sum(left, right)),
-        }
+        Self::wrap_bound(ctx, ctx.alloc_sum(left, right))
     }
 
     /// Create the product of the given `left` and `right` types.
     pub fn product(ctx: &Context, left: Self, right: Self) -> Self {
-        Type {
-            ctx: ctx.shallow_clone(),
-            bound: UbElement::new(ctx.alloc_product(left, right)),
-        }
+        Self::wrap_bound(ctx, ctx.alloc_product(left, right))
     }
 
     /// Create a complete type.
     pub fn complete(ctx: &Context, final_data: Arc<Final>) -> Self {
+        Self::wrap_bound(ctx, ctx.alloc_complete(final_data))
+    }
+
+    fn wrap_bound(ctx: &Context, bound: BoundRef) -> Self {
+        bound.assert_matches_context(ctx);
         Type {
             ctx: ctx.shallow_clone(),
-            bound: UbElement::new(ctx.alloc_complete(final_data)),
+            bound: UbElement::new(bound),
         }
     }
 


### PR DESCRIPTION
Previously we had two types, `Type` and `Bound`, which were mutually recursive. `Type` was also exposed in the public API as a type representing an incomplete Simplicity type. `Bound` was exposed in the public API for a couple of reasons which this PR eliminates.
    
However, because `Type` is both public and unusable without a live type inference context, this means that it needs to contain an `Arc<Context>`. But this means that if we have a self-referential type, this leaks to a somewhat-convoluted reference cycle in which a `Type` holds an `Arc<Context>` which owns a set of `Bound`s which contain the original `Type`. If you are skeptical of this, try running the test harness in valgrind before and after the last commit of this PR -- you will see that previously we were leaking memory in the `memory_leak` unit test but now we are not.

This completes the "type inference overhaul" needed to eliminate the memory leak in infinitely-sized types.