### PR TITLE
re-export ghost_cell at the root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub extern crate serde;
 pub use bitcoin::base64;
 /// Re-export of byteorder crate
 pub extern crate byteorder;
+/// Re-export of ghost_cell crate
+pub extern crate ghost_cell;
 /// Re-export of hashes crate
 pub extern crate hashes;
 /// Re-export of hex crate


### PR DESCRIPTION
We use the GhostToken type in our public API (in Context::new). We should re-export the crate so users can access this type without needing to add their own dependency (and keep it in sync etc)