### PR TITLE
Add optional arguments budget and env to run_program test helper

### DIFF
--- a/fuzz/fuzz_targets/c_rust_merkle.rs
+++ b/fuzz/fuzz_targets/c_rust_merkle.rs
@@ -27,7 +27,7 @@ fn do_test(data: &[u8]) {
     };
 
     let (program, witness) = data.split_at(prog_len);
-    let c_result = run_program(program, witness, TestUpTo::CheckOneOne);
+    let c_result = run_program(program, witness, TestUpTo::CheckOneOne, None, None);
 
     let prog_iter = BitIter::from(program);
     let wit_iter = BitIter::from(witness);

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -723,8 +723,14 @@ mod tests {
     fn check_merkle_roots(test: &TestData) {
         let prog = BitIter::from(test.prog.as_slice());
         let witness = BitIter::from(test.witness.as_slice());
-        ffi::tests::run_program(&test.prog, &test.witness, ffi::tests::TestUpTo::CheckOneOne)
-            .unwrap();
+        ffi::tests::run_program(
+            &test.prog,
+            &test.witness,
+            ffi::tests::TestUpTo::CheckOneOne,
+            None,
+            None,
+        )
+        .unwrap();
         let prog = RedeemNode::<Elements>::decode(prog, witness).unwrap();
         assert_eq!(prog.cmr().to_byte_array(), test.cmr);
         assert_eq!(prog.amr().to_byte_array(), test.amr);


### PR DESCRIPTION
`run_program` test helper is quite useful because it allows to run programs in (almost) the same way they would be run in Elements/Liquid node. The execution behaviour should ideally be identical to `BitMachine`,  but there is a possibility of a divergence and using this helper is a good way to catch it.

This PR adds two optional arguments to allow specifying actual budget and environment. This prevents segmentation fault for some programs.