### PR TITLE
ci: copy clippy config from main Cargo.toml to simpcli Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ cast_possible_wrap = "allow" # Same as above re code comment.
 cast_precision_loss = "warn"
 cast_ptr_alignment = "warn"
 cast_sign_loss = "allow" # All casts should include a code comment (except in test code).
+

--- a/simpcli/Cargo.toml
+++ b/simpcli/Cargo.toml
@@ -13,3 +13,21 @@ simplicity-lang = { version = "0.4", path = "..", features = [ "serde", "element
 [[bin]]
 name = "simpcli"
 path = "src/main.rs"
+
+[lints.clippy]
+# Exclude lints we don't think are valuable.
+needless_question_mark = "allow" # https://github.com/rust-bitcoin/rust-bitcoin/pull/2134
+manual_range_contains = "allow" # More readable than clippy's format.
+uninlined_format_args = "allow" # This is a subjective style choice.
+float_cmp = "allow" # Bitcoin floats are typically limited to 8 decimal places and we want them exact.
+match_bool = "allow" # Adds extra indentation and LOC.
+match_same_arms = "allow" # Collapses things that are conceptually unrelated to each other.
+must_use_candidate = "allow" # Useful for audit but many false positives.
+similar_names = "allow" # Too many (subjectively) false positives.
+# Cast-related lints
+cast_lossless = "warn"
+cast_possible_truncation = "allow" # All casts should include a code comment (except test code).
+cast_possible_wrap = "allow" # Same as above re code comment.
+cast_precision_loss = "warn"
+cast_ptr_alignment = "warn"
+cast_sign_loss = "allow" # All casts should include a code comment (except in test code).


### PR DESCRIPTION
We have the "uninlined format args" lint whitelisted in the main crate but apparently not in simpcli.