### PR TITLE
Value refactor

### DIFF
--- a/jets-bench/benches/elements/main.rs
+++ b/jets-bench/benches/elements/main.rs
@@ -755,30 +755,30 @@ fn bench(c: &mut Criterion) {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let genesis_pegin = genesis_pegin();
         let outpoint = elements::OutPoint::sample().value();
-        Value::prod(ctx8, Value::prod(genesis_pegin, outpoint))
+        Value::product(ctx8, Value::product(genesis_pegin, outpoint))
     }
 
     fn asset_amount_hash() -> Arc<Value> {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let asset = confidential::Asset::sample().value();
         let amount = confidential::Value::sample().value();
-        Value::prod(ctx8, Value::prod(asset, amount))
+        Value::product(ctx8, Value::product(asset, amount))
     }
 
     fn nonce_hash() -> Arc<Value> {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let nonce = confidential::Nonce::sample().value();
-        Value::prod(ctx8, nonce)
+        Value::product(ctx8, nonce)
     }
 
     fn annex_hash() -> Arc<Value> {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let annex = if rand::random() {
-            Value::sum_r(Value::u256_from_slice(&rand::random::<[u8; 32]>()))
+            Value::right(Value::u256_from_slice(&rand::random::<[u8; 32]>()))
         } else {
-            Value::sum_l(Value::unit())
+            Value::left(Value::unit())
         };
-        Value::prod(ctx8, annex)
+        Value::product(ctx8, annex)
     }
     let arr: [(Elements, Arc<dyn Fn() -> Arc<Value>>); 4] = [
         (Elements::OutpointHash, Arc::new(&outpoint_hash)),

--- a/jets-bench/benches/elements/main.rs
+++ b/jets-bench/benches/elements/main.rs
@@ -774,7 +774,7 @@ fn bench(c: &mut Criterion) {
     fn annex_hash() -> Arc<Value> {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let annex = if rand::random() {
-            Value::right(Value::u256_from_slice(&rand::random::<[u8; 32]>()))
+            Value::right(Value::u256(&rand::random::<[u8; 32]>()))
         } else {
             Value::left(Value::unit())
         };

--- a/jets-bench/src/input.rs
+++ b/jets-bench/src/input.rs
@@ -42,16 +42,16 @@ pub fn random_value(ty: &types::Final, rng: &mut ThreadRng) -> Arc<Value> {
             },
             StackItem::LeftSum => {
                 let left = value_stack.pop().unwrap();
-                value_stack.push(Value::sum_l(left));
+                value_stack.push(Value::left(left));
             }
             StackItem::RightSum => {
                 let right = value_stack.pop().unwrap();
-                value_stack.push(Value::sum_r(right));
+                value_stack.push(Value::right(right));
             }
             StackItem::Product => {
                 let right = value_stack.pop().unwrap();
                 let left = value_stack.pop().unwrap();
-                value_stack.push(Value::prod(left, right));
+                value_stack.push(Value::product(left, right));
             }
         }
     }

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -252,16 +252,16 @@ impl<I: Iterator<Item = u8>> BitIter<I> {
                 },
                 State::DoSumL => {
                     let val = result_stack.pop().unwrap();
-                    result_stack.push(Value::sum_l(val));
+                    result_stack.push(Value::left(val));
                 }
                 State::DoSumR => {
                     let val = result_stack.pop().unwrap();
-                    result_stack.push(Value::sum_r(val));
+                    result_stack.push(Value::right(val));
                 }
                 State::DoProduct => {
                     let val_r = result_stack.pop().unwrap();
                     let val_l = result_stack.pop().unwrap();
-                    result_stack.push(Value::prod(val_l, val_r));
+                    result_stack.push(Value::product(val_l, val_r));
                 }
             }
         }

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -347,7 +347,7 @@ pub fn decode_power_of_2<I: Iterator<Item = bool>>(
             let right = stack.pop().unwrap();
             let left = stack.pop().unwrap();
             stack.push(StackElem {
-                value: Value::prod(left.value, right.value),
+                value: Value::product(left.value, right.value),
                 width: left.width * 2,
             });
         }

