### PR TITLE
bump version of simplicity-lang to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.5.0 - 2025-07-29
+
+* Add generic `CaseTracker` in bit machine for debugging [#288](https://github.com/BlockstreamResearch/rust-simplicity/pull/288)
+* Add debugging support to `ExecTracker` [#293](https://github.com/BlockstreamResearch/rust-simplicity/pull/293)
+* Separate linker symbols to allow multiple simplicity-sys versions in same tree [#297](https://github.com/BlockstreamResearch/rust-simplicity/pull/297)
+* Add base64 encoding and decoding support to programs [#299](https://github.com/BlockstreamResearch/rust-simplicity/pull/299)
+

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -419,7 +419,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 name = "simpcli"
 version = "0.3.0"
 dependencies = [
- "simplicity-lang 0.4.0",
+ "simplicity-lang 0.5.0",
 ]
 
 [[package]]
@@ -429,7 +429,7 @@ dependencies = [
  "base64 0.22.1",
  "libfuzzer-sys",
  "simplicity-lang 0.3.1",
- "simplicity-lang 0.4.0",
+ "simplicity-lang 0.5.0",
 ]
 
 [[package]]
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "simplicity-lang"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicity-lang"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/BlockstreamResearch/rust-simplicity/"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ path = "fuzz_lib/lib.rs"
 libfuzzer-sys = "0.4"
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
-simplicity-lang = { path = "..", features = ["test-utils"], version = "0.4.0" }
+simplicity-lang = { path = "..", features = ["test-utils"], version = "0.5.0" }
 old_simplicity = { package = "simplicity-lang", version = "0.3.1", default-features = false }
 
 [dev-dependencies]

--- a/simpcli/Cargo.toml
+++ b/simpcli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 # todo add lexopt for command line parsing
-simplicity-lang = { version = "0.4", path = "..", features = [ "base64", "serde", "elements" ] }
+simplicity-lang = { version = "0.5", path = "..", features = [ "base64", "serde", "elements" ] }
 
 [[bin]]
 name = "simpcli"


### PR DESCRIPTION
Also start maintaining a changelog. This library is used by several other projects and it's not changing rapidly anymore.