### PR TITLE
Typed  value

### DIFF
--- a/jets-bench/benches/elements/main.rs
+++ b/jets-bench/benches/elements/main.rs
@@ -7,6 +7,7 @@ use simplicity::elements;
 use simplicity::jet::elements::ElementsEnv;
 use simplicity::jet::{Elements, Jet};
 use simplicity::types;
+use simplicity::types::Final;
 use simplicity::Value;
 use simplicity_bench::input::{
     self, EqProduct, GenericProduct, InputSample, PrefixBit, Sha256Ctx, UniformBits,
@@ -751,36 +752,36 @@ fn bench(c: &mut Criterion) {
     }
 
     // Input to outpoint hash jet
-    fn outpoint_hash() -> Arc<Value> {
+    fn outpoint_hash() -> Value {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let genesis_pegin = genesis_pegin();
         let outpoint = elements::OutPoint::sample().value();
         Value::product(ctx8, Value::product(genesis_pegin, outpoint))
     }
 
-    fn asset_amount_hash() -> Arc<Value> {
+    fn asset_amount_hash() -> Value {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let asset = confidential::Asset::sample().value();
         let amount = confidential::Value::sample().value();
         Value::product(ctx8, Value::product(asset, amount))
     }
 
-    fn nonce_hash() -> Arc<Value> {
+    fn nonce_hash() -> Value {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let nonce = confidential::Nonce::sample().value();
         Value::product(ctx8, nonce)
     }
 
-    fn annex_hash() -> Arc<Value> {
+    fn annex_hash() -> Value {
         let ctx8 = SimplicityCtx8::with_len(511).value();
         let annex = if rand::random() {
-            Value::right(Value::u256(rand::random::<[u8; 32]>()))
+            Value::some(Value::u256(rand::random::<[u8; 32]>()))
         } else {
-            Value::left(Value::unit())
+            Value::none(Final::u256())
         };
         Value::product(ctx8, annex)
     }
-    let arr: [(Elements, Arc<dyn Fn() -> Arc<Value>>); 4] = [
+    let arr: [(Elements, Arc<dyn Fn() -> Value>); 4] = [
         (Elements::OutpointHash, Arc::new(&outpoint_hash)),
         (Elements::AssetAmountHash, Arc::new(&asset_amount_hash)),
         (Elements::NonceHash, Arc::new(nonce_hash)),
@@ -814,7 +815,7 @@ fn bench(c: &mut Criterion) {
     }
 
     // Operations that use tx input or output index.
-    fn index_value(bound: u32) -> Arc<Value> {
+    fn index_value(bound: u32) -> Value {
         let v = rand::random::<u32>() % bound;
         Value::u32(v)
     }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -317,7 +317,7 @@ impl NodeBounds {
         NodeBounds {
             extra_cells: 0,
             extra_frames: 0,
-            cost: Cost::OVERHEAD + Cost::of_type(value.len()),
+            cost: Cost::OVERHEAD + Cost::of_type(value.padded_len()),
         }
     }
 

--- a/src/bit_encoding/decode.rs
+++ b/src/bit_encoding/decode.rs
@@ -129,7 +129,7 @@ enum DecodeNode<J: Jet> {
     Fail(FailEntropy),
     Hidden(Cmr),
     Jet(J),
-    Word(Arc<Value>),
+    Word(Value),
 }
 
 impl<'d, J: Jet> DagLike for (usize, &'d [DecodeNode<J>]) {
@@ -243,7 +243,9 @@ pub fn decode_expression<I: Iterator<Item = u8>, J: Jet>(
                 Hidden(cmr)
             }
             DecodeNode::Jet(j) => Node(ArcNode::jet(&inference_context, j)),
-            DecodeNode::Word(ref w) => Node(ArcNode::const_word(&inference_context, Arc::clone(w))),
+            DecodeNode::Word(ref w) => {
+                Node(ArcNode::const_word(&inference_context, w.shallow_clone()))
+            }
         };
         converted.push(new);
     }
@@ -326,9 +328,9 @@ fn decode_node<I: Iterator<Item = u8>, J: Jet>(
 pub fn decode_power_of_2<I: Iterator<Item = bool>>(
     iter: &mut I,
     exp: usize,
-) -> Result<Arc<Value>, Error> {
+) -> Result<Value, Error> {
     struct StackElem {
-        value: Arc<Value>,
+        value: Value,
         width: usize,
     }
 

--- a/src/bit_encoding/mod.rs
+++ b/src/bit_encoding/mod.rs
@@ -13,5 +13,5 @@ mod bitwriter;
 pub mod decode;
 pub mod encode;
 
-pub use bititer::{u2, BitIter, CloseError, EarlyEndOfStreamError};
+pub use bititer::{u2, BitCollector, BitIter, CloseError, EarlyEndOfStreamError};
 pub use bitwriter::{write_to_vec, BitWriter};

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -245,7 +245,6 @@ impl BitMachine {
 
         let mut ip = program;
         let mut call_stack = vec![];
-        let mut iterations = 0u64;
 
         let output_width = ip.arrow().target.bit_width();
         if output_width > 0 {
@@ -253,11 +252,6 @@ impl BitMachine {
         }
 
         'main_loop: loop {
-            iterations += 1;
-            if iterations % 1_000_000_000 == 0 {
-                println!("({:5} M) exec {:?}", iterations / 1_000_000, ip);
-            }
-
             match ip.inner() {
                 node::Inner::Unit => {}
                 node::Inner::Iden => {

--- a/src/human_encoding/mod.rs
+++ b/src/human_encoding/mod.rs
@@ -213,7 +213,7 @@ impl<J: Jet> Forest<J> {
     /// Succeeds if the forest contains a "main" root and returns `None` otherwise.
     pub fn to_witness_node(
         &self,
-        witness: &HashMap<Arc<str>, Arc<Value>>,
+        witness: &HashMap<Arc<str>, Value>,
     ) -> Option<Arc<WitnessNode<J>>> {
         let main = self.roots.get("main")?;
         Some(main.to_witness_node(witness, self.roots()))
@@ -230,7 +230,7 @@ mod tests {
 
     fn assert_finalize_ok<J: Jet>(
         s: &str,
-        witness: &HashMap<Arc<str>, Arc<Value>>,
+        witness: &HashMap<Arc<str>, Value>,
         env: &J::Environment,
     ) {
         let program = Forest::<J>::parse(s)
@@ -245,7 +245,7 @@ mod tests {
 
     fn assert_finalize_err<J: Jet>(
         s: &str,
-        witness: &HashMap<Arc<str>, Arc<Value>>,
+        witness: &HashMap<Arc<str>, Value>,
         env: &J::Environment,
         err_msg: &'static str,
     ) {

--- a/src/human_encoding/named_node.rs
+++ b/src/human_encoding/named_node.rs
@@ -110,11 +110,11 @@ impl<J: Jet> NamedCommitNode<J> {
 
     pub fn to_witness_node(
         &self,
-        witness: &HashMap<Arc<str>, Arc<Value>>,
+        witness: &HashMap<Arc<str>, Value>,
         disconnect: &HashMap<Arc<str>, Arc<NamedCommitNode<J>>>,
     ) -> Arc<WitnessNode<J>> {
         struct Populator<'a, J: Jet> {
-            witness_map: &'a HashMap<Arc<str>, Arc<Value>>,
+            witness_map: &'a HashMap<Arc<str>, Value>,
             disconnect_map: &'a HashMap<Arc<str>, Arc<NamedCommitNode<J>>>,
             inference_context: types::Context,
             phantom: PhantomData<J>,
@@ -127,7 +127,7 @@ impl<J: Jet> NamedCommitNode<J> {
                 &mut self,
                 data: &PostOrderIterItem<&Node<Named<Commit<J>>>>,
                 _: &NoWitness,
-            ) -> Result<Option<Arc<Value>>, Self::Error> {
+            ) -> Result<Option<Value>, Self::Error> {
                 let name = &data.node.cached_data().name;
                 // We keep the witness nodes without data unpopulated.
                 // Some nodes are pruned later so they don't need to be populated.
@@ -175,7 +175,7 @@ impl<J: Jet> NamedCommitNode<J> {
                     &Arc<Node<Witness<J>>>,
                     J,
                     &Option<Arc<WitnessNode<J>>>,
-                    &Option<Arc<Value>>,
+                    &Option<Value>,
                 >,
             ) -> Result<WitnessData<J>, Self::Error> {
                 let inner = inner

--- a/src/human_encoding/parse/mod.rs
+++ b/src/human_encoding/parse/mod.rs
@@ -580,7 +580,7 @@ mod tests {
     fn assert_cmr_witness<J: Jet>(
         s: &str,
         cmr: &str,
-        witness: &HashMap<Arc<str>, Arc<Value>>,
+        witness: &HashMap<Arc<str>, Value>,
         env: &J::Environment,
     ) {
         match parse::<J>(s) {
@@ -619,7 +619,7 @@ mod tests {
         }
     }
 
-    fn assert_const<J: Jet>(s: &str, value: Arc<Value>) {
+    fn assert_const<J: Jet>(s: &str, value: Value) {
         match parse::<J>(s) {
             Ok(forest) => {
                 assert_eq!(forest.len(), 1);

--- a/src/human_encoding/serialize.rs
+++ b/src/human_encoding/serialize.rs
@@ -2,11 +2,9 @@
 
 //! Serialization
 
+use crate::bit_encoding::BitCollector;
 use hex::DisplayHex;
 use std::fmt;
-
-use crate::dag::{DagLike, NoSharing};
-use crate::Value;
 
 pub struct DisplayWord<'a>(pub &'a crate::Value);
 
@@ -15,15 +13,14 @@ impl<'a> fmt::Display for DisplayWord<'a> {
         // The default value serialization shows the whole structure of
         // the value; but for words, the structure is always fixed by the
         // length, so it is fine to just serialize the bits.
-        if let Ok(hex) = self.0.try_to_bytes() {
+        if let Ok(hex) = self.0.iter_compact().try_collect_bytes() {
             write!(f, "0x{}", hex.as_hex())?;
         } else {
             f.write_str("0b")?;
-            for comb in self.0.pre_order_iter::<NoSharing>() {
-                match comb {
-                    Value::Left(..) => f.write_str("0")?,
-                    Value::Right(..) => f.write_str("1")?,
-                    _ => {}
+            for bit in self.0.iter_compact() {
+                match bit {
+                    false => f.write_str("0")?,
+                    true => f.write_str("1")?,
                 }
             }
         }

--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -10,6 +10,7 @@ pub mod cmr;
 pub mod imr;
 pub mod tmr;
 
+use crate::bit_encoding::BitCollector;
 use crate::Value;
 use hashes::{sha256, Hash, HashEngine};
 use std::fmt;
@@ -43,7 +44,7 @@ impl AsRef<[u8]> for FailEntropy {
 /// Helper function to compute the "compact value", i.e. the sha256 hash
 /// of the bits of a given value, which is used in some IMRs and AMRs.
 fn compact_value(value: &Value) -> [u8; 32] {
-    let (mut bytes, bit_length) = value.to_bytes_len();
+    let (mut bytes, bit_length) = value.iter_compact().collect_bits();
 
     // TODO: Automate hashing once `hashes` supports bit-wise hashing
     // 1.1 Append single '1' bit

--- a/src/node/construct.rs
+++ b/src/node/construct.rs
@@ -256,7 +256,7 @@ impl<J> CoreConstructible for ConstructData<J> {
         }
     }
 
-    fn const_word(inference_context: &types::Context, word: Arc<Value>) -> Self {
+    fn const_word(inference_context: &types::Context, word: Value) -> Self {
         ConstructData {
             arrow: Arrow::const_word(inference_context, word),
             phantom: PhantomData,
@@ -390,7 +390,7 @@ mod tests {
 
         assert_eq!(
             unit.cmr(),
-            Arc::<ConstructNode<Core>>::scribe(&ctx, &Value::Unit).cmr()
+            Arc::<ConstructNode<Core>>::scribe(&ctx, &Value::unit()).cmr()
         );
         assert_eq!(
             bit0.cmr(),

--- a/src/node/inner.rs
+++ b/src/node/inner.rs
@@ -44,7 +44,7 @@ pub enum Inner<C, J, X, W> {
     /// Application jet
     Jet(J),
     /// Constant word
-    Word(Arc<Value>),
+    Word(Value),
 }
 
 impl<C, J: Clone, X, W> Inner<C, J, X, W> {
@@ -144,7 +144,7 @@ impl<C, J: Clone, X, W> Inner<C, J, X, W> {
             Inner::Witness(w) => Inner::Witness(w),
             Inner::Fail(entropy) => Inner::Fail(*entropy),
             Inner::Jet(j) => Inner::Jet(j.clone()),
-            Inner::Word(w) => Inner::Word(Arc::clone(w)),
+            Inner::Word(w) => Inner::Word(w.shallow_clone()),
         }
     }
 
@@ -171,7 +171,7 @@ impl<C, J: Clone, X, W> Inner<C, J, X, W> {
             Inner::Witness(w) => Inner::Witness(w),
             Inner::Fail(entropy) => Inner::Fail(entropy),
             Inner::Jet(j) => Inner::Jet(j),
-            Inner::Word(ref w) => Inner::Word(Arc::clone(w)),
+            Inner::Word(ref w) => Inner::Word(w.shallow_clone()),
         }
     }
 

--- a/src/policy/serialize.rs
+++ b/src/policy/serialize.rs
@@ -281,7 +281,7 @@ mod tests {
 
     fn execute_successful(
         commit: &CommitNode<Elements>,
-        witness: Vec<Arc<Value>>,
+        witness: Vec<Value>,
         env: &ElementsEnv<Arc<elements::Transaction>>,
     ) -> bool {
         let finalized = commit

--- a/src/types/arrow.rs
+++ b/src/types/arrow.rs
@@ -310,11 +310,11 @@ impl CoreConstructible for Arrow {
         }
     }
 
-    fn const_word(inference_context: &Context, word: Arc<Value>) -> Self {
-        let len = word.len();
+    fn const_word(inference_context: &Context, word: Value) -> Self {
+        let len = word.compact_len();
         assert!(len > 0, "Words must not be the empty bitstring");
         assert!(len.is_power_of_two());
-        let depth = word.len().trailing_zeros();
+        let depth = len.trailing_zeros();
         Arrow {
             source: Type::unit(inference_context),
             target: Type::two_two_n(inference_context, depth as usize),

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -224,6 +224,16 @@ impl Final {
             _ => None,
         }
     }
+
+    /// Compute the padding of left values of the sum type `Self + Other`.
+    pub fn pad_left(&self, other: &Self) -> usize {
+        cmp::max(self.bit_width, other.bit_width) - self.bit_width
+    }
+
+    /// Compute the padding of right values of the sum type `Self + Other`.
+    pub fn pad_right(&self, other: &Self) -> usize {
+        cmp::max(self.bit_width, other.bit_width) - other.bit_width
+    }
 }
 
 #[cfg(test)]

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -148,6 +148,17 @@ impl<'a> DagLike for &'a Final {
     }
 }
 
+macro_rules! construct_final_two_two_n {
+    ($name: ident, $n: expr, $text: expr) => {
+        #[doc = "Create the type of"]
+        #[doc = $text]
+        #[doc = "words.\n\nThe type is precomputed and fast to access."]
+        pub fn $name() -> Arc<Self> {
+            super::precomputed::nth_power_of_2($n)
+        }
+    };
+}
+
 impl Final {
     /// Create the unit type.
     pub fn unit() -> Arc<Self> {
@@ -164,6 +175,17 @@ impl Final {
     pub fn two_two_n(n: usize) -> Arc<Self> {
         super::precomputed::nth_power_of_2(n)
     }
+
+    construct_final_two_two_n!(u1, 0, "1-bit");
+    construct_final_two_two_n!(u2, 1, "2-bit");
+    construct_final_two_two_n!(u4, 2, "4-bit");
+    construct_final_two_two_n!(u8, 3, "8-bit");
+    construct_final_two_two_n!(u16, 4, "16-bit");
+    construct_final_two_two_n!(u32, 5, "32-bit");
+    construct_final_two_two_n!(u64, 6, "64-bit");
+    construct_final_two_two_n!(u128, 7, "128-bit");
+    construct_final_two_two_n!(u256, 8, "256-bit");
+    construct_final_two_two_n!(u512, 9, "512-bit");
 
     /// Create the sum of the given `left` and `right` types.
     pub fn sum(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -170,72 +170,76 @@ impl Value {
         }
     }
 
-    /// Encode a single bit as a value. Will panic if the input is out of range
-    pub fn u1(n: u8) -> Self {
-        match n {
+    /// Create a 1-bit integer.
+    ///
+    /// ## Panics
+    ///
+    /// The value is out of range.
+    pub fn u1(value: u8) -> Self {
+        match value {
             0 => Self::left(Self::unit(), Final::unit()),
             1 => Self::right(Final::unit(), Self::unit()),
             x => panic!("{} out of range for Value::u1", x),
         }
     }
 
-    /// Encode a two-bit number as a value. Will panic if the input is out of range
-    pub fn u2(n: u8) -> Self {
-        let b0 = (n & 2) / 2;
-        let b1 = n & 1;
-        assert!(n <= 3, "{} out of range for Value::u2", n);
+    /// Create a 2-bit integer.
+    ///
+    /// ## Panics
+    ///
+    /// The value is out of range.
+    pub fn u2(value: u8) -> Self {
+        let b0 = (value & 2) / 2;
+        let b1 = value & 1;
+        assert!(value <= 3, "{} out of range for Value::u2", value);
         Self::product(Self::u1(b0), Self::u1(b1))
     }
 
-    /// Encode a four-bit number as a value. Will panic if the input is out of range
-    pub fn u4(n: u8) -> Self {
-        let w0 = (n & 12) / 4;
-        let w1 = n & 3;
-        assert!(n <= 15, "{} out of range for Value::u2", n);
+    /// Create a 4-bit integer.
+    ///
+    /// ## Panics
+    ///
+    /// The value is ouf of range.
+    pub fn u4(value: u8) -> Self {
+        let w0 = (value & 12) / 4;
+        let w1 = value & 3;
+        assert!(value <= 15, "{} out of range for Value::u2", value);
         Self::product(Self::u2(w0), Self::u2(w1))
     }
 
-    /// Encode an eight-bit number as a value
-    pub fn u8(n: u8) -> Self {
-        let w0 = n >> 4;
-        let w1 = n & 0xf;
+    /// Create an 8-bit integer.
+    pub fn u8(value: u8) -> Self {
+        let w0 = value >> 4;
+        let w1 = value & 0xf;
         Self::product(Self::u4(w0), Self::u4(w1))
     }
 
-    /// Encode a 16-bit number as a value
-    pub fn u16(n: u16) -> Self {
-        let w0 = (n >> 8) as u8;
-        let w1 = (n & 0xff) as u8;
-        Self::product(Self::u8(w0), Self::u8(w1))
+    /// Create a 16-bit integer.
+    pub fn u16(bytes: u16) -> Self {
+        Self::from_byte_array(bytes.to_be_bytes())
     }
 
-    /// Encode a 32-bit number as a value
-    pub fn u32(n: u32) -> Self {
-        let w0 = (n >> 16) as u16;
-        let w1 = (n & 0xffff) as u16;
-        Self::product(Self::u16(w0), Self::u16(w1))
+    /// Create a 32-bit integer.
+    pub fn u32(bytes: u32) -> Self {
+        Self::from_byte_array(bytes.to_be_bytes())
     }
 
-    /// Encode a 64-bit number as a value
-    pub fn u64(n: u64) -> Self {
-        let w0 = (n >> 32) as u32;
-        let w1 = (n & 0xffff_ffff) as u32;
-        Self::product(Self::u32(w0), Self::u32(w1))
+    /// Create a 64-bit integer.
+    pub fn u64(bytes: u64) -> Self {
+        Self::from_byte_array(bytes.to_be_bytes())
     }
 
-    /// Encode a 128-bit number as a value
-    pub fn u128(n: u128) -> Self {
-        let w0 = (n >> 64) as u64;
-        let w1 = n as u64; // Cast safety: picking last 64 bits
-        Self::product(Self::u64(w0), Self::u64(w1))
+    /// Create a 128-bit integer.
+    pub fn u128(bytes: u128) -> Self {
+        Self::from_byte_array(bytes.to_be_bytes())
     }
 
-    /// Create a value from 32 bytes.
+    /// Create a 256-bit integer.
     pub fn u256(bytes: [u8; 32]) -> Self {
         Self::from_byte_array(bytes)
     }
 
-    /// Create a value from 64 bytes.
+    /// Create a 512-bit integer.
     pub fn u512(bytes: [u8; 64]) -> Self {
         Self::from_byte_array(bytes)
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -14,8 +14,15 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 /// A Simplicity value.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Value {
+    inner: ValueInner,
+    ty: Arc<Final>,
+}
+
+/// The inner structure of a Simplicity value.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Value {
+enum ValueInner {
     /// The unit value.
     ///
     /// The unit value is the only value of the unit type `1`.
@@ -47,145 +54,190 @@ impl<'a> DagLike for &'a Value {
     }
 
     fn as_dag_node(&self) -> Dag<Self> {
-        match self {
-            Value::Unit => Dag::Nullary,
-            Value::Left(child) | Value::Right(child) => Dag::Unary(child),
-            Value::Product(left, right) => Dag::Binary(left, right),
+        match &self.inner {
+            ValueInner::Unit => Dag::Nullary,
+            ValueInner::Left(child) | ValueInner::Right(child) => Dag::Unary(child),
+            ValueInner::Product(left, right) => Dag::Binary(left, right),
         }
     }
 }
 
 impl Value {
+    /// Make a cheap copy of the value.
+    pub fn shallow_clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            ty: Arc::clone(&self.ty),
+        }
+    }
+
+    /// Access the type of the value.
+    pub fn ty(&self) -> &Final {
+        &self.ty
+    }
+
     /// Create the unit value.
-    pub fn unit() -> Arc<Self> {
-        Arc::new(Self::Unit)
+    pub fn unit() -> Self {
+        Self {
+            inner: ValueInner::Unit,
+            ty: Final::unit(),
+        }
     }
 
     /// Create a left value that wraps the given `inner` value.
-    pub fn left(inner: Arc<Self>) -> Arc<Self> {
-        Arc::new(Value::Left(inner))
+    pub fn left(inner: Self, right: Arc<Final>) -> Self {
+        Self {
+            ty: Final::sum(Arc::clone(&inner.ty), right),
+            inner: ValueInner::Left(Arc::new(inner)),
+        }
     }
 
     /// Create a right value that wraps the given `inner` value.
-    pub fn right(inner: Arc<Self>) -> Arc<Self> {
-        Arc::new(Value::Right(inner))
+    pub fn right(left: Arc<Final>, inner: Self) -> Self {
+        Self {
+            ty: Final::sum(left, Arc::clone(&inner.ty)),
+            inner: ValueInner::Right(Arc::new(inner)),
+        }
     }
 
     /// Create a product value that wraps the given `left` and `right` values.
-    pub fn product(left: Arc<Self>, right: Arc<Self>) -> Arc<Self> {
-        Arc::new(Value::Product(left, right))
+    pub fn product(left: Self, right: Self) -> Self {
+        Self {
+            ty: Final::product(Arc::clone(&left.ty), Arc::clone(&right.ty)),
+            inner: ValueInner::Product(Arc::new(left), Arc::new(right)),
+        }
     }
 
-    /// The length, in bits, of the value when encoded in the Bit Machine
-    pub fn len(&self) -> usize {
-        self.pre_order_iter::<NoSharing>()
-            .filter(|inner| matches!(inner, Value::Left(_) | Value::Right(_)))
-            .count()
+    /// Create a none value.
+    pub fn none(right: Arc<Final>) -> Self {
+        Self {
+            ty: Final::sum(Final::unit(), right),
+            inner: ValueInner::Left(Arc::new(Value::unit())),
+        }
+    }
+
+    /// Create a some value.
+    pub fn some(inner: Self) -> Self {
+        Self {
+            ty: Final::sum(Final::unit(), Arc::clone(&inner.ty)),
+            inner: ValueInner::Right(Arc::new(inner)),
+        }
+    }
+
+    /// Return the bit length of the value in compact encoding.
+    pub fn compact_len(&self) -> usize {
+        self.iter_compact().count()
+    }
+
+    /// Return the bit length of the value in padded encoding.
+    pub fn padded_len(&self) -> usize {
+        self.iter_padded().count()
     }
 
     /// Check if the value is a nested product of units.
     /// In this case, the value contains no information.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.pre_order_iter::<NoSharing>()
+            .all(|value| matches!(&value.inner, ValueInner::Unit | ValueInner::Product(..)))
     }
 
     /// Check if the value is a unit.
     pub fn is_unit(&self) -> bool {
-        matches!(self, Value::Unit)
+        matches!(&self.inner, ValueInner::Unit)
     }
 
     /// Access the inner value of a left sum value.
     pub fn as_left(&self) -> Option<&Self> {
-        match self {
-            Value::Left(inner) => Some(inner.as_ref()),
+        match &self.inner {
+            ValueInner::Left(inner) => Some(inner.as_ref()),
             _ => None,
         }
     }
 
     /// Access the inner value of a right sum value.
     pub fn as_right(&self) -> Option<&Self> {
-        match self {
-            Value::Right(inner) => Some(inner.as_ref()),
+        match &self.inner {
+            ValueInner::Right(inner) => Some(inner.as_ref()),
             _ => None,
         }
     }
 
     /// Access the inner values of a product value.
     pub fn as_product(&self) -> Option<(&Self, &Self)> {
-        match self {
-            Value::Product(left, right) => Some((left.as_ref(), right.as_ref())),
+        match &self.inner {
+            ValueInner::Product(left, right) => Some((left.as_ref(), right.as_ref())),
             _ => None,
         }
     }
 
     /// Encode a single bit as a value. Will panic if the input is out of range
-    pub fn u1(n: u8) -> Arc<Self> {
+    pub fn u1(n: u8) -> Self {
         match n {
-            0 => Value::left(Value::unit()),
-            1 => Value::right(Value::unit()),
+            0 => Self::left(Self::unit(), Final::unit()),
+            1 => Self::right(Final::unit(), Self::unit()),
             x => panic!("{} out of range for Value::u1", x),
         }
     }
 
     /// Encode a two-bit number as a value. Will panic if the input is out of range
-    pub fn u2(n: u8) -> Arc<Self> {
+    pub fn u2(n: u8) -> Self {
         let b0 = (n & 2) / 2;
         let b1 = n & 1;
         assert!(n <= 3, "{} out of range for Value::u2", n);
-        Value::product(Value::u1(b0), Value::u1(b1))
+        Self::product(Self::u1(b0), Self::u1(b1))
     }
 
     /// Encode a four-bit number as a value. Will panic if the input is out of range
-    pub fn u4(n: u8) -> Arc<Self> {
+    pub fn u4(n: u8) -> Self {
         let w0 = (n & 12) / 4;
         let w1 = n & 3;
         assert!(n <= 15, "{} out of range for Value::u2", n);
-        Value::product(Value::u2(w0), Value::u2(w1))
+        Self::product(Self::u2(w0), Self::u2(w1))
     }
 
     /// Encode an eight-bit number as a value
-    pub fn u8(n: u8) -> Arc<Self> {
+    pub fn u8(n: u8) -> Self {
         let w0 = n >> 4;
         let w1 = n & 0xf;
-        Value::product(Value::u4(w0), Value::u4(w1))
+        Self::product(Self::u4(w0), Self::u4(w1))
     }
 
     /// Encode a 16-bit number as a value
-    pub fn u16(n: u16) -> Arc<Self> {
+    pub fn u16(n: u16) -> Self {
         let w0 = (n >> 8) as u8;
         let w1 = (n & 0xff) as u8;
-        Value::product(Value::u8(w0), Value::u8(w1))
+        Self::product(Self::u8(w0), Self::u8(w1))
     }
 
     /// Encode a 32-bit number as a value
-    pub fn u32(n: u32) -> Arc<Self> {
+    pub fn u32(n: u32) -> Self {
         let w0 = (n >> 16) as u16;
         let w1 = (n & 0xffff) as u16;
-        Value::product(Value::u16(w0), Value::u16(w1))
+        Self::product(Self::u16(w0), Self::u16(w1))
     }
 
     /// Encode a 64-bit number as a value
-    pub fn u64(n: u64) -> Arc<Self> {
+    pub fn u64(n: u64) -> Self {
         let w0 = (n >> 32) as u32;
         let w1 = (n & 0xffff_ffff) as u32;
-        Value::product(Value::u32(w0), Value::u32(w1))
+        Self::product(Self::u32(w0), Self::u32(w1))
     }
 
     /// Encode a 128-bit number as a value
-    pub fn u128(n: u128) -> Arc<Self> {
+    pub fn u128(n: u128) -> Self {
         let w0 = (n >> 64) as u64;
         let w1 = n as u64; // Cast safety: picking last 64 bits
-        Value::product(Value::u64(w0), Value::u64(w1))
+        Self::product(Self::u64(w0), Self::u64(w1))
     }
 
     /// Create a value from 32 bytes.
-    pub fn u256(bytes: [u8; 32]) -> Arc<Self> {
-        Value::from_byte_array(bytes)
+    pub fn u256(bytes: [u8; 32]) -> Self {
+        Self::from_byte_array(bytes)
     }
 
     /// Create a value from 64 bytes.
-    pub fn u512(bytes: [u8; 64]) -> Arc<Self> {
-        Value::from_byte_array(bytes)
+    pub fn u512(bytes: [u8; 64]) -> Self {
+        Self::from_byte_array(bytes)
     }
 
     /// Create a value from a byte array.
@@ -193,7 +245,7 @@ impl Value {
     /// ## Panics
     ///
     /// The array length is not a power of two.
-    pub fn from_byte_array<const N: usize>(bytes: [u8; N]) -> Arc<Self> {
+    pub fn from_byte_array<const N: usize>(bytes: [u8; N]) -> Self {
         assert!(N.is_power_of_two(), "Array length must be a power of two");
         let mut values: VecDeque<_> = bytes.into_iter().map(Value::u8).collect();
 
@@ -210,95 +262,28 @@ impl Value {
         values.into_iter().next().unwrap()
     }
 
-    /// Execute function `f` on each bit of the encoding of the value.
-    pub fn do_each_bit<F>(&self, mut f: F)
-    where
-        F: FnMut(bool),
-    {
-        for val in self.pre_order_iter::<NoSharing>() {
-            match val {
-                Value::Unit => {}
-                Value::Left(..) => f(false),
-                Value::Right(..) => f(true),
-                Value::Product(..) => {}
-            }
-        }
+    /// Return an iterator over the compact bit encoding of the value.
+    ///
+    /// This encoding is used for writing witness data and for computing IMRs.
+    pub fn iter_compact(&self) -> impl Iterator<Item = bool> + '_ {
+        self.pre_order_iter::<NoSharing>()
+            .filter_map(|value| match &value.inner {
+                ValueInner::Left(..) => Some(false),
+                ValueInner::Right(..) => Some(true),
+                _ => None,
+            })
     }
 
-    /// Encode value as big-endian byte string.
-    /// Fails if underlying bit string has length not divisible by 8
-    pub fn try_to_bytes(&self) -> Result<Vec<u8>, &'static str> {
-        let (bytes, bit_length) = self.to_bytes_len();
-
-        if bit_length % 8 == 0 {
-            Ok(bytes)
-        } else {
-            Err("Length of bit string that encodes this value is not divisible by 8!")
-        }
-    }
-
-    /// Encode value as big-endian byte string.
-    /// Trailing zeroes are added as padding if underlying bit string has length not divisible by 8.
-    /// The length of said bit string is returned as second argument
-    pub fn to_bytes_len(&self) -> (Vec<u8>, usize) {
-        let mut bytes = vec![];
-        let mut unfinished_byte = Vec::with_capacity(8);
-        let update_bytes = |bit: bool| {
-            unfinished_byte.push(bit);
-
-            if unfinished_byte.len() == 8 {
-                bytes.push(
-                    unfinished_byte
-                        .iter()
-                        .fold(0, |acc, &b| acc * 2 + u8::from(b)),
-                );
-                unfinished_byte.clear();
-            }
-        };
-
-        self.do_each_bit(update_bytes);
-        let bit_length = bytes.len() * 8 + unfinished_byte.len();
-
-        if !unfinished_byte.is_empty() {
-            unfinished_byte.resize(8, false);
-            bytes.push(
-                unfinished_byte
-                    .iter()
-                    .fold(0, |acc, &b| acc * 2 + u8::from(b)),
-            );
-        }
-
-        (bytes, bit_length)
+    /// Return an iterator over the padded bit encoding of the value.
+    ///
+    /// This encoding is used to represent the value in the Bit Machine.
+    pub fn iter_padded(&self) -> impl Iterator<Item = bool> + '_ {
+        PaddedBitsIter::new(self)
     }
 
     /// Check if the value is of the given type.
     pub fn is_of_type(&self, ty: &Final) -> bool {
-        let mut stack = vec![(self, ty)];
-
-        while let Some((value, ty)) = stack.pop() {
-            if ty.is_unit() {
-                if !value.is_unit() {
-                    return false;
-                }
-            } else if let Some((ty_l, ty_r)) = ty.as_sum() {
-                if let Some(value_l) = value.as_left() {
-                    stack.push((value_l, ty_l));
-                } else if let Some(value_r) = value.as_right() {
-                    stack.push((value_r, ty_r));
-                } else {
-                    return false;
-                }
-            } else if let Some((ty_l, ty_r)) = ty.as_product() {
-                if let Some((value_l, value_r)) = value.as_product() {
-                    stack.push((value_r, ty_r));
-                    stack.push((value_l, ty_l));
-                } else {
-                    return false;
-                }
-            }
-        }
-
-        true
+        self.ty.as_ref() == ty
     }
 }
 
@@ -311,25 +296,28 @@ impl fmt::Debug for Value {
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for data in self.verbose_pre_order_iter::<NoSharing>(None) {
-            match data.node {
-                Value::Unit => {
+            match &data.node.inner {
+                ValueInner::Unit => {
                     if data.n_children_yielded == 0
-                        && !matches!(data.parent, Some(Value::Left(_)) | Some(Value::Right(_)))
+                        && !matches!(
+                            data.parent.map(|value| &value.inner),
+                            Some(ValueInner::Left(_)) | Some(ValueInner::Right(_))
+                        )
                     {
                         f.write_str("ε")?;
                     }
                 }
-                Value::Left(..) => {
+                ValueInner::Left(..) => {
                     if data.n_children_yielded == 0 {
                         f.write_str("0")?;
                     }
                 }
-                Value::Right(..) => {
+                ValueInner::Right(..) => {
                     if data.n_children_yielded == 0 {
                         f.write_str("1")?;
                     }
                 }
-                Value::Product(..) => match data.n_children_yielded {
+                ValueInner::Product(..) => match data.n_children_yielded {
                     0 => f.write_str("(")?,
                     1 => f.write_str(",")?,
                     2 => f.write_str(")")?,
@@ -338,6 +326,61 @@ impl fmt::Display for Value {
             }
         }
         Ok(())
+    }
+}
+
+/// An iterator over the bits of the padded encoding of a [`Value`].
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+struct PaddedBitsIter<'a> {
+    stack: Vec<&'a Value>,
+    next_padding: Option<usize>,
+}
+
+impl<'a> PaddedBitsIter<'a> {
+    /// Create an iterator over the bits of the padded encoding of the `value`.
+    pub fn new(value: &'a Value) -> Self {
+        Self {
+            stack: vec![value],
+            next_padding: None,
+        }
+    }
+}
+
+impl<'a> Iterator for PaddedBitsIter<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.next_padding {
+            Some(0) => {
+                self.next_padding = None;
+            }
+            Some(n) => {
+                self.next_padding = Some(n - 1);
+                return Some(false);
+            }
+            None => {}
+        }
+
+        while let Some(value) = self.stack.pop() {
+            if value.is_unit() {
+                // NOP
+            } else if let Some(l_value) = value.as_left() {
+                let (l_ty, r_ty) = value.ty.as_sum().unwrap();
+                self.stack.push(l_value);
+                self.next_padding = Some(l_ty.pad_left(r_ty));
+                return Some(false);
+            } else if let Some(r_value) = value.as_right() {
+                let (l_ty, r_ty) = value.ty.as_sum().unwrap();
+                self.stack.push(r_value);
+                self.next_padding = Some(l_ty.pad_right(r_ty));
+                return Some(true);
+            } else if let Some((l_value, r_value)) = value.as_product() {
+                self.stack.push(r_value);
+                self.stack.push(l_value);
+            }
+        }
+
+        None
     }
 }
 
@@ -359,10 +402,16 @@ mod tests {
     fn is_of_type() {
         let value_typename = [
             (Value::unit(), TypeName(b"1")),
-            (Value::left(Value::unit()), TypeName(b"+11")),
-            (Value::right(Value::unit()), TypeName(b"+11")),
-            (Value::left(Value::unit()), TypeName(b"+1h")),
-            (Value::right(Value::unit()), TypeName(b"+h1")),
+            (Value::left(Value::unit(), Final::unit()), TypeName(b"+11")),
+            (Value::right(Final::unit(), Value::unit()), TypeName(b"+11")),
+            (
+                Value::left(Value::unit(), Final::two_two_n(8)),
+                TypeName(b"+1h"),
+            ),
+            (
+                Value::right(Final::two_two_n(8), Value::unit()),
+                TypeName(b"+h1"),
+            ),
             (
                 Value::product(Value::unit(), Value::unit()),
                 TypeName(b"*11"),


### PR DESCRIPTION
We need to encode values with padding on the Bit Machine. This encoding requires information about the type of the value. It turns out that universally typing all Simplicity values produces the smallest diff, and it is the safest API. This PR refactors the `Value` struct to include type information.

I also have ideas for a `Word` struct that wraps values of the word type. Only these values are safe to use in word jets. I will leave this for a follow-up PR.