### PR TITLE
Generic BitMachine execution tracker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,3 +119,16 @@ jobs:
         run: |
           cargo test --locked --manifest-path simplicity-sys/Cargo.toml
           cargo test --locked --workspace --all-features
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v4
+      - name: Checkout Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Check that documentation builds without errors
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings -D rustdoc::broken-intra-doc-links"
+        run: cargo doc -j1 --all-features


### PR DESCRIPTION
This PR generalizes `CaseTracker` to `ExecTracker` that now supports tracking jet calls (in addition to case branches). It is also now possible to run BitMachine with a custom tracker created outside of the crate.

This mechanim allows to implement jet tracer which pretty-prints jet arguments/result for each invocation, see https://github.com/m-kus/simfony/pull/2/files#diff-13e8b158f84f88059e0bd8631dfa9113112e30d7b8c21a15413d0ef36d2ea180

As a follow up it is proposed to further extend `ExecTracker` trait to allow visitor pattern on case/assert expressions. That would enable debug logging, similar to https://github.com/uncomputable/simfony-webide/blob/adb60d4e60c0d6b019ea13f64b1a166da3467d8d/src/function.rs#L145

Having these two features (jet calls tracking and debug symbols) combined it's fairly simple to output weighted stack traces (e.g. in pprof) and build a Simfony profiler.