### PR TITLE
heavily optimize the `Value` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ members = ["simpcli", "simplicity-sys", "fuzz"]
 # Should be manually/separately tested since it has a massive dep tree
 # and not follow MSRV
 exclude = ["jets-bench"]
+
+[lints.rust]
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(bench)'] }

--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ The MSRV of this crate is **1.63.0**.
 Some of the jet files in the library are auto-generated from Haskell code. These can be updated `update_jets.sh`. This requires the user has `cabal` and other necessary things that are required to build simplicity haskell. Instructions for those can be found in the simplicity repository.
 
 This script also checks that the internal vendored version of simplicity has the same git hash as of the version from which we are auto-generating the code. If this is not the case, the script will fail. This is because we only vendor minimal required C simplicity code and not the entire simplicity repo.
+
+# Benchmarking
+
+There are two sets of benchmarks in this codebase. First, there is the `jets-bench`
+sub-crate which uses criterion to collect statistics about jet performance. These
+benchmarks are specifically targeted at the C jets and are intended to estimate
+consensus costs.
+
+See `jets-bench/README.md` for information about running these benchmarks.
+
+The second set of benchmarks are benchmarks for this library's performance. These
+are used to track performance of this library itself. These can be run with
+
+```
+RUSTFLAGS=--cfg=bench cargo +nightly bench
+```
+
+The custom `cfg` flag is used to prevent nightly-only code from polluting ordinary
+code.

--- a/src/bit_encoding/bititer.rs
+++ b/src/bit_encoding/bititer.rs
@@ -69,6 +69,17 @@ pub enum u2 {
     _3,
 }
 
+impl From<u2> for u8 {
+    fn from(s: u2) -> u8 {
+        match s {
+            u2::_0 => 0,
+            u2::_1 => 1,
+            u2::_2 => 2,
+            u2::_3 => 3,
+        }
+    }
+}
+
 /// Bitwise iterator formed from a wrapped bytewise iterator. Bytes are
 /// interpreted big-endian, i.e. MSB is returned first
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
+#![cfg_attr(bench, feature(test))]
 #![allow(
     // we use `bool` to represent bits and frequentely assert_eq against them
     clippy::bool_assert_comparison,
@@ -22,6 +23,9 @@ pub extern crate byteorder;
 pub extern crate hashes;
 /// Re-export of hex crate
 pub extern crate hex;
