### PR TITLE
Followups to #266 -- more `Value` optimizations

### DIFF
--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -121,7 +121,7 @@ impl Cmr {
         let imr_iv = Self::CONST_WORD_IV;
         let imr_pass1 = imr_iv.update_1(cmr_stack[0]);
         // 2. Add TMRs to get the pass-two IMR
-        let imr_pass2 = imr_pass1.update(Tmr::unit().into(), Tmr::POWERS_OF_TWO[w - 1].into());
+        let imr_pass2 = imr_pass1.update(Tmr::unit().into(), Tmr::TWO_TWO_N[w - 1].into());
         // 3. Convert to a jet CMR
         Cmr(bip340_iv(b"Simplicity\x1fJet")).update_with_weight(word.len() as u64, imr_pass2)
     }

--- a/src/merkle/tmr.rs
+++ b/src/merkle/tmr.rs
@@ -41,7 +41,7 @@ impl Tmr {
 
     /// The TMRs of the types TWO^(2^n) for small values of n
     #[rustfmt::skip]
-    pub const POWERS_OF_TWO: [Tmr; 32] = [
+    pub const TWO_TWO_N: [Tmr; 32] = [
         Tmr(Midstate([
             0x88, 0x5a, 0x22, 0xde, 0x3e, 0xdb, 0x3f, 0x40,
             0xdb, 0x06, 0x09, 0xc2, 0x40, 0x23, 0x30, 0x3f,
@@ -305,14 +305,14 @@ mod tests {
             assert_eq!(target, expected_tmrs[i], "mismatch on TMR for TWO^(2^{i})");
         }
 
-        let n = Tmr::POWERS_OF_TWO.len();
+        let n = Tmr::TWO_TWO_N.len();
         let tmrs = types::Type::powers_of_two(&types::Context::new(), n)
             .iter()
             .filter_map(types::Type::tmr)
             .collect::<Vec<Tmr>>();
         debug_assert_eq!(tmrs.len(), n);
         for i in 0..n {
-            check_pow(Tmr::POWERS_OF_TWO[i], i, &tmrs);
+            check_pow(Tmr::TWO_TWO_N[i], i, &tmrs);
         }
     }
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -189,15 +189,17 @@ pub trait CoreConstructible: Sized {
     ///
     /// The expression is minimized by using as many word jets as possible.
     fn scribe(ctx: &types::Context, value: &Value) -> Self {
+        use crate::value::ValueRef;
+
         #[derive(Debug, Clone)]
-        enum Task {
-            Process(Value),
+        enum Task<'v> {
+            Process(ValueRef<'v>),
             MakeLeft,
             MakeRight,
             MakeProduct,
         }
 
-        let mut input = vec![Task::Process(value.shallow_clone())];
+        let mut input = vec![Task::Process(value.as_ref())];
         let mut output = vec![];
         while let Some(top) = input.pop() {
             match top {
@@ -206,13 +208,13 @@ pub trait CoreConstructible: Sized {
                         output.push(Self::unit(ctx));
                     } else if let Some(word) = value.to_word() {
                         output.push(Self::const_word(ctx, word));
-                    } else if let Some(left) = value.to_left() {
+                    } else if let Some(left) = value.as_left() {
                         input.push(Task::MakeLeft);
                         input.push(Task::Process(left));
-                    } else if let Some(right) = value.to_right() {
+                    } else if let Some(right) = value.as_right() {
                         input.push(Task::MakeRight);
                         input.push(Task::Process(right));
-                    } else if let Some((left, right)) = value.to_product() {
+                    } else if let Some((left, right)) = value.as_product() {
                         input.push(Task::MakeProduct);
                         input.push(Task::Process(right));
                         input.push(Task::Process(left));

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -83,11 +83,11 @@ impl fmt::Display for Final {
                 }
                 continue;
             } else {
-                if data.node.tmr == Tmr::POWERS_OF_TWO[0] {
+                if data.node.tmr == Tmr::TWO_TWO_N[0] {
                     f.write_str("2")?;
                     skipping = Some(data.node.tmr);
                 }
-                for (n, tmr) in Tmr::POWERS_OF_TWO.iter().enumerate().skip(1) {
+                for (n, tmr) in Tmr::TWO_TWO_N.iter().enumerate().skip(1) {
                     if data.node.tmr == *tmr {
                         write!(f, "2^{}", 1 << n)?;
                         skipping = Some(data.node.tmr);
@@ -254,7 +254,7 @@ impl Final {
     /// 0 ≤ n < 32.
     pub fn as_word(&self) -> Option<u32> {
         (0..32u32).find(|&n| {
-            self.tmr == Tmr::POWERS_OF_TWO[n as usize] // cast safety: 32-bit machine or higher
+            self.tmr == Tmr::TWO_TWO_N[n as usize] // cast safety: 32-bit machine or higher
         })
     }
 

--- a/src/types/final_data.rs
+++ b/src/types/final_data.rs
@@ -36,6 +36,10 @@ pub struct Final {
     bound: CompleteBound,
     /// Width of the type, in bits, in the bit machine
     bit_width: usize,
+    /// Whether the type's bit representation has any padding. If this is true,
+    /// then its "compact" witness-encoded bit-width may be lower than its "padded"
+    /// bit-machine bit-width.
+    has_padding: bool,
     /// TMR of the type
     tmr: Tmr,
 }
@@ -165,6 +169,7 @@ impl Final {
         Arc::new(Final {
             bound: CompleteBound::Unit,
             bit_width: 0,
+            has_padding: false,
             tmr: Tmr::unit(),
         })
     }
@@ -192,6 +197,7 @@ impl Final {
         Arc::new(Final {
             tmr: Tmr::sum(left.tmr, right.tmr),
             bit_width: 1 + cmp::max(left.bit_width, right.bit_width),
+            has_padding: left.has_padding || right.has_padding || left.bit_width != right.bit_width,
             bound: CompleteBound::Sum(left, right),
         })
     }
@@ -201,6 +207,7 @@ impl Final {
         Arc::new(Final {
             tmr: Tmr::product(left.tmr, right.tmr),
             bit_width: left.bit_width + right.bit_width,
+            has_padding: left.has_padding || right.has_padding,
             bound: CompleteBound::Product(left, right),
         })
     }
@@ -213,6 +220,14 @@ impl Final {
     /// Accessor for the Bit Machine bit-width of the type
     pub fn bit_width(&self) -> usize {
         self.bit_width
+    }
+
+    /// Whether the type's bit representation has any padding.
+    ///
+    /// If this is true, then its "compact" witness-encoded bit-width may be lower
+    /// than its "padded" bit-machine bit-width.
+    pub fn has_padding(&self) -> bool {
+        self.has_padding
     }
 
     /// Check if the type is a nested product of units.

--- a/src/types/precomputed.rs
+++ b/src/types/precomputed.rs
@@ -21,10 +21,10 @@ use std::convert::TryInto;
 use std::sync::Arc;
 
 // Directly use the size of the precomputed TMR table to make sure they're in sync.
-const N_POWERS: usize = Tmr::POWERS_OF_TWO.len();
+const N_POWERS: usize = Tmr::TWO_TWO_N.len();
 
 thread_local! {
-    static POWERS_OF_TWO: RefCell<Option<[Arc<Final>; N_POWERS]>> = const { RefCell::new(None) };
+    static TWO_TWO_N: RefCell<Option<[Arc<Final>; N_POWERS]>> = const { RefCell::new(None) };
 }
 
 fn initialize(write: &mut Option<[Arc<Final>; N_POWERS]>) {
@@ -49,9 +49,9 @@ fn initialize(write: &mut Option<[Arc<Final>; N_POWERS]>) {
 ///
 /// # Panics
 ///
-/// Panics if you request a number `n` greater than or equal to [`Tmr::POWERS_OF_TWO`].
+/// Panics if you request a number `n` greater than or equal to [`Tmr::TWO_TWO_N`].
 pub fn nth_power_of_2(n: usize) -> Arc<Final> {
-    POWERS_OF_TWO.with(|arr| {
+    TWO_TWO_N.with(|arr| {
         if arr.borrow().is_none() {
             initialize(&mut arr.borrow_mut());
         }

--- a/src/value.rs
+++ b/src/value.rs
@@ -419,7 +419,7 @@ impl Value {
     }
 
     /// Helper function to convert the value to a reference
-    fn as_value(&self) -> ValueRef {
+    fn as_ref(&self) -> ValueRef {
         ValueRef {
             inner: self.inner.as_ref(),
             bit_offset: self.bit_offset,
@@ -641,7 +641,7 @@ impl Value {
     ///
     /// This encoding is used for writing witness data and for computing IMRs.
     pub fn iter_compact(&self) -> CompactBitsIter {
-        CompactBitsIter::new(self.as_value())
+        CompactBitsIter::new(self.as_ref())
     }
 
     /// Return an iterator over the padded bit encoding of the value.
@@ -813,7 +813,7 @@ impl fmt::Display for Value {
         // Next node to visit, and a boolean indicating whether we should
         // display units explicitly (turned off for sums, since a sum of
         // a unit is displayed simply as 0 or 1.
-        stack.push(S::Disp(self.as_value()));
+        stack.push(S::Disp(self.as_ref()));
 
         while let Some(next) = stack.pop() {
             let value = match next {

--- a/src/value.rs
+++ b/src/value.rs
@@ -677,6 +677,9 @@ impl Value {
 
         while let Some(task) = stack.pop() {
             match task {
+                Task::Prune(value, pruned_ty) if value.ty.as_ref() == pruned_ty => {
+                    output.push(value.to_value())
+                }
                 Task::Prune(value, pruned_ty) => match pruned_ty.bound() {
                     CompleteBound::Unit => output.push(Value::unit()),
                     CompleteBound::Sum(l_ty, r_ty) => {

--- a/src/value.rs
+++ b/src/value.rs
@@ -961,21 +961,20 @@ impl Value {
         let mut result_stack = vec![];
         'stack_loop: while let Some(state) = stack.pop() {
             match state {
-                State::ProcessType(ty) if ty.tmr() == Tmr::POWERS_OF_TWO[0] => {
+                State::ProcessType(ty) if ty.tmr() == Tmr::TWO_TWO_N[0] => {
                     result_stack.push(Value::u1(bits.read_bit()?.into()));
                 }
-                State::ProcessType(ty) if ty.tmr() == Tmr::POWERS_OF_TWO[1] => {
+                State::ProcessType(ty) if ty.tmr() == Tmr::TWO_TWO_N[1] => {
                     result_stack.push(Value::u2(bits.read_u2()?.into()));
                 }
-                State::ProcessType(ty) if ty.tmr() == Tmr::POWERS_OF_TWO[2] => {
+                State::ProcessType(ty) if ty.tmr() == Tmr::TWO_TWO_N[2] => {
                     let u4 = (u8::from(bits.read_u2()?) << 2) + u8::from(bits.read_u2()?);
                     result_stack.push(Value::u4(u4));
                 }
                 State::ProcessType(ty) => {
-                    // The POWERS_OF_TWO array is somewhat misnamed; the ith index contains
-                    // the TMR of TWO^(2^n). So e.g. the 0th index is 2 (a bit), the 1st is
-                    // u2, then u4, and the 3rd is u8.
-                    for (logn, tmr) in Tmr::POWERS_OF_TWO.iter().skip(3).enumerate() {
+                    // The TWO_TWO_N array is indexed by number of bits. By skipping the
+                    // first three entries we index it by number of bytes.
+                    for (logn, tmr) in Tmr::TWO_TWO_N.iter().skip(3).enumerate() {
                         if ty.tmr() == *tmr {
                             let mut blob = Vec::with_capacity(1 << logn);
                             for _ in 0..blob.capacity() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -817,7 +817,8 @@ impl Iterator for CompactBitsIter<'_> {
 }
 
 impl Value {
-    fn from_bits<I: Iterator<Item = u8>>(
+    /// Decode a value of the given type from its compact bit encoding.
+    pub fn from_compact_bits<I: Iterator<Item = u8>>(
         bits: &mut BitIter<I>,
         ty: &Final,
     ) -> Result<Self, EarlyEndOfStreamError> {
@@ -870,14 +871,6 @@ impl Value {
         }
         debug_assert_eq!(result_stack.len(), 1);
         Ok(result_stack.pop().unwrap())
-    }
-
-    /// Decode a value of the given type from its compact bit encoding.
-    pub fn from_compact_bits<I: Iterator<Item = u8>>(
-        bits: &mut BitIter<I>,
-        ty: &Final,
-    ) -> Result<Self, EarlyEndOfStreamError> {
-        Self::from_bits(bits, ty)
     }
 
     /// Decode a value of the given type from its padded bit encoding.


### PR DESCRIPTION
This cleans up the `Value` API by making `ValueRef` public and using it in place of the slow and redundant `Value::to_*` methods.

It also renames `Tmr::POWERS_OF_TWO` which was noticed as a confusing name.

It adds a `types::Final::has_padding` accessor and uses it to dramatically speed up bit decoding for values.

During pruning, it notices when there is nothing to do (when pruning a value to the type that it already has) and shortcuts.

Unlike #266, this one leaves the API in better shape than it was before, and should be reasonably easy to review. It hsa a lot of commits but they are all pretty small.

Fixes #268 