--- a/src/bit_encoding/encode.rs
+++ b/src/bit_encoding/encode.rs
@@ -291,15 +291,15 @@ pub fn encode_value<W: io::Write>(value: &Value, w: &mut BitWriter<W>) -> io::Re
 
     match value {
         Value::Unit => {}
-        Value::SumL(left) => {
+        Value::Left(left) => {
             w.write_bit(false)?;
             encode_value(left, w)?;
         }
-        Value::SumR(right) => {
+        Value::Right(right) => {
             w.write_bit(true)?;
             encode_value(right, w)?;
         }
-        Value::Prod(left, right) => {
+        Value::Product(left, right) => {
             encode_value(left, w)?;
             encode_value(right, w)?;
         }

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -175,9 +175,9 @@ impl BitMachine {
         for val in val.pre_order_iter::<NoSharing>() {
             match val {
                 Value::Unit => {}
-                Value::SumL(..) => self.write_bit(false),
-                Value::SumR(..) => self.write_bit(true),
-                Value::Prod(..) => {}
+                Value::Left(..) => self.write_bit(false),
+                Value::Right(..) => self.write_bit(true),
+                Value::Product(..) => {}
             }
         }
     }

--- a/src/human_encoding/serialize.rs
+++ b/src/human_encoding/serialize.rs
@@ -21,8 +21,8 @@ impl<'a> fmt::Display for DisplayWord<'a> {
             f.write_str("0b")?;
             for comb in self.0.pre_order_iter::<NoSharing>() {
                 match comb {
-                    Value::SumL(..) => f.write_str("0")?,
-                    Value::SumR(..) => f.write_str("1")?,
+                    Value::Left(..) => f.write_str("0")?,
+                    Value::Right(..) => f.write_str("1")?,
                     _ => {}
                 }
             }

--- a/src/jet/mod.rs
+++ b/src/jet/mod.rs
@@ -111,7 +111,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             BitMachine::test_exec(two_words, &()).expect("executing"),
-            Value::prod(
+            Value::product(
                 Value::u1(0),       // carry bit
                 Value::u32(2 + 16), // result
             ),
@@ -128,7 +128,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             BitMachine::test_exec(two_words, &()).expect("executing"),
-            Value::prod(Value::u32(2), Value::u16(16)),
+            Value::product(Value::u32(2), Value::u16(16)),
         );
     }
 }

--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -422,7 +422,7 @@ mod tests {
     #[test]
     fn fixed_const_word_cmr() {
         // Checked against C implementation
-        let bit0 = Value::sum_l(Value::unit());
+        let bit0 = Value::left(Value::unit());
         #[rustfmt::skip]
         assert_eq!(
             Cmr::const_word(&bit0),

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -190,15 +190,15 @@ pub trait CoreConstructible: Sized {
         for data in value.post_order_iter::<NoSharing>() {
             match data.node {
                 Value::Unit => stack.push(Self::unit(inference_context)),
-                Value::SumL(..) => {
+                Value::Left(..) => {
                     let child = stack.pop().unwrap();
                     stack.push(Self::injl(&child));
                 }
-                Value::SumR(..) => {
+                Value::Right(..) => {
                     let child = stack.pop().unwrap();
                     stack.push(Self::injr(&child));
                 }
-                Value::Prod(..) => {
+                Value::Product(..) => {
                     let right = stack.pop().unwrap();
                     let left = stack.pop().unwrap();
                     stack.push(

--- a/src/policy/satisfy.rs
+++ b/src/policy/satisfy.rs
@@ -105,7 +105,7 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
             Policy::Key(ref key) => {
                 let sig_wit = satisfier
                     .lookup_tap_leaf_script_sig(key, &TapLeafHash::all_zeros())
-                    .map(|sig| Value::u512_from_slice(sig.sig.as_ref()));
+                    .map(|sig| Value::u512(sig.sig.as_ref()));
                 super::serialize::key(inference_context, key, sig_wit)
             }
             Policy::After(n) => {
@@ -128,7 +128,7 @@ impl<Pk: ToXOnlyPubkey> Policy<Pk> {
             Policy::Sha256(ref hash) => {
                 let preimage_wit = satisfier
                     .lookup_sha256(hash)
-                    .map(|preimage| Value::u256_from_slice(preimage.as_ref()));
+                    .map(|preimage| Value::u256(&preimage));
                 super::serialize::sha256::<Pk, _, _>(inference_context, hash, preimage_wit)
             }
             Policy::And {

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -54,7 +54,7 @@ where
     Pk: ToXOnlyPubkey,
     N: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<W>,
 {
-    let key_value = Value::u256_from_slice(&key.to_x_only_pubkey().serialize());
+    let key_value = Value::u256(&key.to_x_only_pubkey().serialize());
     let const_key = N::const_word(inference_context, key_value);
     let sighash_all = N::jet(inference_context, Elements::SigAllHash);
     let pair_key_msg = N::pair(&const_key, &sighash_all).expect("consistent types");
@@ -118,7 +118,7 @@ where
     Pk: ToXOnlyPubkey,
     N: CoreConstructible + JetConstructible<Elements> + WitnessConstructible<W>,
 {
-    let hash_value = Value::u256_from_slice(Pk::to_sha256(hash).as_ref());
+    let hash_value = Value::u256(Pk::to_sha256(hash).as_ref());
     let const_hash = N::const_word(inference_context, hash_value);
     let witness256 = N::witness(inference_context, witness);
     let computed_hash = compute_sha256(&witness256);
@@ -320,7 +320,7 @@ mod tests {
 
         assert!(execute_successful(
             &commit,
-            vec![Value::u512_from_slice(signature.as_ref())],
+            vec![Value::u512(signature.as_ref())],
             &env
         ));
     }
@@ -376,10 +376,10 @@ mod tests {
         let image = sha256::Hash::hash(&preimage);
         let (commit, env) = compile(Policy::Sha256(image));
 
-        let valid_witness = vec![Value::u256_from_slice(&preimage)];
+        let valid_witness = vec![Value::u256(&preimage)];
         assert!(execute_successful(&commit, valid_witness, &env));
 
-        let invalid_witness = vec![Value::u256_from_slice(&[0; 32])];
+        let invalid_witness = vec![Value::u256(&[0; 32])];
         assert!(!execute_successful(&commit, invalid_witness, &env));
     }
 
@@ -395,22 +395,13 @@ mod tests {
             right: Arc::new(Policy::Sha256(image1)),
         });
 
-        let valid_witness = vec![
-            Value::u256_from_slice(&preimage0),
-            Value::u256_from_slice(&preimage1),
-        ];
+        let valid_witness = vec![Value::u256(&preimage0), Value::u256(&preimage1)];
         assert!(execute_successful(&commit, valid_witness, &env));
 
-        let invalid_witness = vec![
-            Value::u256_from_slice(&preimage0),
-            Value::u256_from_slice(&[0; 32]),
-        ];
+        let invalid_witness = vec![Value::u256(&preimage0), Value::u256(&[0; 32])];
         assert!(!execute_successful(&commit, invalid_witness, &env));
 
-        let invalid_witness = vec![
-            Value::u256_from_slice(&[0; 32]),
-            Value::u256_from_slice(&preimage1),
-        ];
+        let invalid_witness = vec![Value::u256(&[0; 32]), Value::u256(&preimage1)];
         assert!(!execute_successful(&commit, invalid_witness, &env));
     }
 
@@ -424,10 +415,10 @@ mod tests {
             right: Arc::new(Policy::Trivial),
         });
 
-        let valid_witness = vec![Value::u256_from_slice(&preimage0)];
+        let valid_witness = vec![Value::u256(&preimage0)];
         assert!(execute_successful(&commit, valid_witness, &env));
 
-        let invalid_witness = vec![Value::u256_from_slice(&[0; 32])];
+        let invalid_witness = vec![Value::u256(&[0; 32])];
         assert!(!execute_successful(&commit, invalid_witness, &env));
     }
 
@@ -443,30 +434,14 @@ mod tests {
             right: Arc::new(Policy::Sha256(image1)),
         });
 
-        let valid_witness = vec![
-            Value::u1(0),
-            Value::u256_from_slice(&preimage0),
-            Value::u256_from_slice(&[0; 32]),
-        ];
+        let valid_witness = vec![Value::u1(0), Value::u256(&preimage0), Value::u256(&[0; 32])];
         assert!(execute_successful(&commit, valid_witness, &env));
-        let valid_witness = vec![
-            Value::u1(1),
-            Value::u256_from_slice(&[0; 32]),
-            Value::u256_from_slice(&preimage1),
-        ];
+        let valid_witness = vec![Value::u1(1), Value::u256(&[0; 32]), Value::u256(&preimage1)];
         assert!(execute_successful(&commit, valid_witness, &env));
 
-        let invalid_witness = vec![
-            Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
-            Value::u256_from_slice(&preimage1),
-        ];
+        let invalid_witness = vec![Value::u1(0), Value::u256(&[0; 32]), Value::u256(&preimage1)];
         assert!(!execute_successful(&commit, invalid_witness, &env));
-        let invalid_witness = vec![
-            Value::u1(1),
-            Value::u256_from_slice(&preimage0),
-            Value::u256_from_slice(&[0; 32]),
-        ];
+        let invalid_witness = vec![Value::u1(1), Value::u256(&preimage0), Value::u256(&[0; 32])];
         assert!(!execute_successful(&commit, invalid_witness, &env));
     }
 
@@ -490,61 +465,61 @@ mod tests {
 
         let valid_witness = vec![
             Value::u1(1),
-            Value::u256_from_slice(&preimage0),
+            Value::u256(&preimage0),
             Value::u1(1),
-            Value::u256_from_slice(&preimage1),
+            Value::u256(&preimage1),
             Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
+            Value::u256(&[0; 32]),
         ];
         assert!(execute_successful(&commit, valid_witness, &env));
 
         let valid_witness = vec![
             Value::u1(1),
-            Value::u256_from_slice(&preimage0),
+            Value::u256(&preimage0),
             Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
+            Value::u256(&[0; 32]),
             Value::u1(1),
-            Value::u256_from_slice(&preimage2),
+            Value::u256(&preimage2),
         ];
         assert!(execute_successful(&commit, valid_witness, &env));
 
         let valid_witness = vec![
             Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
+            Value::u256(&[0; 32]),
             Value::u1(1),
-            Value::u256_from_slice(&preimage1),
+            Value::u256(&preimage1),
             Value::u1(1),
-            Value::u256_from_slice(&preimage2),
+            Value::u256(&preimage2),
         ];
         assert!(execute_successful(&commit, valid_witness, &env));
 
         let invalid_witness = vec![
             Value::u1(1),
-            Value::u256_from_slice(&preimage0),
+            Value::u256(&preimage0),
             Value::u1(1),
-            Value::u256_from_slice(&preimage1),
+            Value::u256(&preimage1),
             Value::u1(1),
-            Value::u256_from_slice(&preimage2),
+            Value::u256(&preimage2),
         ];
         assert!(!execute_successful(&commit, invalid_witness, &env));
 
         let invalid_witness = vec![
             Value::u1(1),
-            Value::u256_from_slice(&preimage1),
+            Value::u256(&preimage1),
             Value::u1(1),
-            Value::u256_from_slice(&preimage0),
+            Value::u256(&preimage0),
             Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
+            Value::u256(&[0; 32]),
         ];
         assert!(!execute_successful(&commit, invalid_witness, &env));
 
         let invalid_witness = vec![
             Value::u1(1),
-            Value::u256_from_slice(&preimage0),
+            Value::u256(&preimage0),
             Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
+            Value::u256(&[0; 32]),
             Value::u1(0),
-            Value::u256_from_slice(&[0; 32]),
+            Value::u256(&[0; 32]),
         ];
         assert!(!execute_successful(&commit, invalid_witness, &env));
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -14,36 +14,29 @@ use std::fmt;
 use std::hash::Hash;
 use std::sync::Arc;
 
-/// Value of some type.
-///
-/// The _unit value_ is the only value of the _unit type_.
-/// This is the basis for everything we are doing.
-/// Because there is only a single unit value, there is no information contained in it.
-/// Instead, we wrap unit values in sum and product values to encode information.
-///
-/// A _sum value_ wraps another value.
-/// The _left sum value_ `L(a)` wraps a value `a` from the _left type_ `A`.
-/// The _right sum value_ `R(b)` wraps a value `b` from the _right type_ `B`.
-/// The type of the sum value is the _sum type_ `A + B` of the left type and the right type.
-///
-/// We represent the false bit as a left value that wraps a unit value.
-/// The true bit is represented as a right value that wraps a unit value.
-///
-/// A _product value_ `(a, b)` wraps two values:
-/// a value `a` from the _left type_ `A` and a value `b` from the _right type_ `B`.
-/// The type of the product value is the _product type_ `A × B` of the left type and the right type.
-///
-/// We represent bit strings (tuples of bits) as trees of nested product values
-/// that have bit values (sum values wrapping the unit value) at their leaves.
+/// A Simplicity value.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Value {
-    /// Unit value
+    /// The unit value.
+    ///
+    /// The unit value is the only value of the unit type `1`.
+    /// It must be wrapped in left and right values to encode information.
     Unit,
-    /// Sum value that wraps a left value
+    /// A left value.
+    ///
+    /// A left value wraps a value of type `A` and its type is the sum `A + B` for some `B`.
+    /// A `false` bit encodes that a left value is wrapped.
     Left(Arc<Value>),
-    /// Sum value that wraps a right value
+    /// A right value.
+    ///
+    /// A right value wraps a value of type `B` and its type is the sum `A + B` for some `A`.
+    /// A `true` bit encodes that a right value is wrapped.
     Right(Arc<Value>),
-    /// Product value that wraps a left and a right value
+    /// A product value.
+    ///
+    /// A product value wraps a left value of type `A` and a right value of type `B`,
+    /// and its type is the product `A × B`.
+    /// A product value combines the information of its inner values.
     Product(Arc<Value>, Arc<Value>),
 }
 
@@ -69,17 +62,17 @@ impl Value {
         Arc::new(Self::Unit)
     }
 
-    /// Create a sum value that wraps a left value.
-    pub fn left(left: Arc<Self>) -> Arc<Self> {
-        Arc::new(Value::Left(left))
+    /// Create a left value that wraps the given `inner` value.
+    pub fn left(inner: Arc<Self>) -> Arc<Self> {
+        Arc::new(Value::Left(inner))
     }
 
-    /// Create a sum value that wraps a right value.
-    pub fn right(right: Arc<Self>) -> Arc<Self> {
-        Arc::new(Value::Right(right))
+    /// Create a right value that wraps the given `inner` value.
+    pub fn right(inner: Arc<Self>) -> Arc<Self> {
+        Arc::new(Value::Right(inner))
     }
 
-    /// Create a product value that wraps a left and a right value.
+    /// Create a product value that wraps the given `left` and `right` values.
     pub fn product(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {
         Arc::new(Value::Product(left, right))
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -9,7 +9,6 @@ use crate::dag::{Dag, DagLike, NoSharing};
 use crate::types::Final;
 
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::fmt;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -187,27 +186,6 @@ impl Value {
     /// Create a value from 64 bytes.
     pub fn u512(bytes: &[u8; 64]) -> Arc<Self> {
         Value::power_of_two(bytes)
-    }
-
-    /// Create a value from a byte slice.
-    /// Create a value from a slice containing 32 bytes.
-    ///
-    /// ## Panics
-    ///
-    /// The slice doesn't have exactly 32 bytes.
-    pub fn u256_from_slice(bytes: &[u8]) -> Arc<Self> {
-        let bytes: &[u8; 32] = bytes.try_into().expect("Expect 32-byte slice");
-        Value::u256(bytes)
-    }
-
-    /// Create a value from a slice containing 64 bytes.
-    ///
-    /// ## Panics
-    ///
-    /// The slice doesn't have exactly 64 bytes.
-    pub fn u512_from_slice(bytes: &[u8]) -> Arc<Self> {
-        let bytes: &[u8; 64] = bytes.try_into().expect("Expect 64-byte slice");
-        Value::u512(bytes)
     }
 
     /// Create a value from a byte slice.

--- a/src/value.rs
+++ b/src/value.rs
@@ -179,39 +179,42 @@ impl Value {
         Value::product(Value::u64(w0), Value::u64(w1))
     }
 
-    /// Encode a 32-byte number as a value
-    ///
-    /// Useful for encoding public keys and hashes
-    pub fn u256_from_slice(v: &[u8]) -> Arc<Self> {
-        assert_eq!(32, v.len(), "Expect 32-byte slice");
-
-        Value::product(
-            Value::product(
-                Value::u64(u64::from_be_bytes(v[0..8].try_into().unwrap())),
-                Value::u64(u64::from_be_bytes(v[8..16].try_into().unwrap())),
-            ),
-            Value::product(
-                Value::u64(u64::from_be_bytes(v[16..24].try_into().unwrap())),
-                Value::u64(u64::from_be_bytes(v[24..32].try_into().unwrap())),
-            ),
-        )
+    /// Create a value from 32 bytes.
+    pub fn u256(bytes: &[u8; 32]) -> Arc<Self> {
+        Value::power_of_two(bytes)
     }
 
-    /// Encode a 64-byte number as a value
-    ///
-    /// Useful for encoding signatures
-    pub fn u512_from_slice(v: &[u8]) -> Arc<Self> {
-        assert_eq!(64, v.len(), "Expect 64-byte slice");
-
-        Value::product(
-            Value::u256_from_slice(&v[0..32]),
-            Value::u256_from_slice(&v[32..64]),
-        )
+    /// Create a value from 64 bytes.
+    pub fn u512(bytes: &[u8; 64]) -> Arc<Self> {
+        Value::power_of_two(bytes)
     }
 
-    /// Encode a byte slice as a value.
+    /// Create a value from a byte slice.
+    /// Create a value from a slice containing 32 bytes.
     ///
-    /// The length of the slice must be a power of two.
+    /// ## Panics
+    ///
+    /// The slice doesn't have exactly 32 bytes.
+    pub fn u256_from_slice(bytes: &[u8]) -> Arc<Self> {
+        let bytes: &[u8; 32] = bytes.try_into().expect("Expect 32-byte slice");
+        Value::u256(bytes)
+    }
+
+    /// Create a value from a slice containing 64 bytes.
+    ///
+    /// ## Panics
+    ///
+    /// The slice doesn't have exactly 64 bytes.
+    pub fn u512_from_slice(bytes: &[u8]) -> Arc<Self> {
+        let bytes: &[u8; 64] = bytes.try_into().expect("Expect 64-byte slice");
+        Value::u512(bytes)
+    }
+
+    /// Create a value from a byte slice.
+    ///
+    /// ## Panics
+    ///
+    /// The length of the slice is not a power of two.
     pub fn power_of_two(v: &[u8]) -> Arc<Self> {
         assert!(
             v.len().is_power_of_two(),


### PR DESCRIPTION
Rename the variants of `Value`  and construct {256, 512}-bit values safely.