+
+#[cfg(bench)]
+extern crate test;
 
 #[macro_use]
 mod macros;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -190,14 +190,14 @@ pub trait CoreConstructible: Sized {
     /// The expression is minimized by using as many word jets as possible.
     fn scribe(ctx: &types::Context, value: &Value) -> Self {
         #[derive(Debug, Clone)]
-        enum Task<'a> {
-            Process(&'a Value),
+        enum Task {
+            Process(Value),
             MakeLeft,
             MakeRight,
             MakeProduct,
         }
 
-        let mut input = vec![Task::Process(value)];
+        let mut input = vec![Task::Process(value.shallow_clone())];
         let mut output = vec![];
         while let Some(top) = input.pop() {
             match top {
@@ -206,13 +206,13 @@ pub trait CoreConstructible: Sized {
                         output.push(Self::unit(ctx));
                     } else if let Some(word) = value.to_word() {
                         output.push(Self::const_word(ctx, word));
-                    } else if let Some(left) = value.as_left() {
+                    } else if let Some(left) = value.to_left() {
                         input.push(Task::MakeLeft);
                         input.push(Task::Process(left));
-                    } else if let Some(right) = value.as_right() {
+                    } else if let Some(right) = value.to_right() {
                         input.push(Task::MakeRight);
                         input.push(Task::Process(right));
-                    } else if let Some((left, right)) = value.as_product() {
+                    } else if let Some((left, right)) = value.to_product() {
                         input.push(Task::MakeProduct);
                         input.push(Task::Process(right));
                         input.push(Task::Process(left));

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -232,17 +232,17 @@ impl Final {
     }
 
     /// Access the inner types of a sum type.
-    pub fn as_sum(&self) -> Option<(&Self, &Self)> {
+    pub fn as_sum(&self) -> Option<(&Arc<Self>, &Arc<Self>)> {
         match &self.bound {
-            CompleteBound::Sum(left, right) => Some((left.as_ref(), right.as_ref())),
+            CompleteBound::Sum(left, right) => Some((left, right)),
             _ => None,
         }
     }
 
     /// Access the inner types of a product type.
-    pub fn as_product(&self) -> Option<(&Self, &Self)> {
+    pub fn as_product(&self) -> Option<(&Arc<Self>, &Arc<Self>)> {
         match &self.bound {
-            CompleteBound::Product(left, right) => Some((left.as_ref(), right.as_ref())),
+            CompleteBound::Product(left, right) => Some((left, right)),
             _ => None,
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -854,6 +854,22 @@ mod tests {
     }
 
     #[test]
+    fn prune_regression_1() {
+        // Found this when fuzzing Elements; unsure how to reduce it further.
+        let nontrivial_sum = Value::product(
+            Value::right(Final::two_two_n(4), Value::u16(0)),
+            Value::u8(0),
+        );
+        // Formatting should succeed and have no effect.
+        let _ = format!("{nontrivial_sum}");
+        // Pruning should succeed and have no effect.
+        assert_eq!(
+            nontrivial_sum.prune(nontrivial_sum.ty()),
+            Some(nontrivial_sum)
+        );
+    }
+
+    #[test]
     fn prune() {
         let test_vectors = [
             (Value::unit(), Value::unit()),

--- a/src/value.rs
+++ b/src/value.rs
@@ -802,6 +802,20 @@ mod tests {
     use crate::jet::type_name::TypeName;
 
     #[test]
+    fn value_len() {
+        let v = Value::u4(6);
+        let s_v = Value::some(v.shallow_clone());
+        let n_v = Value::none(Final::two_two_n(2));
+
+        assert_eq!(v.compact_len(), 4);
+        assert_eq!(v.padded_len(), 4);
+        assert_eq!(s_v.compact_len(), 5);
+        assert_eq!(s_v.padded_len(), 5);
+        assert_eq!(n_v.compact_len(), 1);
+        assert_eq!(n_v.padded_len(), 5);
+    }
+
+    #[test]
     fn value_display() {
         // Only test a couple values becasue we probably want to change this
         // at some point and will have to redo this test.

--- a/src/value.rs
+++ b/src/value.rs
@@ -946,8 +946,8 @@ impl Padding for PaddedEncoding {
 }
 
 impl Value {
-    fn from_bits<I: Iterator<Item = bool>, P: Padding>(
-        bits: &mut I,
+    fn from_bits<I: Iterator<Item = u8>, P: Padding>(
+        bits: &mut BitIter<I>,
         ty: &Final,
     ) -> Result<Self, EarlyEndOfStreamError> {
         enum State<'a> {
@@ -1000,16 +1000,16 @@ impl Value {
     }
 
     /// Decode a value of the given type from its compact bit encoding.
-    pub fn from_compact_bits<I: Iterator<Item = bool>>(
-        bits: &mut I,
+    pub fn from_compact_bits<I: Iterator<Item = u8>>(
+        bits: &mut BitIter<I>,
         ty: &Final,
     ) -> Result<Self, EarlyEndOfStreamError> {
         Self::from_bits::<_, CompactEncoding>(bits, ty)
     }
 
     /// Decode a value of the given type from its padded bit encoding.
-    pub fn from_padded_bits<I: Iterator<Item = bool>>(
-        bits: &mut I,
+    pub fn from_padded_bits<I: Iterator<Item = u8>>(
+        bits: &mut BitIter<I>,
         ty: &Final,
     ) -> Result<Self, EarlyEndOfStreamError> {
         Self::from_bits::<_, PaddedEncoding>(bits, ty)
@@ -1126,8 +1126,8 @@ impl Word {
     /// ## Panics
     ///
     /// n is greater than 31.
-    pub fn from_bits<I: Iterator<Item = bool>>(
-        bits: &mut I,
+    pub fn from_bits<I: Iterator<Item = u8>>(
+        bits: &mut BitIter<I>,
         n: u32,
     ) -> Result<Self, EarlyEndOfStreamError> {
         assert!(n < 32, "TWO^(2^{n}) is not supported as a word type");

--- a/src/value.rs
+++ b/src/value.rs
@@ -111,18 +111,12 @@ impl Value {
 
     /// Create a none value.
     pub fn none(right: Arc<Final>) -> Self {
-        Self {
-            ty: Final::sum(Final::unit(), right),
-            inner: ValueInner::Left(Arc::new(Value::unit())),
-        }
+        Self::left(Value::unit(), right)
     }
 
     /// Create a some value.
     pub fn some(inner: Self) -> Self {
-        Self {
-            ty: Final::sum(Final::unit(), Arc::clone(&inner.ty)),
-            inner: ValueInner::Right(Arc::new(inner)),
-        }
+        Self::right(Final::unit(), inner)
     }
 
     /// Return the bit length of the value in compact encoding.
@@ -132,19 +126,18 @@ impl Value {
 
     /// Return the bit length of the value in padded encoding.
     pub fn padded_len(&self) -> usize {
-        self.iter_padded().count()
+        self.ty.bit_width()
     }
 
     /// Check if the value is a nested product of units.
     /// In this case, the value contains no information.
     pub fn is_empty(&self) -> bool {
-        self.pre_order_iter::<NoSharing>()
-            .all(|value| matches!(&value.inner, ValueInner::Unit | ValueInner::Product(..)))
+        self.ty.bit_width() == 0
     }
 
     /// Check if the value is a unit.
     pub fn is_unit(&self) -> bool {
-        matches!(&self.inner, ValueInner::Unit)
+        self.ty.is_unit()
     }
 
     /// Access the inner value of a left sum value.

--- a/src/value.rs
+++ b/src/value.rs
@@ -799,6 +799,7 @@ impl fmt::Display for Word {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bit_encoding::{BitCollector as _, BitIter};
     use crate::jet::type_name::TypeName;
 
     #[test]
@@ -926,6 +927,24 @@ mod tests {
         for (ty, expected_default_value) in test_vectors {
             assert_eq!(Value::zero(&ty), expected_default_value);
         }
+    }
+
+    #[test]
+    fn compact_round_trip() {
+        let v = Value::u64(0xff00_00ff_ff00_00ff);
+        let (bits, _) = v.iter_compact().collect_bits();
+        let mut iter = BitIter::new(bits.into_iter());
+        let new_v = Value::from_compact_bits(&mut iter, &v.ty).unwrap();
+        assert_eq!(v, new_v);
+    }
+
+    #[test]
+    fn padded_round_trip() {
+        let v = Value::u64(0xff00_00ff_ff00_00ff);
+        let (bits, _) = v.iter_padded().collect_bits();
+        let mut iter = BitIter::new(bits.into_iter());
+        let new_v = Value::from_padded_bits(&mut iter, &v.ty).unwrap();
+        assert_eq!(v, new_v);
     }
 }
 


### PR DESCRIPTION
This PR has many commits but only one I would say is "big". This logic is all pretty-heavily covered by tests, and I added more tests, as well as benchmarks, so hopefully you don't need to review the fiddly bit-manipulation stuff too hard.

It also leaves the `value` module in a somewhat messier state than when it started -- we have a new `ValueRef` type which duplicates some functionality of `Value` but isn't exposed in the public API; we now implement `DagLike` on `Value` itself rather than `&Value`, but using it is pretty slow compared to using it on `ValueRef`. The `Eq` and `Ord` traits are now implemented manually, but `Eq` requires a bit of computation and `Ord`, despite being implemented manually, still exposes a pretty-arbitrary ordering on values which have different types.

So it is probably worthwhile to follow up on this with a PR that overhauls the public API and tries to provide a cleaner interface.

**However**, this PR also introduces some massive speedups. It introduces new benchmarks and has their output in some commit messages. The highlights are as follows:

Prior to this PR:
```
    benches::bench_value_create_64k               ... bench:   2,565,318.90 ns/iter (+/- 40,140.60)
    benches::bench_value_create_64k_compact       ... bench: 214,621,296.60 ns/iter (+/- 23,731,924.55)
    benches::bench_value_display_64k              ... bench:  17,526,983.30 ns/iter (+/- 339,118.95)
````

With this PR:
```
    benches::bench_value_create_64k               ... bench:     875,039.00 ns/iter (+/- 5,007.70)
    benches::bench_value_create_64k_compact       ... bench:      45,258.88 ns/iter (+/- 169.22)
    benches::bench_value_display_64k              ... bench:   9,685,460.80 ns/iter (+/- 48,509.31)
```

In other words, directly creating a value which is a 64 kilobyte (not kilobit) bitstring used to take 2.5ms; displaying took 17ms; and parsing it from a bit iterator took **214** milliseconds. Now these take 0.875ms, 9ms and 0.045ms, respectively. These are a 2.8, 1.8, and 4700x speedup respectively.

The latter operation in particular, creating values from bitstrings and types, has been a major bottleneck in my fuzzer and is the motivation for this PR.