### PR TITLE
Add historical benchmark results

### DIFF
--- a/data/jet_bench_2024-07-22_17-33-28.json
+++ b/data/jet_bench_2024-07-22_17-33-28.json
@@ -1,0 +1,3754 @@
+{
+  "Add16": {
+    "best_name": "hi-bits_+_ufmbits_3",
+    "best_value": 30.97136913752267,
+    "median_name": "ufmbits_+_hi-bits_2",
+    "median_value": 42.1900744722124,
+    "worst_name": "lo-bits_+_hi-bits_0",
+    "worst_value": 60.085041109205505
+  },
+  "Add32": {
+    "best_name": "lo-bits_+_inv_self_4",
+    "best_value": 28.446085261821803,
+    "median_name": "ufmbits_+_lo-bits_0",
+    "median_value": 50.36945375570735,
+    "worst_name": "lo-bits_+_hi-bits_3",
+    "worst_value": 65.00459118488351
+  },
+  "Add64": {
+    "best_name": "lo-bits_+_lo-bits_1",
+    "best_value": 29.693193864358037,
+    "median_name": "lo-bits_+_inv_self_4",
+    "median_value": 40.86696573287803,
+    "worst_name": "lo-bits_+_hi-bits_4",
+    "worst_value": 60.770501535336855
+  },
+  "Add8": {
+    "best_name": "ufmbits_+_inv_self_0",
+    "best_value": 31.54143549690385,
+    "median_name": "hi-bits_+_inv_self_0",
+    "median_value": 49.87393682270814,
+    "worst_name": "ufmbits_+_hi-bits_2",
+    "worst_value": 62.62388142499319
+  },
+  "All16": {
+    "best_name": "ufmbits_4",
+    "best_value": 23.63693477413265,
+    "median_name": "hi-bits_3",
+    "median_value": 26.311125603695274,
+    "worst_name": "lo-bits_0",
+    "worst_value": 34.58413668932453
+  },
+  "All32": {
+    "best_name": "lo-bits_3",
+    "best_value": 24.27466303378688,
+    "median_name": "lo-bits_0",
+    "median_value": 25.11123286235879,
+    "worst_name": "hi-bits_0",
+    "worst_value": 36.12506541685401
+  },
+  "All64": {
+    "best_name": "lo-bits_2",
+    "best_value": 24.386700228113305,
+    "median_name": "hi-bits_3",
+    "median_value": 38.002161682329636,
+    "worst_name": "ufmbits_0",
+    "worst_value": 43.94474405869988
+  },
+  "All8": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.48692976346098,
+    "median_name": "lo-bits_4",
+    "median_value": 29.93772653653189,
+    "worst_name": "hi-bits_0",
+    "worst_value": 42.298630039382395
+  },
+  "And1": {
+    "best_name": "hi-bits_+_self_1",
+    "best_value": 20.565151103250525,
+    "median_name": "lo-bits_+_lo-bits_4",
+    "median_value": 34.48120029289612,
+    "worst_name": "lo-bits_+_self_1",
+    "worst_value": 44.41796508997593
+  },
+  "And16": {
+    "best_name": "ufmbits_+_self_2",
+    "best_value": 27.21457331304465,
+    "median_name": "lo-bits_+_lo-bits_0",
+    "median_value": 41.14367396924451,
+    "worst_name": "lo-bits_+_hi-bits_2",
+    "worst_value": 49.190985826792
+  },
+  "And32": {
+    "best_name": "lo-bits_+_ufmbits_0",
+    "best_value": 28.285804974025723,
+    "median_name": "ufmbits_+_lo-bits_1",
+    "median_value": 40.48233252137524,
+    "worst_name": "hi-bits_+_lo-bits_0",
+    "worst_value": 52.330825534594354
+  },
+  "And64": {
+    "best_name": "hi-bits_+_lo-bits_4",
+    "best_value": 28.22380988760334,
+    "median_name": "hi-bits_+_hi-bits_3",
+    "median_value": 33.39188885583571,
+    "worst_name": "ufmbits_+_lo-bits_2",
+    "worst_value": 52.00679267933024
+  },
+  "And8": {
+    "best_name": "lo-bits_+_lo-bits_4",
+    "best_value": 27.085396566803638,
+    "median_name": "lo-bits_+_hi-bits_4",
+    "median_value": 38.66922728068457,
+    "worst_name": "ufmbits_+_ufmbits_4",
+    "worst_value": 50.9336818377678
+  },
+  "AnnexHash": {
+    "best_name": "8",
+    "best_value": 120.27,
+    "median_name": "24",
+    "median_value": 127.385,
+    "worst_name": "55",
+    "worst_value": 133.8975
+  },
+  "AssetAmountHash": {
+    "best_name": "78",
+    "best_value": 136.13,
+    "median_name": "46",
+    "median_value": 142.74,
+    "worst_name": "72",
+    "worst_value": 171.26
+  },
+  "Bip0340Verify": {
+    "best_name": "bip340_valid_1",
+    "best_value": 52386.89906961818,
+    "median_name": "bip340_invalid_2",
+    "median_value": 54119.88579251887,
+    "worst_name": "bip340_invalid_4",
+    "worst_value": 54541.00304991227
+  },
+  "BuildTapbranch": {
+    "best_name": "56",
+    "best_value": 1245.565,
+    "median_name": "12",
+    "median_value": 1311.56,
+    "worst_name": "89",
+    "worst_value": 1424.2525
+  },
+  "BuildTapleafSimplicity": {
+    "best_name": "67",
+    "best_value": 942.2142857142857,
+    "median_name": "1",
+    "median_value": 985.957142857143,
+    "worst_name": "4",
+    "worst_value": 1024.204285714286
+  },
+  "CalculateAsset": {
+    "best_name": "12",
+    "best_value": 366.15142857142854,
+    "median_name": "15",
+    "median_value": 382.2757142857144,
+    "worst_name": "16",
+    "worst_value": 448.8285714285716
+  },
+  "CalculateConfidentialToken": {
+    "best_name": "67",
+    "best_value": 368.65375,
+    "median_name": "43",
+    "median_value": 383.5171428571429,
+    "worst_name": "15",
+    "worst_value": 392.9185714285713
+  },
+  "CalculateExplicitToken": {
+    "best_name": "66",
+    "best_value": 366.1175,
+    "median_name": "27",
+    "median_value": 380.99857142857144,
+    "worst_name": "71",
+    "worst_value": 428.43571428571437
+  },
+  "CalculateIssuanceEntropy": {
+    "best_name": "12",
+    "best_value": 963.6925,
+    "median_name": "20",
+    "median_value": 980.4975,
+    "worst_name": "35",
+    "worst_value": 1163.9275
+  },
+  "Ch1": {
+    "best_name": "hi-bits_2",
+    "best_value": 24.43832476134212,
+    "median_name": "ufmbits_4",
+    "median_value": 36.636239274952516,
+    "worst_name": "lo-bits_1",
+    "worst_value": 43.38647329238317
+  },
+  "Ch16": {
+    "best_name": "lo-bits_1",
+    "best_value": 28.641218368786525,
+    "median_name": "ufmbits_3",
+    "median_value": 33.80446273222671,
+    "worst_name": "hi-bits_1",
+    "worst_value": 52.27708434095646
+  },
+  "Ch32": {
+    "best_name": "lo-bits_2",
+    "best_value": 36.14828355254054,
+    "median_name": "ufmbits_1",
+    "median_value": 38.461930911672084,
+    "worst_name": "hi-bits_3",
+    "worst_value": 50.75927210580458
+  },
+  "Ch64": {
+    "best_name": "lo-bits_2",
+    "best_value": 34.91378641392709,
+    "median_name": "hi-bits_0",
+    "median_value": 38.47381685613344,
+    "worst_name": "ufmbits_3",
+    "worst_value": 50.64224884783096
+  },
+  "Ch8": {
+    "best_name": "ufmbits_4",
+    "best_value": 29.04999502908749,
+    "median_name": "hi-bits_4",
+    "median_value": 37.59310318594893,
+    "worst_name": "lo-bits_2",
+    "worst_value": 43.247948521208684
+  },
+  "CheckLockDistance": {
+    "best_name": "14",
+    "best_value": 27.454026492724065,
+    "median_name": "49",
+    "median_value": 30.35740688266128,
+    "worst_name": "16",
+    "worst_value": 58.753725206887374
+  },
+  "CheckLockDuration": {
+    "best_name": "48",
+    "best_value": 28.285532029271323,
+    "median_name": "42",
+    "median_value": 31.0020784767307,
+    "worst_name": "68",
+    "worst_value": 57.030697303127475
+  },
+  "CheckLockHeight": {
+    "best_name": "89",
+    "best_value": 30.362371283800407,
+    "median_name": "64",
+    "median_value": 32.536221197309494,
+    "worst_name": "86",
+    "worst_value": 42.78170096368622
+  },
+  "CheckLockTime": {
+    "best_name": "46",
+    "best_value": 30.508833739029537,
+    "median_name": "36",
+    "median_value": 32.79240978322568,
+    "worst_name": "69",
+    "worst_value": 51.84407299762977
+  },
+  "CheckSigVerify": {
+    "best_name": "checksig_valid_0",
+    "best_value": 46683.25901811255,
+    "median_name": "checksig_invalid_2",
+    "median_value": 55006.16650048723,
+    "worst_name": "checksig_invalid_0",
+    "worst_value": 55555.079016059564
+  },
+  "Complement1": {
+    "best_name": "hi-bits_3",
+    "best_value": 24.576986024998277,
+    "median_name": "ufmbits_4",
+    "median_value": 27.29513662202153,
+    "worst_name": "hi-bits_4",
+    "worst_value": 44.30963250954837
+  },
+  "Complement16": {
+    "best_name": "hi-bits_4",
+    "best_value": 29.364244006913246,
+    "median_name": "ufmbits_3",
+    "median_value": 38.1411036091517,
+    "worst_name": "lo-bits_4",
+    "worst_value": 41.853819540512724
+  },
+  "Complement32": {
+    "best_name": "ufmbits_0",
+    "best_value": 26.92304864161796,
+    "median_name": "lo-bits_2",
+    "median_value": 29.898399576692068,
+    "worst_name": "hi-bits_0",
+    "worst_value": 51.936600421665986
+  },
+  "Complement64": {
+    "best_name": "hi-bits_3",
+    "best_value": 36.08346516161602,
+    "median_name": "lo-bits_0",
+    "median_value": 44.39970700849516,
+    "worst_name": "lo-bits_4",
+    "worst_value": 49.44074859372622
+  },
+  "Complement8": {
+    "best_name": "lo-bits_3",
+    "best_value": 28.646473945090733,
+    "median_name": "lo-bits_1",
+    "median_value": 39.4492324030809,
+    "worst_name": "ufmbits_4",
+    "worst_value": 44.49004402013328
+  },
+  "CurrentAmount": {
+    "best_name": "42",
+    "best_value": 65.75671177303539,
+    "median_name": "94",
+    "median_value": 87.94924226597992,
+    "worst_name": "19",
+    "worst_value": 125.233683871098
+  },
+  "CurrentAnnexHash": {
+    "best_name": "7",
+    "best_value": 23.532758625854022,
+    "median_name": "66",
+    "median_value": 33.437469859895046,
+    "worst_name": "70",
+    "worst_value": 43.96303036926559
+  },
+  "CurrentAsset": {
+    "best_name": "79",
+    "best_value": 53.96589774246913,
+    "median_name": "30",
+    "median_value": 70.6763111877821,
+    "worst_name": "99",
+    "worst_value": 95.55358469768584
+  },
+  "CurrentIndex": {
+    "best_name": "98",
+    "best_value": 25.078620326061824,
+    "median_name": "99",
+    "median_value": 33.24210629917963,
+    "worst_name": "18",
+    "worst_value": 49.14822556250178
+  },
+  "CurrentIssuanceAssetAmount": {
+    "best_name": "77",
+    "best_value": 46.126813798234586,
+    "median_name": "82",
+    "median_value": 64.92414964316434,
+    "worst_name": "2",
+    "worst_value": 91.68812641475432
+  },
+  "CurrentIssuanceAssetProof": {
+    "best_name": "66",
+    "best_value": 39.67966302115419,
+    "median_name": "77",
+    "median_value": 54.55978513565534,
+    "worst_name": "33",
+    "worst_value": 78.32085006755332
+  },
+  "CurrentIssuanceTokenAmount": {
+    "best_name": "6",
+    "best_value": 56.040218875445674,
+    "median_name": "20",
+    "median_value": 73.61542053452766,
+    "worst_name": "49",
+    "worst_value": 104.56443464343835
+  },
+  "CurrentIssuanceTokenProof": {
+    "best_name": "72",
+    "best_value": 40.743084516210544,
+    "median_name": "15",
+    "median_value": 56.80033528906318,
+    "worst_name": "50",
+    "worst_value": 80.11480670010411
+  },
+  "CurrentNewIssuanceContract": {
+    "best_name": "12",
+    "best_value": 41.99248862413817,
+    "median_name": "82",
+    "median_value": 54.060696782678576,
+    "worst_name": "11",
+    "worst_value": 80.93662026502236
+  },
+  "CurrentPegin": {
+    "best_name": "82",
+    "best_value": 42.779549270511296,
+    "median_name": "42",
+    "median_value": 55.50194820203058,
+    "worst_name": "1",
+    "worst_value": 81.6814471387894
+  },
+  "CurrentPrevOutpoint": {
+    "best_name": "3",
+    "best_value": 45.33572354554605,
+    "median_name": "80",
+    "median_value": 59.37765014364849,
+    "worst_name": "91",
+    "worst_value": 87.01737208854547
+  },
+  "CurrentReissuanceBlinding": {
+    "best_name": "65",
+    "best_value": 23.489644265647154,
+    "median_name": "24",
+    "median_value": 32.430148008472536,
+    "worst_name": "53",
+    "worst_value": 52.34362964598284
+  },
+  "CurrentReissuanceEntropy": {
+    "best_name": "94",
+    "best_value": 24.20921022248091,
+    "median_name": "40",
+    "median_value": 33.838244264561624,
+    "worst_name": "36",
+    "worst_value": 47.41824644363429
+  },
+  "CurrentScriptHash": {
+    "best_name": "70",
+    "best_value": 41.80529852621314,
+    "median_name": "6",
+    "median_value": 53.97749847307482,
+    "worst_name": "54",
+    "worst_value": 74.54897385905238
+  },
+  "CurrentScriptSigHash": {
+    "best_name": "77",
+    "best_value": 41.334749251378106,
+    "median_name": "49",
+    "median_value": 55.96722124514496,
+    "worst_name": "29",
+    "worst_value": 77.29143987908452
+  },
+  "CurrentSequence": {
+    "best_name": "34",
+    "best_value": 25.336997106799235,
+    "median_name": "69",
+    "median_value": 34.68168381171692,
+    "worst_name": "84",
+    "worst_value": 49.55213254331629
+  },
+  "Decompress": {
+    "best_name": "pt_ge_oncurve_4",
+    "best_value": 5655.282750940787,
+    "median_name": "pt_ge_offc_fe_lo-bits_4",
+    "median_value": 5732.349113000864,
+    "worst_name": "pt_ge_oncurve_1",
+    "worst_value": 6034.0242131124305
+  },
+  "Decrement16": {
+    "best_name": "lo-bits_1",
+    "best_value": 28.62875308736761,
+    "median_name": "ufmbits_3",
+    "median_value": 38.9136180527453,
+    "worst_name": "hi-bits_0",
+    "worst_value": 47.619384690269044
+  },
+  "Decrement32": {
+    "best_name": "hi-bits_1",
+    "best_value": 24.68853493450904,
+    "median_name": "hi-bits_3",
+    "median_value": 36.38370121942815,
+    "worst_name": "ufmbits_1",
+    "worst_value": 50.70470833162736
+  },
+  "Decrement64": {
+    "best_name": "hi-bits_1",
+    "best_value": 26.844311440391945,
+    "median_name": "ufmbits_1",
+    "median_value": 40.5370056862286,
+    "worst_name": "lo-bits_1",
+    "worst_value": 49.91961044181172
+  },
+  "Decrement8": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.41614467365478,
+    "median_name": "lo-bits_1",
+    "median_value": 40.014438357796664,
+    "worst_name": "hi-bits_2",
+    "worst_value": 44.41452963683716
+  },
+  "DivMod128_64": {
+    "best_name": "hi-bits_+_lo-bits_4",
+    "best_value": 38.50306185280553,
+    "median_name": "ufmbits_+_lo-bits_3",
+    "median_value": 56.519066411257846,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 115.77280158438838
+  },
+  "DivMod16": {
+    "best_name": "ufmbits_+_inv_self_0",
+    "best_value": 33.88516633181033,
+    "median_name": "hi-bits_+_inv_self_1",
+    "median_value": 49.51332354752133,
+    "worst_name": "hi-bits_+_ufmbits_2",
+    "worst_value": 65.69925000385433
+  },
+  "DivMod32": {
+    "best_name": "lo-bits_+_inv_self_3",
+    "best_value": 29.171173255743366,
+    "median_name": "hi-bits_+_ufmbits_0",
+    "median_value": 50.143093238353615,
+    "worst_name": "hi-bits_+_lo-bits_4",
+    "worst_value": 64.04450140966351
+  },
+  "DivMod64": {
+    "best_name": "lo-bits_+_inv_self_0",
+    "best_value": 31.524384084908366,
+    "median_name": "lo-bits_+_lo-bits_1",
+    "median_value": 39.28734878143577,
+    "worst_name": "hi-bits_+_self_0",
+    "worst_value": 48.188851905873335
+  },
+  "DivMod8": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 33.40894897977061,
+    "median_name": "ufmbits_+_self_2",
+    "median_value": 47.06514213193745,
+    "worst_name": "lo-bits_+_lo-bits_0",
+    "worst_value": 71.3705571750924
+  },
+  "Divide16": {
+    "best_name": "ufmbits_+_ufmbits_2",
+    "best_value": 27.629295993547903,
+    "median_name": "lo-bits_+_hi-bits_4",
+    "median_value": 41.90546789628765,
+    "worst_name": "lo-bits_+_inv_self_1",
+    "worst_value": 54.81267262645548
+  },
+  "Divide32": {
+    "best_name": "hi-bits_+_hi-bits_3",
+    "best_value": 30.646418671531286,
+    "median_name": "lo-bits_+_inv_self_4",
+    "median_value": 40.86257693700072,
+    "worst_name": "hi-bits_+_ufmbits_4",
+    "worst_value": 55.81078135389193
+  },
+  "Divide64": {
+    "best_name": "ufmbits_+_inv_self_3",
+    "best_value": 30.363228193867073,
+    "median_name": "lo-bits_+_hi-bits_1",
+    "median_value": 42.25994521186659,
+    "worst_name": "hi-bits_+_self_2",
+    "worst_value": 56.43166191465282
+  },
+  "Divide8": {
+    "best_name": "ufmbits_+_ufmbits_2",
+    "best_value": 31.57205349561464,
+    "median_name": "ufmbits_+_inv_self_2",
+    "median_value": 46.24881423100529,
+    "worst_name": "ufmbits_+_lo-bits_0",
+    "worst_value": 60.07629081022806
+  },
+  "Divides16": {
+    "best_name": "hi-bits_+_ufmbits_2",
+    "best_value": 26.276626595137433,
+    "median_name": "lo-bits_+_self_4",
+    "median_value": 34.116458885286214,
+    "worst_name": "lo-bits_+_inv_self_1",
+    "worst_value": 51.9870240819556
+  },
+  "Divides32": {
+    "best_name": "lo-bits_+_self_0",
+    "best_value": 28.9939354537174,
+    "median_name": "hi-bits_+_lo-bits_4",
+    "median_value": 43.19978589391214,
+    "worst_name": "hi-bits_+_inv_self_0",
+    "worst_value": 48.77753656294132
+  },
+  "Divides64": {
+    "best_name": "ufmbits_+_inv_self_2",
+    "best_value": 29.807297251194292,
+    "median_name": "lo-bits_+_ufmbits_3",
+    "median_value": 39.29849619123238,
+    "worst_name": "lo-bits_+_lo-bits_4",
+    "worst_value": 50.6929784746092
+  },
+  "Divides8": {
+    "best_name": "hi-bits_+_self_0",
+    "best_value": 27.383689394931913,
+    "median_name": "hi-bits_+_ufmbits_0",
+    "median_value": 42.076443069452125,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 54.766521462004285
+  },
+  "Eq1": {
+    "best_name": "hi-bits_+_inv_self_2",
+    "best_value": 21.644800934417514,
+    "median_name": "hi-bits_+_lo-bits_4",
+    "median_value": 32.241099472703915,
+    "worst_name": "hi-bits_+_self_2",
+    "worst_value": 41.19704900879444
+  },
+  "Eq16": {
+    "best_name": "hi-bits_+_lo-bits_3",
+    "best_value": 25.66688736191733,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 37.186692096271095,
+    "worst_name": "hi-bits_+_ufmbits_0",
+    "worst_value": 46.96434429747661
+  },
+  "Eq256": {
+    "best_name": "lo-bits_+_hi-bits_2",
+    "best_value": 70.08850100563849,
+    "median_name": "hi-bits_+_self_4",
+    "median_value": 95.51950813430084,
+    "worst_name": "hi-bits_+_ufmbits_1",
+    "worst_value": 125.24267688284475
+  },
+  "Eq32": {
+    "best_name": "lo-bits_+_hi-bits_3",
+    "best_value": 26.710450017568995,
+    "median_name": "hi-bits_+_lo-bits_2",
+    "median_value": 39.47869561158995,
+    "worst_name": "hi-bits_+_inv_self_1",
+    "worst_value": 49.127933441004416
+  },
+  "Eq64": {
+    "best_name": "lo-bits_+_ufmbits_0",
+    "best_value": 28.818074078797363,
+    "median_name": "lo-bits_+_self_3",
+    "median_value": 39.92543340827314,
+    "worst_name": "ufmbits_+_lo-bits_0",
+    "worst_value": 56.10776637742226
+  },
+  "Eq8": {
+    "best_name": "lo-bits_+_self_3",
+    "best_value": 24.161955778677473,
+    "median_name": "hi-bits_+_inv_self_1",
+    "median_value": 36.04066346484346,
+    "worst_name": "lo-bits_+_ufmbits_1",
+    "worst_value": 53.09387335277708
+  },
+  "FeAdd": {
+    "best_name": "fe_lo-bits_+_fe_lo-bits_2",
+    "best_value": 387.9781752084236,
+    "median_name": "fe_ufmbits_+_fe_lo-bits_0",
+    "median_value": 402.1712703182464,
+    "worst_name": "fe_ufmbits_+_fe_outofrange_2",
+    "worst_value": 419.4421553609743
+  },
+  "FeInvert": {
+    "best_name": "fe_outofrange_3",
+    "best_value": 1247.6163168819417,
+    "median_name": "fe_hi-bits_0",
+    "median_value": 1518.283611329516,
+    "worst_name": "fe_ufmbits_2",
+    "worst_value": 1764.2095713900258
+  },
+  "FeIsOdd": {
+    "best_name": "fe_lo-bits_3",
+    "best_value": 141.84050095715418,
+    "median_name": "fe_ufmbits_0",
+    "median_value": 150.3270453589355,
+    "worst_name": "fe_outofrange_0",
+    "worst_value": 161.4908040889559
+  },
+  "FeIsZero": {
+    "best_name": "fe_ufmbits_0",
+    "best_value": 141.24436269662837,
+    "median_name": "fe_outofrange_3",
+    "median_value": 146.6980163703596,
+    "worst_name": "fe_hi-bits_4",
+    "worst_value": 148.9500015909772
+  },
+  "FeMultiply": {
+    "best_name": "fe_lo-bits_+_fe_lo-bits_1",
+    "best_value": 405.11840342590034,
+    "median_name": "fe_hi-bits_+_fe_outofrange_1",
+    "median_value": 422.0663041939343,
+    "worst_name": "fe_lo-bits_+_fe_outofrange_2",
+    "worst_value": 449.33346943264536
+  },
+  "FeMultiplyBeta": {
+    "best_name": "fe_ufmbits_3",
+    "best_value": 284.96276700058013,
+    "median_name": "fe_lo-bits_4",
+    "median_value": 304.3456636458927,
+    "worst_name": "fe_outofrange_4",
+    "worst_value": 321.936623495282
+  },
+  "FeNegate": {
+    "best_name": "fe_ufmbits_1",
+    "best_value": 266.3723343841882,
+    "median_name": "fe_lo-bits_0",
+    "median_value": 285.56627111054377,
+    "worst_name": "fe_outofrange_2",
+    "worst_value": 295.2583854628667
+  },
+  "FeNormalize": {
+    "best_name": "fe_ufmbits_3",
+    "best_value": 273.98806748923636,
+    "median_name": "fe_outofrange_1",
+    "median_value": 285.6916773990088,
+    "worst_name": "fe_hi-bits_1",
+    "worst_value": 289.8402224157142
+  },
+  "FeSquare": {
+    "best_name": "fe_ufmbits_4",
+    "best_value": 289.4714382267642,
+    "median_name": "fe_hi-bits_4",
+    "median_value": 302.016491140935,
+    "worst_name": "fe_outofrange_4",
+    "worst_value": 309.0320861847194
+  },
+  "FeSquareRoot": {
+    "best_name": "fe_ufmbits_3",
+    "best_value": 5623.858843231592,
+    "median_name": "fe_lo-bits_3",
+    "median_value": 5680.394754757226,
+    "worst_name": "fe_outofrange_0",
+    "worst_value": 5708.658550943187
+  },
+  "FullAdd16": {
+    "best_name": "1lo-bits_+_lo-bits_4",
+    "best_value": 30.42174816474015,
+    "median_name": "0ufmbits_+_inv_self_1",
+    "median_value": 50.38894215795544,
+    "worst_name": "0ufmbits_+_self_3",
+    "worst_value": 67.58987477677238
+  },
+  "FullAdd32": {
+    "best_name": "1ufmbits_+_inv_self_0",
+    "best_value": 29.220882510139642,
+    "median_name": "1ufmbits_+_lo-bits_2",
+    "median_value": 46.08228046212284,
+    "worst_name": "1hi-bits_+_lo-bits_4",
+    "worst_value": 66.11773354771384
+  },
+  "FullAdd64": {
+    "best_name": "1hi-bits_+_self_0",
+    "best_value": 29.980127823505605,
+    "median_name": "1ufmbits_+_self_1",
+    "median_value": 41.71742536124031,
+    "worst_name": "0ufmbits_+_ufmbits_0",
+    "worst_value": 67.48909817913685
+  },
+  "FullAdd8": {
+    "best_name": "0lo-bits_+_inv_self_3",
+    "best_value": 29.483889452183117,
+    "median_name": "1ufmbits_+_self_0",
+    "median_value": 45.99433098873886,
+    "worst_name": "0ufmbits_+_self_4",
+    "worst_value": 70.65903996899138
+  },
+  "FullDecrement16": {
+    "best_name": "0ufmbits_1",
+    "best_value": 25.115916595012514,
+    "median_name": "0hi-bits_0",
+    "median_value": 37.0283884327326,
+    "worst_name": "0lo-bits_3",
+    "worst_value": 51.39362224910755
+  },
+  "FullDecrement32": {
+    "best_name": "1ufmbits_0",
+    "best_value": 33.0266167182263,
+    "median_name": "0ufmbits_4",
+    "median_value": 55.60985603317462,
+    "worst_name": "1hi-bits_3",
+    "worst_value": 59.97907579303369
+  },
+  "FullDecrement64": {
+    "best_name": "0ufmbits_1",
+    "best_value": 27.574602679047544,
+    "median_name": "1hi-bits_0",
+    "median_value": 33.8455766392606,
+    "worst_name": "1ufmbits_3",
+    "worst_value": 45.49679194449331
+  },
+  "FullDecrement8": {
+    "best_name": "1lo-bits_1",
+    "best_value": 25.85989316064757,
+    "median_name": "1ufmbits_2",
+    "median_value": 30.634117716076272,
+    "worst_name": "0lo-bits_1",
+    "worst_value": 50.64117149094439
+  },
+  "FullIncrement16": {
+    "best_name": "0ufmbits_4",
+    "best_value": 26.512057462475944,
+    "median_name": "0lo-bits_4",
+    "median_value": 27.935854190714586,
+    "worst_name": "0ufmbits_3",
+    "worst_value": 49.66797298374831
+  },
+  "FullIncrement32": {
+    "best_name": "0ufmbits_4",
+    "best_value": 34.5719534036927,
+    "median_name": "0hi-bits_1",
+    "median_value": 44.70590368033474,
+    "worst_name": "1hi-bits_4",
+    "worst_value": 58.30643709946031
+  },
+  "FullIncrement64": {
+    "best_name": "0hi-bits_4",
+    "best_value": 27.234293403916293,
+    "median_name": "1ufmbits_1",
+    "median_value": 43.655177927096695,
+    "worst_name": "0lo-bits_4",
+    "worst_value": 55.24105841134342
+  },
+  "FullIncrement8": {
+    "best_name": "1hi-bits_1",
+    "best_value": 26.737763048001458,
+    "median_name": "1ufmbits_1",
+    "median_value": 30.294627315103693,
+    "worst_name": "1lo-bits_3",
+    "worst_value": 40.36810258706402
+  },
+  "FullLeftShift16_1": {
+    "best_name": "hi-bits_2",
+    "best_value": 26.155121149368984,
+    "median_name": "ufmbits_3",
+    "median_value": 38.488399297016265,
+    "worst_name": "hi-bits_1",
+    "worst_value": 46.18858118129996
+  },
+  "FullLeftShift16_2": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.85612938988652,
+    "median_name": "lo-bits_0",
+    "median_value": 43.814724693956904,
+    "worst_name": "hi-bits_4",
+    "worst_value": 46.620891275146725
+  },
+  "FullLeftShift16_4": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.42173168307829,
+    "median_name": "ufmbits_3",
+    "median_value": 35.660864960277586,
+    "worst_name": "hi-bits_1",
+    "worst_value": 49.483816401261585
+  },
+  "FullLeftShift16_8": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.09668324356188,
+    "median_name": "hi-bits_2",
+    "median_value": 29.65205052357481,
+    "worst_name": "ufmbits_2",
+    "worst_value": 36.162357067674385
+  },
+  "FullLeftShift32_1": {
+    "best_name": "ufmbits_3",
+    "best_value": 26.569275982495196,
+    "median_name": "hi-bits_2",
+    "median_value": 30.283991059613456,
+    "worst_name": "lo-bits_4",
+    "worst_value": 46.939178133248234
+  },
+  "FullLeftShift32_16": {
+    "best_name": "hi-bits_2",
+    "best_value": 24.8426619689519,
+    "median_name": "lo-bits_4",
+    "median_value": 38.30344162789776,
+    "worst_name": "lo-bits_0",
+    "worst_value": 45.4571656643761
+  },
+  "FullLeftShift32_2": {
+    "best_name": "lo-bits_3",
+    "best_value": 32.79151110600218,
+    "median_name": "ufmbits_0",
+    "median_value": 34.52308946901857,
+    "worst_name": "hi-bits_0",
+    "worst_value": 37.55784335894769
+  },
+  "FullLeftShift32_4": {
+    "best_name": "lo-bits_2",
+    "best_value": 36.03996202709709,
+    "median_name": "lo-bits_4",
+    "median_value": 38.78581309198243,
+    "worst_name": "hi-bits_2",
+    "worst_value": 46.8616632714964
+  },
+  "FullLeftShift32_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.632816917339596,
+    "median_name": "lo-bits_3",
+    "median_value": 41.75342652246399,
+    "worst_name": "hi-bits_1",
+    "worst_value": 50.89997070924756
+  },
+  "FullLeftShift64_1": {
+    "best_name": "lo-bits_3",
+    "best_value": 40.370585158048634,
+    "median_name": "ufmbits_0",
+    "median_value": 49.874286051418395,
+    "worst_name": "hi-bits_2",
+    "worst_value": 55.05773228244788
+  },
+  "FullLeftShift64_16": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.80859131673234,
+    "median_name": "ufmbits_4",
+    "median_value": 45.238798159335005,
+    "worst_name": "hi-bits_3",
+    "worst_value": 50.35375142144335
+  },
+  "FullLeftShift64_2": {
+    "best_name": "lo-bits_2",
+    "best_value": 30.511606228441888,
+    "median_name": "ufmbits_0",
+    "median_value": 37.2845950205656,
+    "worst_name": "hi-bits_2",
+    "worst_value": 52.524422908169726
+  },
+  "FullLeftShift64_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 34.105449060180206,
+    "median_name": "lo-bits_2",
+    "median_value": 44.58339707092764,
+    "worst_name": "lo-bits_4",
+    "worst_value": 48.19968554848869
+  },
+  "FullLeftShift64_4": {
+    "best_name": "ufmbits_4",
+    "best_value": 29.40545890938449,
+    "median_name": "hi-bits_2",
+    "median_value": 42.128577169440376,
+    "worst_name": "lo-bits_4",
+    "worst_value": 52.64511921564639
+  },
+  "FullLeftShift64_8": {
+    "best_name": "lo-bits_1",
+    "best_value": 29.50026918903303,
+    "median_name": "hi-bits_3",
+    "median_value": 31.879209702747662,
+    "worst_name": "ufmbits_0",
+    "worst_value": 47.92651978022118
+  },
+  "FullLeftShift8_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.786032744798277,
+    "median_name": "ufmbits_1",
+    "median_value": 40.44716569589232,
+    "worst_name": "hi-bits_3",
+    "worst_value": 53.371611885499135
+  },
+  "FullLeftShift8_2": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.782619560175373,
+    "median_name": "hi-bits_4",
+    "median_value": 45.90129105453945,
+    "worst_name": "lo-bits_4",
+    "worst_value": 53.40012672044502
+  },
+  "FullLeftShift8_4": {
+    "best_name": "ufmbits_1",
+    "best_value": 30.626846468167106,
+    "median_name": "lo-bits_1",
+    "median_value": 42.88060750331645,
+    "worst_name": "hi-bits_3",
+    "worst_value": 47.39442146733317
+  },
+  "FullMultiply16": {
+    "best_name": "lo-bits_+_ufmbits_2",
+    "best_value": 34.139800962363765,
+    "median_name": "lo-bits_+_lo-bits_1",
+    "median_value": 50.99137087876983,
+    "worst_name": "hi-bits_+_hi-bits_3",
+    "worst_value": 62.764043288900055
+  },
+  "FullMultiply32": {
+    "best_name": "ufmbits_+_lo-bits_3",
+    "best_value": 33.735567676763296,
+    "median_name": "ufmbits_+_hi-bits_0",
+    "median_value": 45.95747885067776,
+    "worst_name": "lo-bits_+_inv_self_0",
+    "worst_value": 53.41609046991522
+  },
+  "FullMultiply64": {
+    "best_name": "lo-bits_+_self_0",
+    "best_value": 36.51109829970296,
+    "median_name": "hi-bits_+_hi-bits_2",
+    "median_value": 59.4275760837471,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 70.99465378729637
+  },
+  "FullMultiply8": {
+    "best_name": "hi-bits_+_ufmbits_2",
+    "best_value": 32.184992329233985,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 46.80701775266642,
+    "worst_name": "hi-bits_+_inv_self_1",
+    "worst_value": 60.79100324703799
+  },
+  "FullRightShift16_1": {
+    "best_name": "hi-bits_0",
+    "best_value": 28.420156441192358,
+    "median_name": "ufmbits_0",
+    "median_value": 37.88814085133089,
+    "worst_name": "lo-bits_4",
+    "worst_value": 44.463801274297026
+  },
+  "FullRightShift16_2": {
+    "best_name": "lo-bits_1",
+    "best_value": 35.24131009435117,
+    "median_name": "ufmbits_2",
+    "median_value": 40.208774314021696,
+    "worst_name": "hi-bits_1",
+    "worst_value": 44.24484734954473
+  },
+  "FullRightShift16_4": {
+    "best_name": "hi-bits_4",
+    "best_value": 31.660949888369924,
+    "median_name": "lo-bits_0",
+    "median_value": 43.26335233672734,
+    "worst_name": "ufmbits_3",
+    "worst_value": 49.377415322695924
+  },
+  "FullRightShift16_8": {
+    "best_name": "hi-bits_1",
+    "best_value": 25.107666660751455,
+    "median_name": "ufmbits_4",
+    "median_value": 29.377409805426332,
+    "worst_name": "hi-bits_0",
+    "worst_value": 31.761769518909432
+  },
+  "FullRightShift32_1": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.72065648094641,
+    "median_name": "hi-bits_3",
+    "median_value": 28.803469790653953,
+    "worst_name": "lo-bits_4",
+    "worst_value": 41.12634362378231
+  },
+  "FullRightShift32_16": {
+    "best_name": "ufmbits_1",
+    "best_value": 26.182047746982185,
+    "median_name": "hi-bits_2",
+    "median_value": 30.8649348525744,
+    "worst_name": "lo-bits_0",
+    "worst_value": 35.61914526793314
+  },
+  "FullRightShift32_2": {
+    "best_name": "lo-bits_0",
+    "best_value": 25.27649635775414,
+    "median_name": "lo-bits_4",
+    "median_value": 25.978673725457078,
+    "worst_name": "ufmbits_3",
+    "worst_value": 35.367670218288545
+  },
+  "FullRightShift32_4": {
+    "best_name": "ufmbits_4",
+    "best_value": 24.598274452478105,
+    "median_name": "lo-bits_3",
+    "median_value": 27.014020442668325,
+    "worst_name": "hi-bits_3",
+    "worst_value": 39.91820320167241
+  },
+  "FullRightShift32_8": {
+    "best_name": "hi-bits_1",
+    "best_value": 27.53409626423874,
+    "median_name": "lo-bits_3",
+    "median_value": 44.83759534720925,
+    "worst_name": "lo-bits_1",
+    "worst_value": 46.755300941717685
+  },
+  "FullRightShift64_1": {
+    "best_name": "ufmbits_1",
+    "best_value": 31.644756205894954,
+    "median_name": "hi-bits_4",
+    "median_value": 43.257021390880716,
+    "worst_name": "lo-bits_4",
+    "worst_value": 55.084156371380026
+  },
+  "FullRightShift64_16": {
+    "best_name": "lo-bits_4",
+    "best_value": 28.966977018819243,
+    "median_name": "hi-bits_1",
+    "median_value": 41.898651157094015,
+    "worst_name": "ufmbits_4",
+    "worst_value": 48.15200506212657
+  },
+  "FullRightShift64_2": {
+    "best_name": "hi-bits_1",
+    "best_value": 35.08049394150023,
+    "median_name": "lo-bits_0",
+    "median_value": 45.45718520729915,
+    "worst_name": "ufmbits_3",
+    "worst_value": 48.06952686812977
+  },
+  "FullRightShift64_32": {
+    "best_name": "hi-bits_4",
+    "best_value": 30.12317089629473,
+    "median_name": "lo-bits_2",
+    "median_value": 31.55326884394979,
+    "worst_name": "ufmbits_2",
+    "worst_value": 41.03987641674198
+  },
+  "FullRightShift64_4": {
+    "best_name": "ufmbits_3",
+    "best_value": 45.469547079734205,
+    "median_name": "ufmbits_2",
+    "median_value": 48.79101585542626,
+    "worst_name": "lo-bits_3",
+    "worst_value": 52.21526347861463
+  },
+  "FullRightShift64_8": {
+    "best_name": "lo-bits_0",
+    "best_value": 45.93393772128116,
+    "median_name": "ufmbits_4",
+    "median_value": 52.32604241832638,
+    "worst_name": "lo-bits_2",
+    "worst_value": 55.476007550145084
+  },
+  "FullRightShift8_1": {
+    "best_name": "hi-bits_0",
+    "best_value": 37.78887836821279,
+    "median_name": "ufmbits_2",
+    "median_value": 46.00895364359133,
+    "worst_name": "ufmbits_4",
+    "worst_value": 48.89242850292436
+  },
+  "FullRightShift8_2": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.597947909889616,
+    "median_name": "hi-bits_2",
+    "median_value": 40.61159787189616,
+    "worst_name": "ufmbits_4",
+    "worst_value": 47.923842296151605
+  },
+  "FullRightShift8_4": {
+    "best_name": "ufmbits_0",
+    "best_value": 34.15402065996579,
+    "median_name": "lo-bits_3",
+    "median_value": 36.776945832893205,
+    "worst_name": "hi-bits_1",
+    "worst_value": 49.464558624033415
+  },
+  "FullSubtract16": {
+    "best_name": "1hi-bits_+_self_4",
+    "best_value": 28.777542931912013,
+    "median_name": "0ufmbits_+_hi-bits_0",
+    "median_value": 49.7613451355809,
+    "worst_name": "0hi-bits_+_hi-bits_4",
+    "worst_value": 67.38341429479223
+  },
+  "FullSubtract32": {
+    "best_name": "1hi-bits_+_self_2",
+    "best_value": 28.32445597882436,
+    "median_name": "0lo-bits_+_inv_self_0",
+    "median_value": 46.98784893425004,
+    "worst_name": "0lo-bits_+_lo-bits_1",
+    "worst_value": 64.95233724051934
+  },
+  "FullSubtract64": {
+    "best_name": "1ufmbits_+_self_2",
+    "best_value": 31.2503748418335,
+    "median_name": "0ufmbits_+_inv_self_2",
+    "median_value": 39.711527132793236,
+    "worst_name": "1lo-bits_+_lo-bits_4",
+    "worst_value": 54.67370881511828
+  },
+  "FullSubtract8": {
+    "best_name": "0hi-bits_+_lo-bits_0",
+    "best_value": 34.912646649679374,
+    "median_name": "0hi-bits_+_ufmbits_3",
+    "median_value": 54.53071020244403,
+    "worst_name": "0ufmbits_+_inv_self_1",
+    "worst_value": 70.40320985209922
+  },
+  "GeIsOnCurve": {
+    "best_name": "ge_oncurve_0",
+    "best_value": 337.937537158155,
+    "median_name": "ge_offc_fe_hi-bits_2",
+    "median_value": 343.1925007279417,
+    "worst_name": "ge_offc_fe_outofrange_2",
+    "worst_value": 357.15050069150345
+  },
+  "GeNegate": {
+    "best_name": "ge_oncurve_4",
+    "best_value": 491.9634455313467,
+    "median_name": "ge_offc_fe_hi-bits_1",
+    "median_value": 503.21024371760336,
+    "worst_name": "ge_offc_fe_lo-bits_3",
+    "worst_value": 525.226102912438
+  },
+  "GejAdd": {
+    "best_name": "gej_zero_fe_lo-bits_+_gej_offc_fe_ufmbits_0",
+    "best_value": 1092.6032329851214,
+    "median_name": "gej_zero_fe_outofrange_+_gej_offc_fe_lo-bits_4",
+    "median_value": 1161.8200495919098,
+    "worst_name": "gej_offc_fe_outofrange_+_gej_offc_fe_outofrange_0",
+    "worst_value": 1609.7141943875479
+  },
+  "GejDouble": {
+    "best_name": "gej_zero_fe_ufmbits_4",
+    "best_value": 742.0684139071567,
+    "median_name": "gej_offc_fe_ufmbits_4",
+    "median_value": 913.5965934034513,
+    "worst_name": "gej_offc_fe_outofrange_0",
+    "worst_value": 980.0399024548117
+  },
+  "GejEquiv": {
+    "best_name": "gej_zero_fe_ufmbits_+_gej_zero_fe_lo-bits_0",
+    "best_value": 701.82827729214,
+    "median_name": "gej_zero_fe_outofrange_+_gej_offc_fe_lo-bits_0",
+    "median_value": 759.2389483980181,
+    "worst_name": "gej_offc_fe_outofrange_+_gej_offc_fe_outofrange_2",
+    "worst_value": 1233.877894994496
+  },
+  "GejGeAdd": {
+    "best_name": "gej_zero_fe_ufmbits_+_ge_oncurve_2",
+    "best_value": 944.1710953366346,
+    "median_name": "gej_offc_fe_lo-bits_+_ge_offc_fe_ufmbits_4",
+    "median_value": 1257.3401624203962,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_4",
+    "worst_value": 1376.3073973202286
+  },
+  "GejGeAddEx": {
+    "best_name": "gej_zero_fe_lo-bits_+_ge_offc_fe_lo-bits_0",
+    "best_value": 1062.2539226174165,
+    "median_name": "gej_offc_fe_ufmbits_+_ge_offc_fe_ufmbits_0",
+    "median_value": 1383.6092923789772,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_1",
+    "worst_value": 1510.6965337240808
+  },
+  "GejGeEquiv": {
+    "best_name": "gej_zero_fe_ufmbits_+_ge_offc_fe_lo-bits_2",
+    "best_value": 626.0074255026796,
+    "median_name": "gej_offc_fe_ufmbits_+_ge_offc_fe_ufmbits_3",
+    "median_value": 894.7686644747113,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_lo-bits_4",
+    "worst_value": 980.6789399836443
+  },
+  "GejInfinity": {
+    "best_name": "unit_4",
+    "best_value": 395.56994947522185,
+    "median_name": "unit_1",
+    "median_value": 396.60776478144294,
+    "worst_name": "unit_3",
+    "worst_value": 398.03834524479885
+  },
+  "GejIsInfinity": {
+    "best_name": "gej_zero_fe_ufmbits_2",
+    "best_value": 347.68066805892005,
+    "median_name": "gej_zero_fe_hi-bits_3",
+    "median_value": 362.72974985950293,
+    "worst_name": "gej_offc_fe_outofrange_4",
+    "worst_value": 370.3037942737992
+  },
+  "GejIsOnCurve": {
+    "best_name": "gej_zero_fe_ufmbits_4",
+    "best_value": 510.52288682309575,
+    "median_name": "gej_zero_fe_hi-bits_0",
+    "median_value": 534.631146638176,
+    "worst_name": "gej_offc_fe_outofrange_1",
+    "worst_value": 564.8607923748427
+  },
+  "GejNegate": {
+    "best_name": "gej_zero_fe_ufmbits_4",
+    "best_value": 715.4054981831537,
+    "median_name": "gej_oncurve_1",
+    "median_value": 750.3264728351799,
+    "worst_name": "gej_offc_fe_outofrange_4",
+    "worst_value": 767.335419690289
+  },
+  "GejNormalize": {
+    "best_name": "gej_zero_fe_ufmbits_2",
+    "best_value": 367.05607411663374,
+    "median_name": "gej_offc_fe_outofrange_3",
+    "median_value": 1727.713736233583,
+    "worst_name": "gej_oncurve_2",
+    "worst_value": 2277.254498988017
+  },
+  "GejRescale": {
+    "best_name": "gej_offc_fe_lo-bits_+_fe_lo-bits_1",
+    "best_value": 962.3800412192762,
+    "median_name": "gej_offc_fe_ufmbits_+_fe_ufmbits_3",
+    "median_value": 994.2729691729344,
+    "worst_name": "gej_offc_fe_outofrange_+_fe_ufmbits_0",
+    "worst_value": 1060.3680232144072
+  },
+  "GejXEquiv": {
+    "best_name": "fe_ufmbits_+_gej_zero_fe_lo-bits_2",
+    "best_value": 475.5405128371392,
+    "median_name": "fe_hi-bits_+_gej_oncurve_3",
+    "median_value": 534.7498921138128,
+    "worst_name": "fe_outofrange_+_gej_offc_fe_outofrange_1",
+    "worst_value": 581.9587646807994
+  },
+  "GejYIsOdd": {
+    "best_name": "gej_zero_fe_ufmbits_0",
+    "best_value": 361.3378964415095,
+    "median_name": "gej_offc_fe_outofrange_3",
+    "median_value": 1500.0043008275443,
+    "worst_name": "gej_oncurve_0",
+    "worst_value": 2028.4000778806126
+  },
+  "Generate": {
+    "best_name": "sc_lo-bits_4",
+    "best_value": 15698.303578674544,
+    "median_name": "scalar_outofrange_3",
+    "median_value": 24749.44655594019,
+    "worst_name": "sc_ufmbits_0",
+    "worst_value": 27817.092507074034
+  },
+  "GenesisBlockHash": {
+    "best_name": "6",
+    "best_value": 43.25225571261357,
+    "median_name": "51",
+    "median_value": 60.448618594295404,
+    "worst_name": "47",
+    "worst_value": 82.31162715271869
+  },
+  "HashToCurve": {
+    "best_name": "lo-bits_2",
+    "best_value": 37696.405137430746,
+    "median_name": "hi-bits_1",
+    "median_value": 37709.77173172522,
+    "worst_name": "ufmbits_0",
+    "worst_value": 37829.83541169991
+  },
+  "High1": {
+    "best_name": "unit_4",
+    "best_value": 29.243935264778948,
+    "median_name": "unit_0",
+    "median_value": 31.00224198059028,
+    "worst_name": "unit_2",
+    "worst_value": 31.86779242260267
+  },
+  "High16": {
+    "best_name": "unit_0",
+    "best_value": 35.181166832885204,
+    "median_name": "unit_1",
+    "median_value": 36.672900526975255,
+    "worst_name": "unit_2",
+    "worst_value": 36.868090596516424
+  },
+  "High32": {
+    "best_name": "unit_0",
+    "best_value": 28.656112765090278,
+    "median_name": "unit_1",
+    "median_value": 29.7345030110922,
+    "worst_name": "unit_4",
+    "worst_value": 32.65996617035562
+  },
+  "High64": {
+    "best_name": "unit_0",
+    "best_value": 33.54449599229995,
+    "median_name": "unit_4",
+    "median_value": 37.78743672283476,
+    "worst_name": "unit_1",
+    "worst_value": 37.93536469075943
+  },
+  "High8": {
+    "best_name": "unit_3",
+    "best_value": 31.67500695987919,
+    "median_name": "unit_1",
+    "median_value": 31.898178195561105,
+    "worst_name": "unit_2",
+    "worst_value": 32.943473850377345
+  },
+  "Increment16": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.904559810273618,
+    "median_name": "hi-bits_4",
+    "median_value": 27.60724485729396,
+    "worst_name": "lo-bits_1",
+    "worst_value": 38.392451852783076
+  },
+  "Increment32": {
+    "best_name": "lo-bits_1",
+    "best_value": 25.965387694938737,
+    "median_name": "ufmbits_3",
+    "median_value": 26.792562159313988,
+    "worst_name": "hi-bits_0",
+    "worst_value": 51.55474922519457
+  },
+  "Increment64": {
+    "best_name": "hi-bits_0",
+    "best_value": 43.59374940435655,
+    "median_name": "hi-bits_4",
+    "median_value": 47.5045706603502,
+    "worst_name": "lo-bits_2",
+    "worst_value": 48.75851943327705
+  },
+  "Increment8": {
+    "best_name": "ufmbits_1",
+    "best_value": 25.11750752410983,
+    "median_name": "hi-bits_1",
+    "median_value": 29.11919402212685,
+    "worst_name": "lo-bits_0",
+    "worst_value": 47.33246517826407
+  },
+  "InputAmount": {
+    "best_name": "19",
+    "best_value": 64.99343623413108,
+    "median_name": "43",
+    "median_value": 97.1957274543763,
+    "worst_name": "11",
+    "worst_value": 158.40519188620513
+  },
+  "InputAmountsHash": {
+    "best_name": "85",
+    "best_value": 42.71495706533363,
+    "median_name": "62",
+    "median_value": 59.09759557052893,
+    "worst_name": "31",
+    "worst_value": 78.18657902074679
+  },
+  "InputAnnexHash": {
+    "best_name": "71",
+    "best_value": 25.53879430298116,
+    "median_name": "85",
+    "median_value": 39.142053464184535,
+    "worst_name": "53",
+    "worst_value": 50.39975862268921
+  },
+  "InputAnnexesHash": {
+    "best_name": "97",
+    "best_value": 39.3725413204957,
+    "median_name": "99",
+    "median_value": 55.47878477651745,
+    "worst_name": "3",
+    "worst_value": 86.3866910419064
+  },
+  "InputAsset": {
+    "best_name": "90",
+    "best_value": 49.49686971949008,
+    "median_name": "10",
+    "median_value": 73.04410559524534,
+    "worst_name": "48",
+    "worst_value": 90.4780872924351
+  },
+  "InputHash": {
+    "best_name": "95",
+    "best_value": 360.1155719010522,
+    "median_name": "8",
+    "median_value": 462.1145540918667,
+    "worst_name": "83",
+    "worst_value": 536.5958475792895
+  },
+  "InputOutpointsHash": {
+    "best_name": "88",
+    "best_value": 40.777196472545405,
+    "median_name": "82",
+    "median_value": 56.045877143445274,
+    "worst_name": "51",
+    "worst_value": 79.08911806240489
+  },
+  "InputPegin": {
+    "best_name": "95",
+    "best_value": 45.78229986215249,
+    "median_name": "30",
+    "median_value": 69.36787056710592,
+    "worst_name": "25",
+    "worst_value": 83.98879360287582
+  },
+  "InputPrevOutpoint": {
+    "best_name": "3",
+    "best_value": 48.45305152978792,
+    "median_name": "82",
+    "median_value": 72.19596175891142,
+    "worst_name": "64",
+    "worst_value": 89.3872112500479
+  },
+  "InputScriptHash": {
+    "best_name": "89",
+    "best_value": 45.527477653864445,
+    "median_name": "64",
+    "median_value": 66.45249744992849,
+    "worst_name": "35",
+    "worst_value": 81.89252511817973
+  },
+  "InputScriptSigHash": {
+    "best_name": "97",
+    "best_value": 45.21737415118796,
+    "median_name": "16",
+    "median_value": 67.88301346806892,
+    "worst_name": "46",
+    "worst_value": 85.18974271907717
+  },
+  "InputScriptSigsHash": {
+    "best_name": "2",
+    "best_value": 39.276290886581975,
+    "median_name": "5",
+    "median_value": 53.908218192889144,
+    "worst_name": "87",
+    "worst_value": 76.77862968879907
+  },
+  "InputScriptsHash": {
+    "best_name": "77",
+    "best_value": 42.27041735599021,
+    "median_name": "94",
+    "median_value": 55.653550810753444,
+    "worst_name": "95",
+    "worst_value": 76.14052574532384
+  },
+  "InputSequence": {
+    "best_name": "18",
+    "best_value": 27.287588020660838,
+    "median_name": "19",
+    "median_value": 40.52529484393947,
+    "worst_name": "55",
+    "worst_value": 55.04705395962086
+  },
+  "InputSequencesHash": {
+    "best_name": "85",
+    "best_value": 39.30634700897404,
+    "median_name": "40",
+    "median_value": 54.76590911993369,
+    "worst_name": "52",
+    "worst_value": 79.43302880722794
+  },
+  "InputUtxoHash": {
+    "best_name": "37",
+    "best_value": 647.598706777708,
+    "median_name": "21",
+    "median_value": 673.703662747168,
+    "worst_name": "12",
+    "worst_value": 1109.0519630683661
+  },
+  "InputUtxosHash": {
+    "best_name": "1",
+    "best_value": 42.10823460993056,
+    "median_name": "45",
+    "median_value": 54.23621230655698,
+    "worst_name": "52",
+    "worst_value": 77.9855360566019
+  },
+  "InputsHash": {
+    "best_name": "80",
+    "best_value": 48.70448621917453,
+    "median_name": "1",
+    "median_value": 65.72033588822752,
+    "worst_name": "28",
+    "worst_value": 86.08549951543868
+  },
+  "InternalKey": {
+    "best_name": "46",
+    "best_value": 42.56996251190801,
+    "median_name": "77",
+    "median_value": 59.69682854927077,
+    "worst_name": "82",
+    "worst_value": 84.89379535345726
+  },
+  "IsOne16": {
+    "best_name": "lo-bits_4",
+    "best_value": 35.53947584807388,
+    "median_name": "hi-bits_3",
+    "median_value": 36.56727742171436,
+    "worst_name": "ufmbits_3",
+    "worst_value": 45.64683559591153
+  },
+  "IsOne32": {
+    "best_name": "hi-bits_4",
+    "best_value": 27.31143075292734,
+    "median_name": "ufmbits_4",
+    "median_value": 28.362962665198076,
+    "worst_name": "lo-bits_4",
+    "worst_value": 36.58111091935885
+  },
+  "IsOne64": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.260018613136623,
+    "median_name": "lo-bits_4",
+    "median_value": 41.68185876545817,
+    "worst_name": "ufmbits_4",
+    "worst_value": 46.45643688595097
+  },
+  "IsOne8": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.672788189074687,
+    "median_name": "hi-bits_3",
+    "median_value": 47.175843615368876,
+    "worst_name": "ufmbits_1",
+    "worst_value": 50.62634232797921
+  },
+  "IsZero16": {
+    "best_name": "hi-bits_1",
+    "best_value": 27.253582612738104,
+    "median_name": "ufmbits_0",
+    "median_value": 32.17663392378322,
+    "worst_name": "lo-bits_2",
+    "worst_value": 42.109412893391784
+  },
+  "IsZero32": {
+    "best_name": "ufmbits_2",
+    "best_value": 26.138551527220688,
+    "median_name": "hi-bits_0",
+    "median_value": 27.108406078331715,
+    "worst_name": "lo-bits_4",
+    "worst_value": 47.422659579472345
+  },
+  "IsZero64": {
+    "best_name": "hi-bits_3",
+    "best_value": 32.45111066912009,
+    "median_name": "ufmbits_1",
+    "median_value": 39.194309680174314,
+    "worst_name": "lo-bits_4",
+    "worst_value": 44.99474610179195
+  },
+  "IsZero8": {
+    "best_name": "hi-bits_0",
+    "best_value": 26.68021795727784,
+    "median_name": "lo-bits_2",
+    "median_value": 37.93892654835223,
+    "worst_name": "hi-bits_4",
+    "worst_value": 43.2557200624648
+  },
+  "Issuance": {
+    "best_name": "16",
+    "best_value": 26.258448969631235,
+    "median_name": "75",
+    "median_value": 39.72950477237139,
+    "worst_name": "80",
+    "worst_value": 50.74625704409637
+  },
+  "IssuanceAsset": {
+    "best_name": "97",
+    "best_value": 45.02716009487313,
+    "median_name": "74",
+    "median_value": 66.05538036424389,
+    "worst_name": "63",
+    "worst_value": 83.923133996747
+  },
+  "IssuanceAssetAmount": {
+    "best_name": "78",
+    "best_value": 50.899836727380816,
+    "median_name": "15",
+    "median_value": 72.40026128489706,
+    "worst_name": "10",
+    "worst_value": 90.39955141184957
+  },
+  "IssuanceAssetAmountsHash": {
+    "best_name": "85",
+    "best_value": 40.61588723709189,
+    "median_name": "92",
+    "median_value": 54.370066453573145,
+    "worst_name": "69",
+    "worst_value": 77.23792759162177
+  },
+  "IssuanceAssetProof": {
+    "best_name": "94",
+    "best_value": 45.12731891944114,
+    "median_name": "29",
+    "median_value": 66.66820728067886,
+    "worst_name": "22",
+    "worst_value": 83.58936713231286
+  },
+  "IssuanceBlindingEntropyHash": {
+    "best_name": "65",
+    "best_value": 39.14354118115262,
+    "median_name": "90",
+    "median_value": 53.79931798070203,
+    "worst_name": "82",
+    "worst_value": 71.8325573717658
+  },
+  "IssuanceEntropy": {
+    "best_name": "89",
+    "best_value": 45.87185623583348,
+    "median_name": "44",
+    "median_value": 65.62425743346937,
+    "worst_name": "83",
+    "worst_value": 85.07102143556246
+  },
+  "IssuanceHash": {
+    "best_name": "42",
+    "best_value": 1532.5070882405812,
+    "median_name": "95",
+    "median_value": 1832.123565886997,
+    "worst_name": "29",
+    "worst_value": 2076.7943990862123
+  },
+  "IssuanceRangeProofsHash": {
+    "best_name": "75",
+    "best_value": 39.08201685997385,
+    "median_name": "2",
+    "median_value": 53.044927469857555,
+    "worst_name": "6",
+    "worst_value": 71.96306342619509
+  },
+  "IssuanceToken": {
+    "best_name": "96",
+    "best_value": 46.10657246915781,
+    "median_name": "46",
+    "median_value": 68.61801809935193,
+    "worst_name": "92",
+    "worst_value": 83.0717304440206
+  },
+  "IssuanceTokenAmount": {
+    "best_name": "49",
+    "best_value": 60.45792008105446,
+    "median_name": "87",
+    "median_value": 88.02643368013811,
+    "worst_name": "81",
+    "worst_value": 109.09867909211174
+  },
+  "IssuanceTokenAmountsHash": {
+    "best_name": "3",
+    "best_value": 39.678226946801026,
+    "median_name": "74",
+    "median_value": 56.79690518434488,
+    "worst_name": "88",
+    "worst_value": 76.77352744178933
+  },
+  "IssuanceTokenProof": {
+    "best_name": "81",
+    "best_value": 44.918106536706475,
+    "median_name": "59",
+    "median_value": 67.62454602780969,
+    "worst_name": "51",
+    "worst_value": 83.80024681603632
+  },
+  "IssuancesHash": {
+    "best_name": "91",
+    "best_value": 42.53873087223922,
+    "median_name": "43",
+    "median_value": 55.73176395214035,
+    "worst_name": "28",
+    "worst_value": 78.75424725524539
+  },
+  "LbtcAsset": {
+    "best_name": "4",
+    "best_value": 44.894769727397154,
+    "median_name": "95",
+    "median_value": 57.25124594094398,
+    "worst_name": "56",
+    "worst_value": 80.81176100612451
+  },
+  "Le16": {
+    "best_name": "lo-bits_+_self_1",
+    "best_value": 30.34088225840403,
+    "median_name": "lo-bits_+_inv_self_1",
+    "median_value": 47.98446115810057,
+    "worst_name": "hi-bits_+_hi-bits_3",
+    "worst_value": 62.59866562816164
+  },
+  "Le32": {
+    "best_name": "lo-bits_+_self_1",
+    "best_value": 29.12212183814467,
+    "median_name": "ufmbits_+_hi-bits_1",
+    "median_value": 42.71193947801562,
+    "worst_name": "hi-bits_+_hi-bits_0",
+    "worst_value": 51.691597800360576
+  },
+  "Le64": {
+    "best_name": "ufmbits_+_self_3",
+    "best_value": 28.937344164334927,
+    "median_name": "hi-bits_+_self_2",
+    "median_value": 40.0698942436579,
+    "worst_name": "hi-bits_+_hi-bits_3",
+    "worst_value": 51.98614962560549
+  },
+  "Le8": {
+    "best_name": "lo-bits_+_self_2",
+    "best_value": 27.03264997582991,
+    "median_name": "lo-bits_+_ufmbits_4",
+    "median_value": 49.28463999956982,
+    "worst_name": "hi-bits_+_inv_self_4",
+    "worst_value": 60.913133751779085
+  },
+  "LeftExtend16_32": {
+    "best_name": "lo-bits_2",
+    "best_value": 27.60724575929097,
+    "median_name": "ufmbits_3",
+    "median_value": 34.52329658623194,
+    "worst_name": "hi-bits_1",
+    "worst_value": 48.321737975265485
+  },
+  "LeftExtend16_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 31.76762748707037,
+    "median_name": "ufmbits_3",
+    "median_value": 46.3235324437823,
+    "worst_name": "hi-bits_4",
+    "worst_value": 49.768255836158694
+  },
+  "LeftExtend1_16": {
+    "best_name": "ufmbits_3",
+    "best_value": 22.584231301742822,
+    "median_name": "lo-bits_4",
+    "median_value": 24.475391094664545,
+    "worst_name": "hi-bits_4",
+    "worst_value": 37.33174442804743
+  },
+  "LeftExtend1_32": {
+    "best_name": "ufmbits_3",
+    "best_value": 23.195782422462727,
+    "median_name": "lo-bits_4",
+    "median_value": 24.21921390648314,
+    "worst_name": "hi-bits_2",
+    "worst_value": 33.51980854843369
+  },
+  "LeftExtend1_64": {
+    "best_name": "lo-bits_4",
+    "best_value": 24.20322438713264,
+    "median_name": "ufmbits_0",
+    "median_value": 30.25414389283585,
+    "worst_name": "hi-bits_1",
+    "worst_value": 42.74855194501722
+  },
+  "LeftExtend1_8": {
+    "best_name": "lo-bits_4",
+    "best_value": 22.298555920938657,
+    "median_name": "lo-bits_0",
+    "median_value": 23.05879472168493,
+    "worst_name": "ufmbits_1",
+    "worst_value": 36.301294529908404
+  },
+  "LeftExtend32_64": {
+    "best_name": "hi-bits_3",
+    "best_value": 27.006115354400826,
+    "median_name": "lo-bits_4",
+    "median_value": 28.657336845462627,
+    "worst_name": "ufmbits_2",
+    "worst_value": 35.00507852860337
+  },
+  "LeftExtend8_16": {
+    "best_name": "lo-bits_2",
+    "best_value": 26.081052161968696,
+    "median_name": "ufmbits_4",
+    "median_value": 28.138503267418404,
+    "worst_name": "lo-bits_3",
+    "worst_value": 49.27356422938357
+  },
+  "LeftExtend8_32": {
+    "best_name": "hi-bits_2",
+    "best_value": 37.692931271650146,
+    "median_name": "ufmbits_1",
+    "median_value": 46.435379463877425,
+    "worst_name": "lo-bits_0",
+    "worst_value": 50.49729967016896
+  },
+  "LeftExtend8_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 46.71663250444631,
+    "median_name": "lo-bits_2",
+    "median_value": 52.784890984910795,
+    "worst_name": "ufmbits_2",
+    "worst_value": 59.47812571540859
+  },
+  "LeftPadHigh16_32": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.840550399139673,
+    "median_name": "lo-bits_2",
+    "median_value": 28.438727006510135,
+    "worst_name": "hi-bits_4",
+    "worst_value": 50.98338161795605
+  },
+  "LeftPadHigh16_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 48.298733891432306,
+    "median_name": "hi-bits_3",
+    "median_value": 57.51346182590562,
+    "worst_name": "hi-bits_0",
+    "worst_value": 61.60346108788994
+  },
+  "LeftPadHigh1_16": {
+    "best_name": "lo-bits_4",
+    "best_value": 54.72865525123967,
+    "median_name": "ufmbits_1",
+    "median_value": 71.08629821582177,
+    "worst_name": "hi-bits_3",
+    "worst_value": 78.50508931127487
+  },
+  "LeftPadHigh1_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 85.62622942059551,
+    "median_name": "hi-bits_0",
+    "median_value": 88.28206181859464,
+    "worst_name": "lo-bits_1",
+    "worst_value": 146.26121054697865
+  },
+  "LeftPadHigh1_64": {
+    "best_name": "ufmbits_1",
+    "best_value": 157.77207332455305,
+    "median_name": "lo-bits_0",
+    "median_value": 193.3789167239055,
+    "worst_name": "hi-bits_1",
+    "worst_value": 234.97787849061334
+  },
+  "LeftPadHigh1_8": {
+    "best_name": "ufmbits_4",
+    "best_value": 33.00893334753427,
+    "median_name": "lo-bits_0",
+    "median_value": 36.99728364413255,
+    "worst_name": "hi-bits_3",
+    "worst_value": 55.39324189082562
+  },
+  "LeftPadHigh32_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 32.23195458400074,
+    "median_name": "lo-bits_3",
+    "median_value": 38.69597800010778,
+    "worst_name": "hi-bits_3",
+    "worst_value": 52.17097219985573
+  },
+  "LeftPadHigh8_16": {
+    "best_name": "hi-bits_3",
+    "best_value": 39.316368580594855,
+    "median_name": "ufmbits_0",
+    "median_value": 41.937830441536434,
+    "worst_name": "lo-bits_2",
+    "worst_value": 49.21564430401875
+  },
+  "LeftPadHigh8_32": {
+    "best_name": "ufmbits_0",
+    "best_value": 32.307752831394595,
+    "median_name": "hi-bits_1",
+    "median_value": 47.08104754447575,
+    "worst_name": "lo-bits_1",
+    "worst_value": 57.68232149971271
+  },
+  "LeftPadHigh8_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 46.430387333204436,
+    "median_name": "lo-bits_2",
+    "median_value": 62.51393594776203,
+    "worst_name": "ufmbits_1",
+    "worst_value": 75.61993575310662
+  },
+  "LeftPadLow16_32": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.639413156070024,
+    "median_name": "lo-bits_4",
+    "median_value": 34.541814274059824,
+    "worst_name": "ufmbits_3",
+    "worst_value": 38.49926754604619
+  },
+  "LeftPadLow16_64": {
+    "best_name": "ufmbits_1",
+    "best_value": 33.00200528898948,
+    "median_name": "lo-bits_1",
+    "median_value": 45.75364436337687,
+    "worst_name": "ufmbits_0",
+    "worst_value": 59.250342412456355
+  },
+  "LeftPadLow1_16": {
+    "best_name": "lo-bits_4",
+    "best_value": 29.57997524872911,
+    "median_name": "hi-bits_2",
+    "median_value": 34.702563726491356,
+    "worst_name": "ufmbits_1",
+    "worst_value": 36.36920559197807
+  },
+  "LeftPadLow1_32": {
+    "best_name": "hi-bits_2",
+    "best_value": 24.28726102424316,
+    "median_name": "lo-bits_1",
+    "median_value": 28.693015443015966,
+    "worst_name": "ufmbits_2",
+    "worst_value": 35.466251309723425
+  },
+  "LeftPadLow1_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 28.686998367989723,
+    "median_name": "hi-bits_3",
+    "median_value": 29.884711991225956,
+    "worst_name": "ufmbits_3",
+    "worst_value": 33.98849564613479
+  },
+  "LeftPadLow1_8": {
+    "best_name": "hi-bits_0",
+    "best_value": 25.371924896965215,
+    "median_name": "ufmbits_0",
+    "median_value": 29.42043574081547,
+    "worst_name": "lo-bits_0",
+    "worst_value": 31.204669198216017
+  },
+  "LeftPadLow32_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 31.174208999124804,
+    "median_name": "hi-bits_2",
+    "median_value": 47.14741107525216,
+    "worst_name": "hi-bits_0",
+    "worst_value": 50.99335457473273
+  },
+  "LeftPadLow8_16": {
+    "best_name": "lo-bits_2",
+    "best_value": 26.83305666447143,
+    "median_name": "lo-bits_4",
+    "median_value": 28.80467108878098,
+    "worst_name": "ufmbits_2",
+    "worst_value": 37.126983955984464
+  },
+  "LeftPadLow8_32": {
+    "best_name": "hi-bits_1",
+    "best_value": 29.984495674545588,
+    "median_name": "lo-bits_1",
+    "median_value": 31.962835628721056,
+    "worst_name": "ufmbits_0",
+    "worst_value": 34.00684198357385
+  },
+  "LeftPadLow8_64": {
+    "best_name": "lo-bits_4",
+    "best_value": 43.71895102282509,
+    "median_name": "hi-bits_4",
+    "median_value": 55.837371077543565,
+    "worst_name": "ufmbits_0",
+    "worst_value": 62.53255064489368
+  },
+  "LeftRotate16": {
+    "best_name": "lo-bits_1",
+    "best_value": 33.18338946765996,
+    "median_name": "hi-bits_0",
+    "median_value": 38.415021084196084,
+    "worst_name": "ufmbits_0",
+    "worst_value": 43.001392195690684
+  },
+  "LeftRotate32": {
+    "best_name": "hi-bits_3",
+    "best_value": 34.400718185485914,
+    "median_name": "ufmbits_0",
+    "median_value": 48.954634965396615,
+    "worst_name": "lo-bits_0",
+    "worst_value": 59.09903021360284
+  },
+  "LeftRotate64": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.167996282165845,
+    "median_name": "lo-bits_0",
+    "median_value": 45.192542338870766,
+    "worst_name": "hi-bits_1",
+    "worst_value": 54.856167630986604
+  },
+  "LeftRotate8": {
+    "best_name": "hi-bits_2",
+    "best_value": 37.27986407008672,
+    "median_name": "ufmbits_3",
+    "median_value": 42.27146125386285,
+    "worst_name": "lo-bits_0",
+    "worst_value": 49.076586368944184
+  },
+  "LeftShift16": {
+    "best_name": "hi-bits_3",
+    "best_value": 34.87989682898781,
+    "median_name": "hi-bits_0",
+    "median_value": 37.47969416624982,
+    "worst_name": "lo-bits_4",
+    "worst_value": 40.235919376592726
+  },
+  "LeftShift32": {
+    "best_name": "lo-bits_1",
+    "best_value": 27.444934857148393,
+    "median_name": "ufmbits_3",
+    "median_value": 38.45170052360088,
+    "worst_name": "hi-bits_4",
+    "worst_value": 43.76932719716762
+  },
+  "LeftShift64": {
+    "best_name": "lo-bits_2",
+    "best_value": 27.97288443964869,
+    "median_name": "lo-bits_4",
+    "median_value": 29.030766806883456,
+    "worst_name": "ufmbits_3",
+    "worst_value": 45.73742443386188
+  },
+  "LeftShift8": {
+    "best_name": "lo-bits_0",
+    "best_value": 35.45100906132754,
+    "median_name": "hi-bits_3",
+    "median_value": 39.09342907737663,
+    "worst_name": "ufmbits_0",
+    "worst_value": 50.57937158222907
+  },
+  "LeftShiftWith16": {
+    "best_name": "ufmbits_2",
+    "best_value": 33.13145196203757,
+    "median_name": "hi-bits_1",
+    "median_value": 43.68195330152237,
+    "worst_name": "hi-bits_2",
+    "worst_value": 46.61700433558814
+  },
+  "LeftShiftWith32": {
+    "best_name": "hi-bits_3",
+    "best_value": 38.43934403028453,
+    "median_name": "lo-bits_2",
+    "median_value": 45.71345021661054,
+    "worst_name": "ufmbits_2",
+    "worst_value": 52.81674643546554
+  },
+  "LeftShiftWith64": {
+    "best_name": "ufmbits_2",
+    "best_value": 35.50151707377847,
+    "median_name": "hi-bits_0",
+    "median_value": 40.04937658229536,
+    "worst_name": "ufmbits_3",
+    "worst_value": 57.28743045790752
+  },
+  "LeftShiftWith8": {
+    "best_name": "ufmbits_4",
+    "best_value": 37.65510901233168,
+    "median_name": "lo-bits_1",
+    "median_value": 55.45615615572039,
+    "worst_name": "hi-bits_4",
+    "worst_value": 59.90532889097582
+  },
+  "Leftmost16_1": {
+    "best_name": "hi-bits_3",
+    "best_value": 39.539830344390104,
+    "median_name": "hi-bits_1",
+    "median_value": 41.34251050825635,
+    "worst_name": "lo-bits_0",
+    "worst_value": 51.70552021960683
+  },
+  "Leftmost16_2": {
+    "best_name": "hi-bits_4",
+    "best_value": 26.312446253048833,
+    "median_name": "lo-bits_2",
+    "median_value": 38.86756532985321,
+    "worst_name": "ufmbits_4",
+    "worst_value": 50.08994317254649
+  },
+  "Leftmost16_4": {
+    "best_name": "ufmbits_1",
+    "best_value": 35.33630973521769,
+    "median_name": "lo-bits_3",
+    "median_value": 36.98741697378062,
+    "worst_name": "hi-bits_0",
+    "worst_value": 41.80688946896769
+  },
+  "Leftmost16_8": {
+    "best_name": "hi-bits_2",
+    "best_value": 28.719694523198847,
+    "median_name": "lo-bits_1",
+    "median_value": 34.7636964422974,
+    "worst_name": "ufmbits_4",
+    "worst_value": 39.60132273936846
+  },
+  "Leftmost32_1": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.348845607769846,
+    "median_name": "hi-bits_2",
+    "median_value": 29.88621037251314,
+    "worst_name": "lo-bits_1",
+    "worst_value": 43.30897199282181
+  },
+  "Leftmost32_16": {
+    "best_name": "hi-bits_3",
+    "best_value": 25.410104985905647,
+    "median_name": "ufmbits_4",
+    "median_value": 37.14866252034516,
+    "worst_name": "lo-bits_4",
+    "worst_value": 56.9016513351459
+  },
+  "Leftmost32_2": {
+    "best_name": "lo-bits_3",
+    "best_value": 28.904713541158618,
+    "median_name": "ufmbits_4",
+    "median_value": 35.749752398557895,
+    "worst_name": "hi-bits_0",
+    "worst_value": 37.2079258996741
+  },
+  "Leftmost32_4": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.332255669646912,
+    "median_name": "lo-bits_4",
+    "median_value": 28.052603160987506,
+    "worst_name": "hi-bits_4",
+    "worst_value": 29.068274922258183
+  },
+  "Leftmost32_8": {
+    "best_name": "ufmbits_3",
+    "best_value": 39.348030648686546,
+    "median_name": "lo-bits_1",
+    "median_value": 50.733444362711,
+    "worst_name": "hi-bits_2",
+    "worst_value": 57.77525039357289
+  },
+  "Leftmost64_1": {
+    "best_name": "ufmbits_2",
+    "best_value": 25.49247800096101,
+    "median_name": "lo-bits_4",
+    "median_value": 36.215234835173035,
+    "worst_name": "hi-bits_2",
+    "worst_value": 43.60916457293865
+  },
+  "Leftmost64_16": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.376534271685404,
+    "median_name": "hi-bits_3",
+    "median_value": 40.53588019188435,
+    "worst_name": "ufmbits_1",
+    "worst_value": 48.96468216997573
+  },
+  "Leftmost64_2": {
+    "best_name": "lo-bits_0",
+    "best_value": 25.40896814441953,
+    "median_name": "hi-bits_0",
+    "median_value": 37.42465212295261,
+    "worst_name": "ufmbits_2",
+    "worst_value": 39.922903799137245
+  },
+  "Leftmost64_32": {
+    "best_name": "ufmbits_3",
+    "best_value": 37.046250132007955,
+    "median_name": "hi-bits_4",
+    "median_value": 45.20167581284499,
+    "worst_name": "lo-bits_4",
+    "worst_value": 50.08880572463181
+  },
+  "Leftmost64_4": {
+    "best_name": "lo-bits_0",
+    "best_value": 36.353183289199066,
+    "median_name": "ufmbits_4",
+    "median_value": 40.4899524433025,
+    "worst_name": "hi-bits_4",
+    "worst_value": 44.43246907916128
+  },
+  "Leftmost64_8": {
+    "best_name": "hi-bits_3",
+    "best_value": 29.25967460769129,
+    "median_name": "ufmbits_3",
+    "median_value": 38.34153859272675,
+    "worst_name": "lo-bits_3",
+    "worst_value": 47.83372489702833
+  },
+  "Leftmost8_1": {
+    "best_name": "hi-bits_0",
+    "best_value": 29.533837854046386,
+    "median_name": "ufmbits_2",
+    "median_value": 38.05212373109571,
+    "worst_name": "lo-bits_3",
+    "worst_value": 50.511534173537996
+  },
+  "Leftmost8_2": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.9950803180808,
+    "median_name": "hi-bits_3",
+    "median_value": 32.092900190191735,
+    "worst_name": "ufmbits_4",
+    "worst_value": 50.40905212515953
+  },
+  "Leftmost8_4": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.391937526501536,
+    "median_name": "lo-bits_3",
+    "median_value": 40.19133999126908,
+    "worst_name": "hi-bits_2",
+    "worst_value": 48.50341727771359
+  },
+  "LinearCombination1": {
+    "best_name": "sc_ufmbits_+_gej_offc_fe_ufmbits_+_sc_ufmbits_0",
+    "best_value": 749.593240095093,
+    "median_name": "sc_ufmbits_+_gej_zero_fe_outofrange_+_sc_lo-bits_2",
+    "median_value": 801.9941282849895,
+    "worst_name": "sc_ufmbits_+_gej_oncurve_+_sc_ufmbits_0",
+    "worst_value": 47040.93376314034
+  },
+  "LinearVerify1": {
+    "best_name": "sc_ufmbits_+_ge_offc_fe_ufmbits_+_sc_ufmbits_+_ge_offc_fe_lo-bit_2",
+    "best_value": 772.34053081413,
+    "median_name": "sc_hi-bits_+_ge_offc_fe_ufmbits_+_scalar_outofrange_+_ge_offc_fe_17",
+    "median_value": 813.6977012735672,
+    "worst_name": "sc_hi-bits_+_ge_oncurve_+_sc_ufmbits_+_ge_oncurve_2",
+    "worst_value": 48182.42296619453
+  },
+  "LockTime": {
+    "best_name": "99",
+    "best_value": 24.238274545124096,
+    "median_name": "78",
+    "median_value": 31.50454910513223,
+    "worst_name": "21",
+    "worst_value": 47.70317349257734
+  },
+  "Low1": {
+    "best_name": "unit_0",
+    "best_value": 20.719560089507272,
+    "median_name": "unit_4",
+    "median_value": 21.022910968020323,
+    "worst_name": "unit_1",
+    "worst_value": 21.364181571710727
+  },
+  "Low16": {
+    "best_name": "unit_2",
+    "best_value": 27.795695386590708,
+    "median_name": "unit_1",
+    "median_value": 38.411613320957294,
+    "worst_name": "unit_3",
+    "worst_value": 38.49685288168574
+  },
+  "Low32": {
+    "best_name": "unit_1",
+    "best_value": 33.03896225929875,
+    "median_name": "unit_2",
+    "median_value": 33.47048350079208,
+    "worst_name": "unit_4",
+    "worst_value": 34.91518106691244
+  },
+  "Low64": {
+    "best_name": "unit_3",
+    "best_value": 24.031536048454278,
+    "median_name": "unit_0",
+    "median_value": 24.859715271133496,
+    "worst_name": "unit_4",
+    "worst_value": 26.186652606444063
+  },
+  "Low8": {
+    "best_name": "unit_0",
+    "best_value": 24.489675031212418,
+    "median_name": "unit_3",
+    "median_value": 24.811699580388225,
+    "worst_name": "unit_4",
+    "worst_value": 26.29098053293153
+  },
+  "Lt16": {
+    "best_name": "ufmbits_+_hi-bits_3",
+    "best_value": 29.167129197742387,
+    "median_name": "ufmbits_+_self_2",
+    "median_value": 43.951229401587504,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 68.8706112088274
+  },
+  "Lt32": {
+    "best_name": "lo-bits_+_self_0",
+    "best_value": 28.115062773485967,
+    "median_name": "lo-bits_+_self_4",
+    "median_value": 45.459818294200815,
+    "worst_name": "lo-bits_+_inv_self_2",
+    "worst_value": 59.53443050674163
+  },
+  "Lt64": {
+    "best_name": "lo-bits_+_inv_self_3",
+    "best_value": 28.723973724547005,
+    "median_name": "lo-bits_+_lo-bits_4",
+    "median_value": 36.295070796222355,
+    "worst_name": "hi-bits_+_lo-bits_1",
+    "worst_value": 42.364172739029975
+  },
+  "Lt8": {
+    "best_name": "hi-bits_+_self_4",
+    "best_value": 26.77753781909267,
+    "median_name": "lo-bits_+_ufmbits_2",
+    "median_value": 48.051310305605,
+    "worst_name": "ufmbits_+_ufmbits_0",
+    "worst_value": 59.93172194081304
+  },
+  "Maj1": {
+    "best_name": "hi-bits_2",
+    "best_value": 23.66337932535962,
+    "median_name": "ufmbits_2",
+    "median_value": 30.76162922357607,
+    "worst_name": "lo-bits_4",
+    "worst_value": 34.96061898351924
+  },
+  "Maj16": {
+    "best_name": "lo-bits_4",
+    "best_value": 29.120710584891953,
+    "median_name": "lo-bits_0",
+    "median_value": 29.95421868727593,
+    "worst_name": "ufmbits_1",
+    "worst_value": 44.94543138149138
+  },
+  "Maj32": {
+    "best_name": "hi-bits_0",
+    "best_value": 29.33064430781893,
+    "median_name": "lo-bits_1",
+    "median_value": 31.210498899440687,
+    "worst_name": "ufmbits_4",
+    "worst_value": 53.683025295042526
+  },
+  "Maj64": {
+    "best_name": "lo-bits_0",
+    "best_value": 35.408306229819,
+    "median_name": "hi-bits_0",
+    "median_value": 47.993683371506386,
+    "worst_name": "ufmbits_0",
+    "worst_value": 51.72821494872019
+  },
+  "Maj8": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.885420326863095,
+    "median_name": "ufmbits_2",
+    "median_value": 45.97796530275017,
+    "worst_name": "hi-bits_0",
+    "worst_value": 52.36812937443448
+  },
+  "Max16": {
+    "best_name": "ufmbits_+_ufmbits_3",
+    "best_value": 29.496008830984763,
+    "median_name": "lo-bits_+_self_2",
+    "median_value": 44.7938861470306,
+    "worst_name": "lo-bits_+_inv_self_3",
+    "worst_value": 63.71134773209803
+  },
+  "Max32": {
+    "best_name": "hi-bits_+_hi-bits_1",
+    "best_value": 27.336484875745555,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 39.48480693111424,
+    "worst_name": "hi-bits_+_self_1",
+    "worst_value": 51.18820119510864
+  },
+  "Max64": {
+    "best_name": "ufmbits_+_inv_self_1",
+    "best_value": 30.046766460542077,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 40.258343298307615,
+    "worst_name": "hi-bits_+_self_4",
+    "worst_value": 57.83190769189562
+  },
+  "Max8": {
+    "best_name": "hi-bits_+_lo-bits_2",
+    "best_value": 31.96931290727763,
+    "median_name": "hi-bits_+_inv_self_2",
+    "median_value": 43.17224413625689,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 53.8515645366078
+  },
+  "Median16": {
+    "best_name": "lo-bits_3",
+    "best_value": 39.11978073923268,
+    "median_name": "hi-bits_2",
+    "median_value": 57.90827822739677,
+    "worst_name": "ufmbits_4",
+    "worst_value": 68.42782342281728
+  },
+  "Median32": {
+    "best_name": "lo-bits_3",
+    "best_value": 37.651397379789834,
+    "median_name": "lo-bits_2",
+    "median_value": 53.358793993707685,
+    "worst_name": "ufmbits_0",
+    "worst_value": 56.38805745851612
+  },
+  "Median64": {
+    "best_name": "lo-bits_0",
+    "best_value": 37.36938706003227,
+    "median_name": "hi-bits_4",
+    "median_value": 56.84007263114306,
+    "worst_name": "ufmbits_4",
+    "worst_value": 60.56301468794372
+  },
+  "Median8": {
+    "best_name": "hi-bits_3",
+    "best_value": 42.79637830023749,
+    "median_name": "ufmbits_2",
+    "median_value": 54.71918937141778,
+    "worst_name": "lo-bits_2",
+    "worst_value": 67.89381197782626
+  },
+  "Min16": {
+    "best_name": "hi-bits_+_ufmbits_0",
+    "best_value": 27.413203917110266,
+    "median_name": "ufmbits_+_ufmbits_3",
+    "median_value": 41.178858212992,
+    "worst_name": "hi-bits_+_hi-bits_0",
+    "worst_value": 54.04518077046216
+  },
+  "Min32": {
+    "best_name": "hi-bits_+_inv_self_0",
+    "best_value": 30.307940342796286,
+    "median_name": "ufmbits_+_self_3",
+    "median_value": 41.901508115922226,
+    "worst_name": "lo-bits_+_self_0",
+    "worst_value": 62.97525599888933
+  },
+  "Min64": {
+    "best_name": "lo-bits_+_ufmbits_2",
+    "best_value": 29.38927204688429,
+    "median_name": "ufmbits_+_hi-bits_2",
+    "median_value": 38.28955915017933,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 56.81753152966646
+  },
+  "Min8": {
+    "best_name": "ufmbits_+_lo-bits_3",
+    "best_value": 27.70644811073446,
+    "median_name": "ufmbits_+_inv_self_1",
+    "median_value": 39.58593412991212,
+    "worst_name": "hi-bits_+_ufmbits_4",
+    "worst_value": 55.00456012337589
+  },
+  "Modulo16": {
+    "best_name": "lo-bits_+_inv_self_3",
+    "best_value": 27.582000046439763,
+    "median_name": "ufmbits_+_ufmbits_3",
+    "median_value": 40.825314486627,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 57.518560975532644
+  },
+  "Modulo32": {
+    "best_name": "lo-bits_+_inv_self_3",
+    "best_value": 27.18428882726748,
+    "median_name": "lo-bits_+_lo-bits_0",
+    "median_value": 44.2755818821249,
+    "worst_name": "lo-bits_+_ufmbits_2",
+    "worst_value": 57.08875049862416
+  },
+  "Modulo64": {
+    "best_name": "ufmbits_+_inv_self_1",
+    "best_value": 30.384172643284156,
+    "median_name": "ufmbits_+_lo-bits_1",
+    "median_value": 35.65479699015466,
+    "worst_name": "lo-bits_+_inv_self_1",
+    "worst_value": 47.65027121643483
+  },
+  "Modulo8": {
+    "best_name": "ufmbits_+_ufmbits_0",
+    "best_value": 28.50041976892818,
+    "median_name": "ufmbits_+_lo-bits_2",
+    "median_value": 36.4628804838467,
+    "worst_name": "hi-bits_+_inv_self_3",
+    "worst_value": 56.70553878631508
+  },
+  "Multiply16": {
+    "best_name": "ufmbits_+_hi-bits_3",
+    "best_value": 26.73798268426804,
+    "median_name": "hi-bits_+_ufmbits_2",
+    "median_value": 40.38479432999215,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 50.145505525636324
+  },
+  "Multiply32": {
+    "best_name": "hi-bits_+_inv_self_3",
+    "best_value": 27.313444990274615,
+    "median_name": "lo-bits_+_lo-bits_0",
+    "median_value": 39.84320931894671,
+    "worst_name": "ufmbits_+_inv_self_3",
+    "worst_value": 50.46424112527131
+  },
+  "Multiply64": {
+    "best_name": "hi-bits_+_ufmbits_1",
+    "best_value": 29.25821846311843,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 41.18075754914756,
+    "worst_name": "hi-bits_+_self_1",
+    "worst_value": 47.45018438748184
+  },
+  "Multiply8": {
+    "best_name": "ufmbits_+_inv_self_3",
+    "best_value": 26.78402747359439,
+    "median_name": "ufmbits_+_lo-bits_1",
+    "median_value": 31.535047173487154,
+    "worst_name": "hi-bits_+_self_4",
+    "worst_value": 52.03683827069245
+  },
+  "Negate16": {
+    "best_name": "lo-bits_3",
+    "best_value": 27.89532186295149,
+    "median_name": "ufmbits_3",
+    "median_value": 33.54747117868546,
+    "worst_name": "hi-bits_3",
+    "worst_value": 38.90971489117882
+  },
+  "Negate32": {
+    "best_name": "hi-bits_0",
+    "best_value": 24.29169751560119,
+    "median_name": "hi-bits_2",
+    "median_value": 43.009496960765375,
+    "worst_name": "ufmbits_4",
+    "worst_value": 47.61426946368856
+  },
+  "Negate64": {
+    "best_name": "hi-bits_2",
+    "best_value": 39.36138208956124,
+    "median_name": "ufmbits_1",
+    "median_value": 41.17984897425767,
+    "worst_name": "lo-bits_2",
+    "worst_value": 52.41405985192276
+  },
+  "Negate8": {
+    "best_name": "lo-bits_2",
+    "best_value": 27.553128427494617,
+    "median_name": "ufmbits_0",
+    "median_value": 38.28655784809801,
+    "worst_name": "lo-bits_1",
+    "worst_value": 50.833505778893596
+  },
+  "NewIssuanceContract": {
+    "best_name": "97",
+    "best_value": 47.74649418393557,
+    "median_name": "17",
+    "median_value": 67.6958325023025,
+    "worst_name": "29",
+    "worst_value": 87.26032454930737
+  },
+  "NonceHash": {
+    "best_name": "10",
+    "best_value": 125.1275,
+    "median_name": "15",
+    "median_value": 131.8375,
+    "worst_name": "88",
+    "worst_value": 176.1925
+  },
+  "NumInputs": {
+    "best_name": "55",
+    "best_value": 25.18321138225883,
+    "median_name": "34",
+    "median_value": 32.61842280944478,
+    "worst_name": "17",
+    "worst_value": 48.16180127047511
+  },
+  "NumOutputs": {
+    "best_name": "90",
+    "best_value": 23.479921262285355,
+    "median_name": "80",
+    "median_value": 30.792487298271954,
+    "worst_name": "97",
+    "worst_value": 44.087257539344634
+  },
+  "One16": {
+    "best_name": "unit_4",
+    "best_value": 33.02087160894317,
+    "median_name": "unit_1",
+    "median_value": 33.333484246092326,
+    "worst_name": "unit_3",
+    "worst_value": 33.60409513338236
+  },
+  "One32": {
+    "best_name": "unit_3",
+    "best_value": 26.01449284028833,
+    "median_name": "unit_1",
+    "median_value": 32.983847189690806,
+    "worst_name": "unit_0",
+    "worst_value": 33.222841959359855
+  },
+  "One64": {
+    "best_name": "unit_2",
+    "best_value": 30.623586985649577,
+    "median_name": "unit_0",
+    "median_value": 31.276818463246997,
+    "worst_name": "unit_3",
+    "worst_value": 33.2636748253045
+  },
+  "One8": {
+    "best_name": "unit_0",
+    "best_value": 32.84193489584102,
+    "median_name": "unit_1",
+    "median_value": 33.16792226242381,
+    "worst_name": "unit_2",
+    "worst_value": 34.88577796465835
+  },
+  "Or1": {
+    "best_name": "hi-bits_+_hi-bits_4",
+    "best_value": 22.40251092333455,
+    "median_name": "ufmbits_+_ufmbits_1",
+    "median_value": 29.962605352248328,
+    "worst_name": "hi-bits_+_inv_self_3",
+    "worst_value": 42.911584386668494
+  },
+  "Or16": {
+    "best_name": "ufmbits_+_hi-bits_3",
+    "best_value": 27.855262213805712,
+    "median_name": "ufmbits_+_ufmbits_0",
+    "median_value": 41.348411560401246,
+    "worst_name": "lo-bits_+_self_3",
+    "worst_value": 52.44067390159183
+  },
+  "Or32": {
+    "best_name": "hi-bits_+_lo-bits_2",
+    "best_value": 33.2853503691054,
+    "median_name": "ufmbits_+_hi-bits_1",
+    "median_value": 42.5199864770586,
+    "worst_name": "hi-bits_+_hi-bits_0",
+    "worst_value": 58.43280128473747
+  },
+  "Or64": {
+    "best_name": "ufmbits_+_ufmbits_0",
+    "best_value": 29.624906829955084,
+    "median_name": "ufmbits_+_hi-bits_1",
+    "median_value": 38.612805447862335,
+    "worst_name": "lo-bits_+_ufmbits_4",
+    "worst_value": 55.4909110467771
+  },
+  "Or8": {
+    "best_name": "hi-bits_+_lo-bits_0",
+    "best_value": 27.187018286218432,
+    "median_name": "lo-bits_+_self_0",
+    "median_value": 32.37380166130396,
+    "worst_name": "hi-bits_+_self_1",
+    "worst_value": 52.17171918086705
+  },
+  "OutpointHash": {
+    "best_name": "14",
+    "best_value": 136.35,
+    "median_name": "55",
+    "median_value": 149.44666666666666,
+    "worst_name": "1",
+    "worst_value": 177.4066666666666
+  },
+  "OutputAmount": {
+    "best_name": "94",
+    "best_value": 64.68438411832493,
+    "median_name": "39",
+    "median_value": 98.77231217149533,
+    "worst_name": "37",
+    "worst_value": 165.73152456360123
+  },
+  "OutputAmountsHash": {
+    "best_name": "79",
+    "best_value": 41.23114682949916,
+    "median_name": "21",
+    "median_value": 59.10941282404893,
+    "worst_name": "59",
+    "worst_value": 77.96882406434946
+  },
+  "OutputAsset": {
+    "best_name": "15",
+    "best_value": 49.31506377804131,
+    "median_name": "91",
+    "median_value": 73.72218679073137,
+    "worst_name": "1",
+    "worst_value": 94.686291527907
+  },
+  "OutputHash": {
+    "best_name": "86",
+    "best_value": 658.6258301435746,
+    "median_name": "95",
+    "median_value": 680.4341864221306,
+    "worst_name": "27",
+    "worst_value": 1582.7809306692625
+  },
+  "OutputIsFee": {
+    "best_name": "1",
+    "best_value": 27.20600737546863,
+    "median_name": "44",
+    "median_value": 40.65452726651245,
+    "worst_name": "70",
+    "worst_value": 51.60956472131248
+  },
+  "OutputNonce": {
+    "best_name": "75",
+    "best_value": 25.485776713256456,
+    "median_name": "1",
+    "median_value": 40.37030914903516,
+    "worst_name": "55",
+    "worst_value": 109.35522600953867
+  },
+  "OutputNoncesHash": {
+    "best_name": "69",
+    "best_value": 40.74112190191801,
+    "median_name": "25",
+    "median_value": 56.535262402382614,
+    "worst_name": "52",
+    "worst_value": 84.29265131406393
+  },
+  "OutputNullDatum": {
+    "best_name": "2",
+    "best_value": 24.816961675808813,
+    "median_name": "26",
+    "median_value": 37.37885170710482,
+    "worst_name": "69",
+    "worst_value": 48.47393556700054
+  },
+  "OutputRangeProof": {
+    "best_name": "87",
+    "best_value": 44.55641898165405,
+    "median_name": "83",
+    "median_value": 65.46762909729875,
+    "worst_name": "33",
+    "worst_value": 85.91729268925901
+  },
+  "OutputRangeProofsHash": {
+    "best_name": "10",
+    "best_value": 40.91448592292895,
+    "median_name": "9",
+    "median_value": 56.76295157948094,
+    "worst_name": "19",
+    "worst_value": 76.01487688752357
+  },
+  "OutputScriptHash": {
+    "best_name": "7",
+    "best_value": 45.654176273410506,
+    "median_name": "89",
+    "median_value": 66.70316380942823,
+    "worst_name": "8",
+    "worst_value": 84.3315823091484
+  },
+  "OutputScriptsHash": {
+    "best_name": "4",
+    "best_value": 42.40562479402371,
+    "median_name": "14",
+    "median_value": 55.97964939862538,
+    "worst_name": "45",
+    "worst_value": 79.43957403869098
+  },
+  "OutputSurjectionProof": {
+    "best_name": "13",
+    "best_value": 45.74743484986821,
+    "median_name": "4",
+    "median_value": 66.81564032758529,
+    "worst_name": "27",
+    "worst_value": 83.9027630832634
+  },
+  "OutputSurjectionProofsHash": {
+    "best_name": "96",
+    "best_value": 39.699572222293035,
+    "median_name": "44",
+    "median_value": 56.5531383011747,
+    "worst_name": "40",
+    "worst_value": 76.73829814634762
+  },
+  "OutputsHash": {
+    "best_name": "6",
+    "best_value": 40.64102982573428,
+    "median_name": "65",
+    "median_value": 52.84287463013122,
+    "worst_name": "86",
+    "worst_value": 75.43857791831756
+  },
+  "ParseLock": {
+    "best_name": "lo-bits_4",
+    "best_value": 31.797663905244285,
+    "median_name": "ufmbits_1",
+    "median_value": 34.583686517820404,
+    "worst_name": "lo-bits_0",
+    "worst_value": 54.40929208819059
+  },
+  "ParseSequence": {
+    "best_name": "0lo-bits_1",
+    "best_value": 35.1098339973697,
+    "median_name": "1hi-bits_3",
+    "median_value": 51.00850044650956,
+    "worst_name": "1ufmbits_1",
+    "worst_value": 64.73080420529664
+  },
+  "PointVerify1": {
+    "best_name": "sc_lo-bits_+_pt_ge_offc_fe_lo-bits_+_sc_lo-bits_+_pt_ge_offc_fe__10",
+    "best_value": 14576.071829958855,
+    "median_name": "sc_hi-bits_+_pt_ge_offc_fe_ufmbits_+_sc_hi-bits_+_pt_ge_offc_fe__14",
+    "median_value": 20757.536984944967,
+    "worst_name": "sc_hi-bits_+_pt_ge_oncurve_+_sc_ufmbits_+_pt_ge_oncurve_4",
+    "worst_value": 46104.55214160499
+  },
+  "ReissuanceBlinding": {
+    "best_name": "20",
+    "best_value": 26.67010976664674,
+    "median_name": "37",
+    "median_value": 39.55789687300379,
+    "worst_name": "70",
+    "worst_value": 50.73337651212825
+  },
+  "ReissuanceEntropy": {
+    "best_name": "90",
+    "best_value": 25.74737740412547,
+    "median_name": "73",
+    "median_value": 36.946033379558806,
+    "worst_name": "43",
+    "worst_value": 51.84338682545885
+  },
+  "RightExtend16_32": {
+    "best_name": "lo-bits_3",
+    "best_value": 26.7567869115577,
+    "median_name": "ufmbits_4",
+    "median_value": 29.420068954100337,
+    "worst_name": "hi-bits_4",
+    "worst_value": 41.1152394906143
+  },
+  "RightExtend16_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 30.61811013514934,
+    "median_name": "lo-bits_2",
+    "median_value": 43.1556159274022,
+    "worst_name": "hi-bits_0",
+    "worst_value": 45.58796842580513
+  },
+  "RightExtend32_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 29.655904166486803,
+    "median_name": "lo-bits_1",
+    "median_value": 43.39868586182551,
+    "worst_name": "ufmbits_4",
+    "worst_value": 52.52115235015417
+  },
+  "RightExtend8_16": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.321139225024197,
+    "median_name": "hi-bits_4",
+    "median_value": 31.525607967730743,
+    "worst_name": "lo-bits_3",
+    "worst_value": 42.62436355994448
+  },
+  "RightExtend8_32": {
+    "best_name": "ufmbits_0",
+    "best_value": 32.033413899942836,
+    "median_name": "lo-bits_3",
+    "median_value": 48.643009577851934,
+    "worst_name": "hi-bits_4",
+    "worst_value": 58.95339195029901
+  },
+  "RightExtend8_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 46.23821504657839,
+    "median_name": "lo-bits_2",
+    "median_value": 50.00908082302534,
+    "worst_name": "hi-bits_2",
+    "worst_value": 69.32207026801537
+  },
+  "RightPadHigh16_32": {
+    "best_name": "ufmbits_4",
+    "best_value": 28.598975721514464,
+    "median_name": "hi-bits_2",
+    "median_value": 29.88816654674123,
+    "worst_name": "lo-bits_3",
+    "worst_value": 39.424436392837556
+  },
+  "RightPadHigh16_64": {
+    "best_name": "hi-bits_2",
+    "best_value": 38.8698631448203,
+    "median_name": "ufmbits_0",
+    "median_value": 44.610350223591006,
+    "worst_name": "lo-bits_4",
+    "worst_value": 49.248174058995446
+  },
+  "RightPadHigh1_16": {
+    "best_name": "lo-bits_1",
+    "best_value": 52.034088693930954,
+    "median_name": "hi-bits_1",
+    "median_value": 68.05420193138985,
+    "worst_name": "ufmbits_4",
+    "worst_value": 79.72621339569697
+  },
+  "RightPadHigh1_32": {
+    "best_name": "ufmbits_2",
+    "best_value": 95.9281392671574,
+    "median_name": "hi-bits_2",
+    "median_value": 121.24194960316188,
+    "worst_name": "lo-bits_3",
+    "worst_value": 124.40833120289545
+  },
+  "RightPadHigh1_64": {
+    "best_name": "hi-bits_3",
+    "best_value": 157.58838122436632,
+    "median_name": "hi-bits_2",
+    "median_value": 214.90701405828622,
+    "worst_name": "lo-bits_3",
+    "worst_value": 264.5187952944149
+  },
+  "RightPadHigh1_8": {
+    "best_name": "ufmbits_1",
+    "best_value": 46.40746463295773,
+    "median_name": "hi-bits_4",
+    "median_value": 51.46729276879861,
+    "worst_name": "lo-bits_0",
+    "worst_value": 59.84994335191323
+  },
+  "RightPadHigh32_64": {
+    "best_name": "lo-bits_2",
+    "best_value": 38.883842109620666,
+    "median_name": "hi-bits_0",
+    "median_value": 43.28112163121601,
+    "worst_name": "ufmbits_3",
+    "worst_value": 52.54942442499254
+  },
+  "RightPadHigh8_16": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.429596158258047,
+    "median_name": "hi-bits_4",
+    "median_value": 43.43919456643293,
+    "worst_name": "ufmbits_3",
+    "worst_value": 49.67776118222926
+  },
+  "RightPadHigh8_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 34.842890064768774,
+    "median_name": "lo-bits_2",
+    "median_value": 44.537758063976945,
+    "worst_name": "ufmbits_3",
+    "worst_value": 61.532852924980645
+  },
+  "RightPadHigh8_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 45.19799718829813,
+    "median_name": "hi-bits_1",
+    "median_value": 54.413101584088615,
+    "worst_name": "lo-bits_3",
+    "worst_value": 59.83710387705546
+  },
+  "RightPadLow16_32": {
+    "best_name": "hi-bits_3",
+    "best_value": 27.621616605375742,
+    "median_name": "hi-bits_0",
+    "median_value": 28.70772005463971,
+    "worst_name": "ufmbits_2",
+    "worst_value": 39.87733699553977
+  },
+  "RightPadLow16_64": {
+    "best_name": "hi-bits_0",
+    "best_value": 31.121844574142724,
+    "median_name": "ufmbits_4",
+    "median_value": 35.742290208240874,
+    "worst_name": "lo-bits_2",
+    "worst_value": 53.36064826952089
+  },
+  "RightPadLow1_16": {
+    "best_name": "ufmbits_2",
+    "best_value": 36.64814351834059,
+    "median_name": "hi-bits_1",
+    "median_value": 41.16983631402673,
+    "worst_name": "lo-bits_1",
+    "worst_value": 45.07485014417921
+  },
+  "RightPadLow1_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 29.773216157261956,
+    "median_name": "lo-bits_2",
+    "median_value": 35.18668414185505,
+    "worst_name": "hi-bits_0",
+    "worst_value": 41.676208784085105
+  },
+  "RightPadLow1_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 32.11238946430422,
+    "median_name": "ufmbits_1",
+    "median_value": 34.12548482190902,
+    "worst_name": "lo-bits_2",
+    "worst_value": 41.090406238456374
+  },
+  "RightPadLow1_8": {
+    "best_name": "ufmbits_4",
+    "best_value": 29.8092066024314,
+    "median_name": "lo-bits_2",
+    "median_value": 34.488590022955385,
+    "worst_name": "hi-bits_1",
+    "worst_value": 37.92725470993486
+  },
+  "RightPadLow32_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 36.40963654461299,
+    "median_name": "hi-bits_2",
+    "median_value": 40.61955365089779,
+    "worst_name": "lo-bits_1",
+    "worst_value": 44.8312134267434
+  },
+  "RightPadLow8_16": {
+    "best_name": "ufmbits_2",
+    "best_value": 26.653862741172084,
+    "median_name": "lo-bits_1",
+    "median_value": 37.992051011048595,
+    "worst_name": "hi-bits_1",
+    "worst_value": 41.75506302525163
+  },
+  "RightPadLow8_32": {
+    "best_name": "ufmbits_2",
+    "best_value": 29.9650814648944,
+    "median_name": "ufmbits_4",
+    "median_value": 31.710795186478645,
+    "worst_name": "lo-bits_3",
+    "worst_value": 43.22301100078246
+  },
+  "RightPadLow8_64": {
+    "best_name": "lo-bits_4",
+    "best_value": 43.3357090952513,
+    "median_name": "ufmbits_1",
+    "median_value": 44.237595573091205,
+    "worst_name": "hi-bits_4",
+    "worst_value": 46.0905871657453
+  },
+  "RightRotate16": {
+    "best_name": "ufmbits_0",
+    "best_value": 38.42232294672128,
+    "median_name": "hi-bits_1",
+    "median_value": 45.31426103428303,
+    "worst_name": "lo-bits_4",
+    "worst_value": 55.451707999091234
+  },
+  "RightRotate32": {
+    "best_name": "lo-bits_4",
+    "best_value": 32.06414638951726,
+    "median_name": "hi-bits_0",
+    "median_value": 37.48803015909194,
+    "worst_name": "ufmbits_2",
+    "worst_value": 51.33869960974644
+  },
+  "RightRotate64": {
+    "best_name": "lo-bits_4",
+    "best_value": 27.659659341428004,
+    "median_name": "lo-bits_0",
+    "median_value": 29.307773054474477,
+    "worst_name": "ufmbits_1",
+    "worst_value": 51.72067856450664
+  },
+  "RightRotate8": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.768515636209766,
+    "median_name": "ufmbits_2",
+    "median_value": 28.100749667443466,
+    "worst_name": "hi-bits_2",
+    "worst_value": 41.88436010698827
+  },
+  "RightShift16": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.98372275595897,
+    "median_name": "lo-bits_4",
+    "median_value": 40.054712455970964,
+    "worst_name": "hi-bits_2",
+    "worst_value": 47.19331997670199
+  },
+  "RightShift32": {
+    "best_name": "hi-bits_2",
+    "best_value": 38.01205741127036,
+    "median_name": "ufmbits_4",
+    "median_value": 41.75582927379089,
+    "worst_name": "lo-bits_2",
+    "worst_value": 49.25458525218545
+  },
+  "RightShift64": {
+    "best_name": "hi-bits_0",
+    "best_value": 29.59665388570158,
+    "median_name": "ufmbits_1",
+    "median_value": 43.3720535723752,
+    "worst_name": "lo-bits_2",
+    "worst_value": 50.88231418071366
+  },
+  "RightShift8": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.66448529272257,
+    "median_name": "hi-bits_3",
+    "median_value": 38.8492129605502,
+    "worst_name": "lo-bits_3",
+    "worst_value": 49.252427103572366
+  },
+  "RightShiftWith16": {
+    "best_name": "lo-bits_1",
+    "best_value": 41.749010766860145,
+    "median_name": "ufmbits_3",
+    "median_value": 56.16183341076149,
+    "worst_name": "hi-bits_4",
+    "worst_value": 58.52512455955412
+  },
+  "RightShiftWith32": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.808114015889768,
+    "median_name": "ufmbits_2",
+    "median_value": 48.33345230720726,
+    "worst_name": "hi-bits_1",
+    "worst_value": 51.447551882228765
+  },
+  "RightShiftWith64": {
+    "best_name": "lo-bits_0",
+    "best_value": 40.53760531163264,
+    "median_name": "hi-bits_0",
+    "median_value": 45.839963818671976,
+    "worst_name": "ufmbits_2",
+    "worst_value": 53.91540234901843
+  },
+  "RightShiftWith8": {
+    "best_name": "hi-bits_2",
+    "best_value": 49.78146410300067,
+    "median_name": "hi-bits_4",
+    "median_value": 50.813956691336834,
+    "worst_name": "lo-bits_0",
+    "worst_value": 57.29707045629772
+  },
+  "Rightmost16_1": {
+    "best_name": "ufmbits_1",
+    "best_value": 35.65021933696171,
+    "median_name": "ufmbits_3",
+    "median_value": 36.520399664810405,
+    "worst_name": "hi-bits_3",
+    "worst_value": 39.17928949934075
+  },
+  "Rightmost16_2": {
+    "best_name": "ufmbits_4",
+    "best_value": 25.82839986993757,
+    "median_name": "lo-bits_4",
+    "median_value": 32.40244410506576,
+    "worst_name": "ufmbits_1",
+    "worst_value": 45.91367784810004
+  },
+  "Rightmost16_4": {
+    "best_name": "lo-bits_0",
+    "best_value": 26.22765215983056,
+    "median_name": "ufmbits_2",
+    "median_value": 29.81259542416511,
+    "worst_name": "hi-bits_4",
+    "worst_value": 42.474022809253114
+  },
+  "Rightmost16_8": {
+    "best_name": "ufmbits_2",
+    "best_value": 28.21560645745408,
+    "median_name": "lo-bits_0",
+    "median_value": 30.336499496222988,
+    "worst_name": "lo-bits_4",
+    "worst_value": 38.446904909381345
+  },
+  "Rightmost32_1": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.242381188803034,
+    "median_name": "hi-bits_3",
+    "median_value": 43.778442775032566,
+    "worst_name": "lo-bits_1",
+    "worst_value": 50.25654518416595
+  },
+  "Rightmost32_16": {
+    "best_name": "hi-bits_4",
+    "best_value": 24.30627225936285,
+    "median_name": "ufmbits_2",
+    "median_value": 25.15332360871102,
+    "worst_name": "lo-bits_4",
+    "worst_value": 35.92965867433983
+  },
+  "Rightmost32_2": {
+    "best_name": "hi-bits_1",
+    "best_value": 33.26623296178827,
+    "median_name": "ufmbits_1",
+    "median_value": 39.84313355704391,
+    "worst_name": "lo-bits_2",
+    "worst_value": 41.65904204963655
+  },
+  "Rightmost32_4": {
+    "best_name": "hi-bits_4",
+    "best_value": 25.871059504416813,
+    "median_name": "lo-bits_1",
+    "median_value": 43.39296158274832,
+    "worst_name": "hi-bits_2",
+    "worst_value": 51.37905781489622
+  },
+  "Rightmost32_8": {
+    "best_name": "hi-bits_0",
+    "best_value": 24.920564803572304,
+    "median_name": "lo-bits_0",
+    "median_value": 36.42990841715485,
+    "worst_name": "hi-bits_3",
+    "worst_value": 43.44904922808357
+  },
+  "Rightmost64_1": {
+    "best_name": "ufmbits_4",
+    "best_value": 25.305279220348865,
+    "median_name": "lo-bits_0",
+    "median_value": 34.574150350667296,
+    "worst_name": "hi-bits_1",
+    "worst_value": 43.0289803608958
+  },
+  "Rightmost64_16": {
+    "best_name": "hi-bits_0",
+    "best_value": 31.22839797374593,
+    "median_name": "ufmbits_2",
+    "median_value": 42.170376534700644,
+    "worst_name": "lo-bits_4",
+    "worst_value": 48.13330514376038
+  },
+  "Rightmost64_2": {
+    "best_name": "hi-bits_4",
+    "best_value": 29.36080660994311,
+    "median_name": "ufmbits_0",
+    "median_value": 35.51336506207931,
+    "worst_name": "lo-bits_2",
+    "worst_value": 41.49489356566985
+  },
+  "Rightmost64_32": {
+    "best_name": "ufmbits_4",
+    "best_value": 37.29670967715282,
+    "median_name": "lo-bits_0",
+    "median_value": 39.47027043040246,
+    "worst_name": "lo-bits_4",
+    "worst_value": 42.65585176023737
+  },
+  "Rightmost64_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 35.56353539193421,
+    "median_name": "lo-bits_0",
+    "median_value": 37.86806986191962,
+    "worst_name": "lo-bits_4",
+    "worst_value": 39.403601089532856
+  },
+  "Rightmost64_8": {
+    "best_name": "ufmbits_2",
+    "best_value": 25.96666102893487,
+    "median_name": "hi-bits_1",
+    "median_value": 35.760834530593954,
+    "worst_name": "lo-bits_3",
+    "worst_value": 38.74161920301971
+  },
+  "Rightmost8_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 34.553980632523576,
+    "median_name": "lo-bits_4",
+    "median_value": 37.308358656136306,
+    "worst_name": "hi-bits_4",
+    "worst_value": 44.41905969704213
+  },
+  "Rightmost8_2": {
+    "best_name": "ufmbits_3",
+    "best_value": 31.356668076185812,
+    "median_name": "lo-bits_0",
+    "median_value": 37.946921854401765,
+    "worst_name": "hi-bits_3",
+    "worst_value": 54.657570189798406
+  },
+  "Rightmost8_4": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.68531290789901,
+    "median_name": "ufmbits_2",
+    "median_value": 42.9703526624956,
+    "worst_name": "hi-bits_2",
+    "worst_value": 54.51548104019699
+  },
+  "ScalarAdd": {
+    "best_name": "sc_hi-bits_+_inv_self_1",
+    "best_value": 382.69218892626157,
+    "median_name": "sc_ufmbits_+_sc_lo-bits_4",
+    "median_value": 397.7129029957393,
+    "worst_name": "scalar_outofrange_+_self_1",
+    "worst_value": 410.7714457930927
+  },
+  "ScalarInvert": {
+    "best_name": "sc_lo-bits_4",
+    "best_value": 1384.8258672671466,
+    "median_name": "sc_ufmbits_1",
+    "median_value": 1756.8517173552834,
+    "worst_name": "scalar_outofrange_4",
+    "worst_value": 1774.301764466127
+  },
+  "ScalarIsZero": {
+    "best_name": "sc_ufmbits_3",
+    "best_value": 145.4454555185457,
+    "median_name": "sc_hi-bits_0",
+    "median_value": 149.57910089347695,
+    "worst_name": "sc_lo-bits_4",
+    "worst_value": 150.68813566357764
+  },
+  "ScalarMultiply": {
+    "best_name": "sc_lo-bits_+_self_4",
+    "best_value": 401.63570960030165,
+    "median_name": "sc_ufmbits_+_scalar_outofrange_0",
+    "median_value": 417.63159847507654,
+    "worst_name": "sc_hi-bits_+_scalar_outofrange_0",
+    "worst_value": 430.52312683792223
+  },
+  "ScalarMultiplyLambda": {
+    "best_name": "sc_hi-bits_1",
+    "best_value": 293.7226658618793,
+    "median_name": "scalar_outofrange_2",
+    "median_value": 304.7095077665189,
+    "worst_name": "sc_hi-bits_2",
+    "worst_value": 309.76081130635305
+  },
+  "ScalarNegate": {
+    "best_name": "sc_ufmbits_4",
+    "best_value": 260.5646906532246,
+    "median_name": "scalar_outofrange_0",
+    "median_value": 268.8647707602343,
+    "worst_name": "sc_lo-bits_0",
+    "worst_value": 272.4586280769547
+  },
+  "ScalarNormalize": {
+    "best_name": "sc_ufmbits_4",
+    "best_value": 247.13227578416314,
+    "median_name": "scalar_outofrange_0",
+    "median_value": 257.3413248378389,
+    "worst_name": "sc_lo-bits_0",
+    "worst_value": 262.222720853674
+  },
+  "ScalarSquare": {
+    "best_name": "sc_ufmbits_2",
+    "best_value": 300.27717910040286,
+    "median_name": "scalar_outofrange_0",
+    "median_value": 311.8978062858323,
+    "worst_name": "sc_lo-bits_2",
+    "worst_value": 319.63744130697734
+  },
+  "Scale": {
+    "best_name": "sc_lo-bits_+_gej_zero_fe_hi-bits_1",
+    "best_value": 630.54654478152,
+    "median_name": "sc_ufmbits_+_gej_offc_fe_ufmbits_1",
+    "median_value": 649.0954473678235,
+    "worst_name": "sc_ufmbits_+_gej_oncurve_1",
+    "worst_value": 40374.728500765836
+  },
+  "ScriptCMR": {
+    "best_name": "64",
+    "best_value": 41.28592955984875,
+    "median_name": "1",
+    "median_value": 51.851235973279515,
+    "worst_name": "69",
+    "worst_value": 76.06354466217492
+  },
+  "Sha256Block": {
+    "best_name": "hi-bits_4",
+    "best_value": 400.30027642805936,
+    "median_name": "lo-bits_4",
+    "median_value": 420.6228826250829,
+    "worst_name": "hi-bits_1",
+    "worst_value": 428.73063753263835
+  },
+  "Sha256Ctx8Add1": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_hi-bits_4",
+    "best_value": 83.64090773717102,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_+_lo-bits_1",
+    "median_value": 222.67480809840626,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_hi-bits_4",
+    "worst_value": 357.1469939873504
+  },
+  "Sha256Ctx8Add128": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_ufmbits_+_lo-bits_4",
+    "best_value": 72.14243666586823,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_hi-bits_2",
+    "median_value": 214.34742187997202,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_ufmbits_4",
+    "worst_value": 988.6918403199944
+  },
+  "Sha256Ctx8Add16": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_ufmbits_+_hi-bits_2",
+    "best_value": 73.17512133812015,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_lo-bits_+_ufmbits_1",
+    "median_value": 210.42694780800971,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_2",
+    "worst_value": 415.4784277283797
+  },
+  "Sha256Ctx8Add2": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_lo-bits_+_lo-bits_0",
+    "best_value": 83.86020155722616,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_+_hi-bits_2",
+    "median_value": 225.82663654937718,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_lo-bits_3",
+    "worst_value": 367.61900312553604
+  },
+  "Sha256Ctx8Add256": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_+_ufmbits_0",
+    "best_value": 69.26510855638901,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_lo-bits_+_hi-bits_3",
+    "median_value": 219.70911957823336,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_3",
+    "worst_value": 1618.063444006473
+  },
+  "Sha256Ctx8Add32": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_lo-bits_+_lo-bits_0",
+    "best_value": 73.71165084483027,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_lo-bits_+_hi-bits_1",
+    "median_value": 216.87250032260857,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_3",
+    "worst_value": 498.1741652411793
+  },
+  "Sha256Ctx8Add4": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_ufmbits_+_ufmbits_0",
+    "best_value": 72.44735223153684,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_ufmbits_0",
+    "median_value": 208.95568345804,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_lo-bits_0",
+    "worst_value": 358.73790652714655
+  },
+  "Sha256Ctx8Add512": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_lo-bits_1",
+    "best_value": 76.62912074561673,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_hi-bits_2",
+    "median_value": 223.86828543182295,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_lo-bits_1",
+    "worst_value": 2943.876504030598
+  },
+  "Sha256Ctx8Add64": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_ufmbits_+_ufmbits_0",
+    "best_value": 72.47421340268872,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_lo-bits_+_lo-bits_1",
+    "median_value": 214.93335533328857,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_lo-bits_1",
+    "worst_value": 659.6032113473665
+  },
+  "Sha256Ctx8Add8": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_lo-bits_+_ufmbits_0",
+    "best_value": 73.02411449981564,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_hi-bits_4",
+    "median_value": 208.24912146063704,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_ufmbits_0",
+    "worst_value": 374.68717127064343
+  },
+  "Sha256Ctx8AddBuffer511": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_lo-bits_4",
+    "best_value": 84.31816116784144,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_lo-bits_+_lo-bits_3",
+    "median_value": 224.4263896529817,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_hi-bits_3",
+    "worst_value": 2811.1712632387207
+  },
+  "Sha256Ctx8Finalize": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_ufmbits_2",
+    "best_value": 62.87056086849767,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_lo-bits_0",
+    "median_value": 204.51808372468923,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_4",
+    "worst_value": 464.13750087504866
+  },
+  "Sha256Ctx8Init": {
+    "best_name": "unit_1",
+    "best_value": 62.70324331621876,
+    "median_name": "unit_3",
+    "median_value": 65.37294778255729,
+    "worst_name": "unit_2",
+    "worst_value": 65.72256048302079
+  },
+  "Sha256Iv": {
+    "best_name": "unit_1",
+    "best_value": 48.855796150856506,
+    "median_name": "unit_3",
+    "median_value": 48.91325427839268,
+    "worst_name": "unit_4",
+    "worst_value": 51.86507201053729
+  },
+  "SigAllHash": {
+    "best_name": "8",
+    "best_value": 39.30176069087804,
+    "median_name": "24",
+    "median_value": 50.86840928919737,
+    "worst_name": "61",
+    "worst_value": 74.01780898147763
+  },
+  "Some1": {
+    "best_name": "ufmbits_0",
+    "best_value": 33.09494595680629,
+    "median_name": "ufmbits_3",
+    "median_value": 34.68831340766848,
+    "worst_name": "lo-bits_4",
+    "worst_value": 39.348504333222046
+  },
+  "Some16": {
+    "best_name": "lo-bits_2",
+    "best_value": 28.922558179822307,
+    "median_name": "lo-bits_4",
+    "median_value": 30.519564865211485,
+    "worst_name": "ufmbits_2",
+    "worst_value": 35.44393063743075
+  },
+  "Some32": {
+    "best_name": "ufmbits_1",
+    "best_value": 26.690227246651748,
+    "median_name": "lo-bits_1",
+    "median_value": 30.755197547659932,
+    "worst_name": "hi-bits_0",
+    "worst_value": 35.685777760954764
+  },
+  "Some64": {
+    "best_name": "ufmbits_2",
+    "best_value": 37.823087867727644,
+    "median_name": "hi-bits_4",
+    "median_value": 46.350069010053105,
+    "worst_name": "lo-bits_4",
+    "worst_value": 52.01425312522673
+  },
+  "Some8": {
+    "best_name": "hi-bits_3",
+    "best_value": 30.977305428851622,
+    "median_name": "ufmbits_0",
+    "median_value": 36.58502570654368,
+    "worst_name": "lo-bits_4",
+    "worst_value": 41.67994966835807
+  },
+  "Subtract16": {
+    "best_name": "lo-bits_+_inv_self_1",
+    "best_value": 30.976947508364912,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 44.257895887114394,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 63.19727385093392
+  },
+  "Subtract32": {
+    "best_name": "lo-bits_+_hi-bits_3",
+    "best_value": 33.19933806975502,
+    "median_name": "lo-bits_+_self_2",
+    "median_value": 47.97416214854465,
+    "worst_name": "hi-bits_+_inv_self_4",
+    "worst_value": 65.73711542469461
+  },
+  "Subtract64": {
+    "best_name": "hi-bits_+_inv_self_0",
+    "best_value": 32.123256158288676,
+    "median_name": "lo-bits_+_self_3",
+    "median_value": 45.40169313551523,
+    "worst_name": "ufmbits_+_hi-bits_1",
+    "worst_value": 63.92384623761226
+  },
+  "Subtract8": {
+    "best_name": "ufmbits_+_self_2",
+    "best_value": 30.380908626744276,
+    "median_name": "lo-bits_+_inv_self_0",
+    "median_value": 48.747054813111184,
+    "worst_name": "ufmbits_+_lo-bits_2",
+    "worst_value": 61.06034896812143
+  },
+  "Swu": {
+    "best_name": "lo-bits_3",
+    "best_value": 17611.478567307815,
+    "median_name": "hi-bits_4",
+    "median_value": 17806.88102846411,
+    "worst_name": "ufmbits_0",
+    "worst_value": 17844.670780310975
+  },
+  "TapEnvHash": {
+    "best_name": "48",
+    "best_value": 49.3325671669094,
+    "median_name": "25",
+    "median_value": 62.73248006826256,
+    "worst_name": "55",
+    "worst_value": 90.34785898924261
+  },
+  "TapleafHash": {
+    "best_name": "68",
+    "best_value": 40.744495022838834,
+    "median_name": "60",
+    "median_value": 55.87937145273402,
+    "worst_name": "51",
+    "worst_value": 75.83151089538666
+  },
+  "TapleafVersion": {
+    "best_name": "19",
+    "best_value": 26.981862928147102,
+    "median_name": "13",
+    "median_value": 37.87179939758946,
+    "worst_name": "90",
+    "worst_value": 58.57378301922501
+  },
+  "Tappath": {
+    "best_name": "93",
+    "best_value": 24.606111176456302,
+    "median_name": "30",
+    "median_value": 33.43854237624224,
+    "worst_name": "33",
+    "worst_value": 46.60476841280421
+  },
+  "TappathHash": {
+    "best_name": "74",
+    "best_value": 40.4713424291572,
+    "median_name": "68",
+    "median_value": 54.088405299765775,
+    "worst_name": "47",
+    "worst_value": 79.52144445412839
+  },
+  "TotalFee": {
+    "best_name": "7",
+    "best_value": 113.69714285714286,
+    "median_name": "60",
+    "median_value": 119.10857142857145,
+    "worst_name": "53",
+    "worst_value": 128.3214285714286
+  },
+  "TransactionId": {
+    "best_name": "26",
+    "best_value": 43.308992492004364,
+    "median_name": "37",
+    "median_value": 59.83371868547206,
+    "worst_name": "84",
+    "worst_value": 77.57004212352764
+  },
+  "TxHash": {
+    "best_name": "47",
+    "best_value": 42.410137540170226,
+    "median_name": "71",
+    "median_value": 56.26042986157572,
+    "worst_name": "19",
+    "worst_value": 79.6895834815193
+  },
+  "TxIsFinal": {
+    "best_name": "4",
+    "best_value": 20.922849536291384,
+    "median_name": "42",
+    "median_value": 29.345620869340244,
+    "worst_name": "64",
+    "worst_value": 39.91991497511649
+  },
+  "TxLockDistance": {
+    "best_name": "2",
+    "best_value": 26.13538734361444,
+    "median_name": "70",
+    "median_value": 35.28080233191306,
+    "worst_name": "14",
+    "worst_value": 50.70260372831025
+  },
+  "TxLockDuration": {
+    "best_name": "4",
+    "best_value": 24.18688835843207,
+    "median_name": "66",
+    "median_value": 34.27387845201783,
+    "worst_name": "43",
+    "worst_value": 46.90895581164496
+  },
+  "TxLockHeight": {
+    "best_name": "77",
+    "best_value": 23.197075832582172,
+    "median_name": "13",
+    "median_value": 32.3024397828497,
+    "worst_name": "59",
+    "worst_value": 44.5346343811494
+  },
+  "TxLockTime": {
+    "best_name": "91",
+    "best_value": 23.504202522828617,
+    "median_name": "78",
+    "median_value": 31.46602756810369,
+    "worst_name": "57",
+    "worst_value": 44.50131256493571
+  },
+  "Verify": {
+    "best_name": "hi-bits_0",
+    "best_value": 18.073030474714038,
+    "median_name": "lo-bits_3",
+    "median_value": 25.346860489303758,
+    "worst_name": "ufmbits_4",
+    "worst_value": 32.09444427680617
+  },
+  "Version": {
+    "best_name": "41",
+    "best_value": 26.71673713074998,
+    "median_name": "17",
+    "median_value": 36.12810269983161,
+    "worst_name": "6",
+    "worst_value": 51.946730072789
+  },
+  "Xor1": {
+    "best_name": "ufmbits_+_lo-bits_2",
+    "best_value": 20.088234336589288,
+    "median_name": "ufmbits_+_self_1",
+    "median_value": 24.235931937235346,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 37.39423846227012
+  },
+  "Xor16": {
+    "best_name": "ufmbits_+_ufmbits_2",
+    "best_value": 25.67631552465425,
+    "median_name": "ufmbits_+_self_2",
+    "median_value": 38.795126939266225,
+    "worst_name": "ufmbits_+_hi-bits_4",
+    "worst_value": 46.3143332902559
+  },
+  "Xor32": {
+    "best_name": "hi-bits_+_inv_self_4",
+    "best_value": 25.22829150422298,
+    "median_name": "lo-bits_+_inv_self_4",
+    "median_value": 42.12965938799412,
+    "worst_name": "hi-bits_+_hi-bits_1",
+    "worst_value": 51.3678650882931
+  },
+  "Xor64": {
+    "best_name": "lo-bits_+_self_2",
+    "best_value": 27.32093316429211,
+    "median_name": "ufmbits_+_hi-bits_0",
+    "median_value": 36.82723513512602,
+    "worst_name": "hi-bits_+_self_3",
+    "worst_value": 53.19079568520052
+  },
+  "Xor8": {
+    "best_name": "ufmbits_+_inv_self_2",
+    "best_value": 25.31597621382317,
+    "median_name": "lo-bits_+_lo-bits_4",
+    "median_value": 39.60911560820747,
+    "worst_name": "hi-bits_+_ufmbits_0",
+    "worst_value": 47.77399820413938
+  },
+  "XorXor1": {
+    "best_name": "lo-bits_3",
+    "best_value": 21.28350676738664,
+    "median_name": "hi-bits_0",
+    "median_value": 37.775273532167645,
+    "worst_name": "ufmbits_2",
+    "worst_value": 40.36662737601213
+  },
+  "XorXor16": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.56214183067037,
+    "median_name": "hi-bits_1",
+    "median_value": 30.09600679787834,
+    "worst_name": "lo-bits_3",
+    "worst_value": 44.24820795601652
+  },
+  "XorXor32": {
+    "best_name": "hi-bits_1",
+    "best_value": 30.710339061448693,
+    "median_name": "ufmbits_2",
+    "median_value": 43.61794320801464,
+    "worst_name": "lo-bits_3",
+    "worst_value": 53.43665625904725
+  },
+  "XorXor64": {
+    "best_name": "ufmbits_3",
+    "best_value": 33.58547634512629,
+    "median_name": "hi-bits_4",
+    "median_value": 41.2198279801901,
+    "worst_name": "ufmbits_1",
+    "worst_value": 52.088775723655864
+  },
+  "XorXor8": {
+    "best_name": "ufmbits_4",
+    "best_value": 49.13336044447217,
+    "median_name": "ufmbits_2",
+    "median_value": 50.82715259648643,
+    "worst_name": "hi-bits_0",
+    "worst_value": 54.87228218084948
+  }
+}

--- a/data/jet_bench_2024-09-12.json
+++ b/data/jet_bench_2024-09-12.json
@@ -1,0 +1,3482 @@
+{
+  "Add16": {
+    "best_name": "hi-bits_+_self_2",
+    "best_value": 35.81082464870567,
+    "median_name": "ufmbits_+_lo-bits_3",
+    "median_value": 50.996275100474996,
+    "worst_name": "lo-bits_+_lo-bits_4",
+    "worst_value": 67.33910007669502
+  },
+  "Add32": {
+    "best_name": "hi-bits_+_self_3",
+    "best_value": 30.27806104622498,
+    "median_name": "hi-bits_+_inv_self_4",
+    "median_value": 42.94506338559493,
+    "worst_name": "ufmbits_+_ufmbits_0",
+    "worst_value": 64.69366584604568
+  },
+  "Add64": {
+    "best_name": "lo-bits_+_lo-bits_0",
+    "best_value": 32.253577854572875,
+    "median_name": "ufmbits_+_inv_self_1",
+    "median_value": 42.23279531013222,
+    "worst_name": "hi-bits_+_lo-bits_4",
+    "worst_value": 55.07496349180881
+  },
+  "Add8": {
+    "best_name": "lo-bits_+_inv_self_3",
+    "best_value": 30.0529655689253,
+    "median_name": "hi-bits_+_inv_self_4",
+    "median_value": 49.92904870431334,
+    "worst_name": "hi-bits_+_inv_self_3",
+    "worst_value": 67.16319053127195
+  },
+  "All16": {
+    "best_name": "ufmbits_3",
+    "best_value": 27.651203348807815,
+    "median_name": "ufmbits_0",
+    "median_value": 36.33787200574236,
+    "worst_name": "hi-bits_2",
+    "worst_value": 42.9465660198316
+  },
+  "All32": {
+    "best_name": "lo-bits_4",
+    "best_value": 35.039972510594765,
+    "median_name": "lo-bits_2",
+    "median_value": 36.259248013995354,
+    "worst_name": "ufmbits_1",
+    "worst_value": 41.98827377051287
+  },
+  "All64": {
+    "best_name": "hi-bits_0",
+    "best_value": 31.324658320124076,
+    "median_name": "ufmbits_2",
+    "median_value": 37.17741641960076,
+    "worst_name": "lo-bits_1",
+    "worst_value": 43.86633919903927
+  },
+  "All8": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.577605929658933,
+    "median_name": "lo-bits_3",
+    "median_value": 34.1025320250679,
+    "worst_name": "hi-bits_2",
+    "worst_value": 43.78252536007793
+  },
+  "And1": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 27.09941273269546,
+    "median_name": "hi-bits_+_inv_self_0",
+    "median_value": 32.880134805323586,
+    "worst_name": "lo-bits_+_hi-bits_3",
+    "worst_value": 52.74402943974578
+  },
+  "And16": {
+    "best_name": "ufmbits_+_ufmbits_1",
+    "best_value": 29.507031698414707,
+    "median_name": "ufmbits_+_self_3",
+    "median_value": 41.67344789607829,
+    "worst_name": "lo-bits_+_inv_self_0",
+    "worst_value": 53.82233662031152
+  },
+  "And32": {
+    "best_name": "ufmbits_+_hi-bits_1",
+    "best_value": 30.130861948355,
+    "median_name": "lo-bits_+_hi-bits_3",
+    "median_value": 41.72745070949302,
+    "worst_name": "lo-bits_+_lo-bits_2",
+    "worst_value": 54.06480316761403
+  },
+  "And64": {
+    "best_name": "ufmbits_+_hi-bits_2",
+    "best_value": 31.752057208947647,
+    "median_name": "ufmbits_+_self_1",
+    "median_value": 42.77379102352814,
+    "worst_name": "ufmbits_+_lo-bits_0",
+    "worst_value": 56.64805806309936
+  },
+  "And8": {
+    "best_name": "lo-bits_+_lo-bits_0",
+    "best_value": 27.938184155979393,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 37.67447847947878,
+    "worst_name": "hi-bits_+_lo-bits_0",
+    "worst_value": 54.26368036749522
+  },
+  "Bip0340Verify": {
+    "best_name": "bip340_valid_2",
+    "best_value": 52343.33314535521,
+    "median_name": "bip340_invalid_3",
+    "median_value": 54234.27040315989,
+    "worst_name": "bip340_invalid_2",
+    "worst_value": 54475.26644559062
+  },
+  "BuildTapbranch": {
+    "best_name": "3",
+    "best_value": 1376.225,
+    "median_name": "6",
+    "median_value": 1499.415,
+    "worst_name": "88",
+    "worst_value": 1576.695
+  },
+  "BuildTapleafSimplicity": {
+    "best_name": "97",
+    "best_value": 1043.89,
+    "median_name": "96",
+    "median_value": 1165.566666666667,
+    "worst_name": "75",
+    "worst_value": 1239.9166666666663
+  },
+  "BuildTaptweak": {
+    "best_name": "xo_pt_ge_offc_fe_outofrange_+_hi-bits_0",
+    "best_value": 723.1729932177461,
+    "median_name": "xo_pt_ge_offc_fe_lo-bits_+_lo-bits_4",
+    "median_value": 29087.074000000004,
+    "worst_name": "xo_pt_ge_oncurve_+_lo-bits_4",
+    "worst_value": 51562.63
+  },
+  "CalculateAsset": {
+    "best_name": "15",
+    "best_value": 366.9666666666666,
+    "median_name": "94",
+    "median_value": 463.56000000000006,
+    "worst_name": "50",
+    "worst_value": 473.75
+  },
+  "CalculateConfidentialToken": {
+    "best_name": "47",
+    "best_value": 410.6200000000001,
+    "median_name": "99",
+    "median_value": 459.0900000000001,
+    "worst_name": "32",
+    "worst_value": 494.51000000000016
+  },
+  "CalculateExplicitToken": {
+    "best_name": "28",
+    "best_value": 427.54666666666685,
+    "median_name": "11",
+    "median_value": 459.3933333333331,
+    "worst_name": "29",
+    "worst_value": 478.36666666666673
+  },
+  "CalculateIssuanceEntropy": {
+    "best_name": "9",
+    "best_value": 1040.645,
+    "median_name": "59",
+    "median_value": 1156.145,
+    "worst_name": "28",
+    "worst_value": 1224.425
+  },
+  "Ch1": {
+    "best_name": "hi-bits_4",
+    "best_value": 25.21725212542663,
+    "median_name": "ufmbits_1",
+    "median_value": 33.20008205296228,
+    "worst_name": "hi-bits_3",
+    "worst_value": 46.39971574151361
+  },
+  "Ch16": {
+    "best_name": "ufmbits_2",
+    "best_value": 33.98640406051519,
+    "median_name": "ufmbits_0",
+    "median_value": 48.59792098441178,
+    "worst_name": "hi-bits_2",
+    "worst_value": 57.64946591542
+  },
+  "Ch32": {
+    "best_name": "ufmbits_4",
+    "best_value": 41.843303588370816,
+    "median_name": "lo-bits_1",
+    "median_value": 51.340905777086135,
+    "worst_name": "hi-bits_1",
+    "worst_value": 57.532246162266
+  },
+  "Ch64": {
+    "best_name": "hi-bits_2",
+    "best_value": 36.18970401732305,
+    "median_name": "hi-bits_3",
+    "median_value": 42.28912486142578,
+    "worst_name": "ufmbits_4",
+    "worst_value": 53.71981406829397
+  },
+  "Ch8": {
+    "best_name": "lo-bits_0",
+    "best_value": 33.51491505250273,
+    "median_name": "lo-bits_1",
+    "median_value": 33.96218621773313,
+    "worst_name": "hi-bits_0",
+    "worst_value": 43.43505303158464
+  },
+  "CheckLockDistance": {
+    "best_name": "41",
+    "best_value": 30.680249957850098,
+    "median_name": "2",
+    "median_value": 49.704968103947856,
+    "worst_name": "32",
+    "worst_value": 110.39919076116836
+  },
+  "CheckLockDuration": {
+    "best_name": "31",
+    "best_value": 45.24506482909259,
+    "median_name": "36",
+    "median_value": 50.21202685257078,
+    "worst_name": "82",
+    "worst_value": 76.65039833019505
+  },
+  "CheckLockHeight": {
+    "best_name": "25",
+    "best_value": 34.39250042404404,
+    "median_name": "97",
+    "median_value": 58.86000000000004,
+    "worst_name": "15",
+    "worst_value": 63.12555555555563
+  },
+  "CheckLockTime": {
+    "best_name": "14",
+    "best_value": 37.42211298947797,
+    "median_name": "27",
+    "median_value": 60.13388888888895,
+    "worst_name": "87",
+    "worst_value": 71.20333333333342
+  },
+  "CheckSigVerify": {
+    "best_name": "checksig_valid_2",
+    "best_value": 46847.591519375375,
+    "median_name": "checksig_invalid_3",
+    "median_value": 54620.79115217704,
+    "worst_name": "checksig_invalid_0",
+    "worst_value": 55137.063193306836
+  },
+  "Complement1": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.374512367346696,
+    "median_name": "lo-bits_0",
+    "median_value": 32.2400420254362,
+    "worst_name": "hi-bits_2",
+    "worst_value": 33.19292504128335
+  },
+  "Complement16": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.2764890387059,
+    "median_name": "lo-bits_3",
+    "median_value": 35.85439069885773,
+    "worst_name": "hi-bits_4",
+    "worst_value": 46.64797676882486
+  },
+  "Complement32": {
+    "best_name": "ufmbits_1",
+    "best_value": 26.68471796195669,
+    "median_name": "lo-bits_4",
+    "median_value": 33.42982133418251,
+    "worst_name": "hi-bits_3",
+    "worst_value": 45.404607694576626
+  },
+  "Complement64": {
+    "best_name": "hi-bits_3",
+    "best_value": 31.416225050541744,
+    "median_name": "lo-bits_1",
+    "median_value": 32.221958264477806,
+    "worst_name": "lo-bits_2",
+    "worst_value": 51.29685036881474
+  },
+  "Complement8": {
+    "best_name": "lo-bits_3",
+    "best_value": 26.227896880530324,
+    "median_name": "hi-bits_2",
+    "median_value": 28.396825874413377,
+    "worst_name": "ufmbits_2",
+    "worst_value": 41.10767298637007
+  },
+  "CurrentAmount": {
+    "best_name": "99",
+    "best_value": 82.84823116398233,
+    "median_name": "33",
+    "median_value": 105.86647585111876,
+    "worst_name": "15",
+    "worst_value": 144.35209254631766
+  },
+  "CurrentAnnexHash": {
+    "best_name": "60",
+    "best_value": 22.871541948773537,
+    "median_name": "69",
+    "median_value": 29.727446457698278,
+    "worst_name": "31",
+    "worst_value": 46.312196207531386
+  },
+  "CurrentAsset": {
+    "best_name": "93",
+    "best_value": 44.01813591096832,
+    "median_name": "81",
+    "median_value": 60.924987700361314,
+    "worst_name": "38",
+    "worst_value": 84.53627741324406
+  },
+  "CurrentIndex": {
+    "best_name": "76",
+    "best_value": 23.631285793057533,
+    "median_name": "34",
+    "median_value": 32.74658105674145,
+    "worst_name": "78",
+    "worst_value": 46.744880941902366
+  },
+  "CurrentIssuanceAssetAmount": {
+    "best_name": "96",
+    "best_value": 46.34388738986262,
+    "median_name": "13",
+    "median_value": 62.22604659477958,
+    "worst_name": "53",
+    "worst_value": 87.42481198988803
+  },
+  "CurrentIssuanceAssetProof": {
+    "best_name": "96",
+    "best_value": 39.417293400076375,
+    "median_name": "30",
+    "median_value": 51.74205040001203,
+    "worst_name": "46",
+    "worst_value": 73.46473168888225
+  },
+  "CurrentIssuanceTokenAmount": {
+    "best_name": "77",
+    "best_value": 46.98484921657262,
+    "median_name": "4",
+    "median_value": 64.5991943400305,
+    "worst_name": "40",
+    "worst_value": 88.3129000355603
+  },
+  "CurrentIssuanceTokenProof": {
+    "best_name": "84",
+    "best_value": 39.00810086534371,
+    "median_name": "21",
+    "median_value": 55.14490682741637,
+    "worst_name": "9",
+    "worst_value": 72.45831134839732
+  },
+  "CurrentNewIssuanceContract": {
+    "best_name": "83",
+    "best_value": 42.133920006474135,
+    "median_name": "65",
+    "median_value": 58.10367590584708,
+    "worst_name": "54",
+    "worst_value": 80.23053321781742
+  },
+  "CurrentPegin": {
+    "best_name": "77",
+    "best_value": 41.91728736646844,
+    "median_name": "13",
+    "median_value": 58.96491424449465,
+    "worst_name": "53",
+    "worst_value": 79.07262036278765
+  },
+  "CurrentPrevOutpoint": {
+    "best_name": "15",
+    "best_value": 44.75396796809199,
+    "median_name": "28",
+    "median_value": 57.79322899807887,
+    "worst_name": "26",
+    "worst_value": 86.0697820942771
+  },
+  "CurrentReissuanceBlinding": {
+    "best_name": "70",
+    "best_value": 22.232741978385274,
+    "median_name": "78",
+    "median_value": 31.528904451394084,
+    "worst_name": "43",
+    "worst_value": 43.54690373767161
+  },
+  "CurrentReissuanceEntropy": {
+    "best_name": "92",
+    "best_value": 23.33167215593237,
+    "median_name": "11",
+    "median_value": 33.22192307791182,
+    "worst_name": "48",
+    "worst_value": 45.22544588507279
+  },
+  "CurrentScriptHash": {
+    "best_name": "89",
+    "best_value": 39.30467916916793,
+    "median_name": "73",
+    "median_value": 53.6922906736608,
+    "worst_name": "10",
+    "worst_value": 72.53257211123197
+  },
+  "CurrentScriptSigHash": {
+    "best_name": "12",
+    "best_value": 40.36114309050823,
+    "median_name": "4",
+    "median_value": 51.39699760238058,
+    "worst_name": "43",
+    "worst_value": 74.3269013962611
+  },
+  "CurrentSequence": {
+    "best_name": "2",
+    "best_value": 23.332856436438252,
+    "median_name": "86",
+    "median_value": 33.78080636850576,
+    "worst_name": "60",
+    "worst_value": 45.53510064349729
+  },
+  "Decompress": {
+    "best_name": "pt_ge_oncurve_0",
+    "best_value": 5662.972267735858,
+    "median_name": "pt_ge_offc_fe_lo-bits_0",
+    "median_value": 5737.514559689976,
+    "worst_name": "pt_ge_offc_fe_hi-bits_1",
+    "worst_value": 5781.016780026115
+  },
+  "Decrement16": {
+    "best_name": "hi-bits_0",
+    "best_value": 26.8991620876094,
+    "median_name": "lo-bits_2",
+    "median_value": 36.598211792079155,
+    "worst_name": "lo-bits_0",
+    "worst_value": 40.005659161616194
+  },
+  "Decrement32": {
+    "best_name": "hi-bits_1",
+    "best_value": 26.518158199272126,
+    "median_name": "hi-bits_2",
+    "median_value": 30.062601631053518,
+    "worst_name": "lo-bits_2",
+    "worst_value": 41.21819359035899
+  },
+  "Decrement64": {
+    "best_name": "hi-bits_2",
+    "best_value": 28.095435967068045,
+    "median_name": "hi-bits_4",
+    "median_value": 41.04823870983602,
+    "worst_name": "lo-bits_4",
+    "worst_value": 46.36636753950096
+  },
+  "Decrement8": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.530677006515155,
+    "median_name": "lo-bits_4",
+    "median_value": 29.93461100181767,
+    "worst_name": "hi-bits_3",
+    "worst_value": 47.763800500497524
+  },
+  "DivMod128_64": {
+    "best_name": "hi-bits_+_lo-bits_0",
+    "best_value": 38.523291794910975,
+    "median_name": "ufmbits_+_lo-bits_2",
+    "median_value": 55.947764968780504,
+    "worst_name": "ufmbits_+_hi-bits_1",
+    "worst_value": 120.26966627950334
+  },
+  "DivMod16": {
+    "best_name": "ufmbits_+_ufmbits_2",
+    "best_value": 31.57855142762845,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 45.90448040120941,
+    "worst_name": "lo-bits_+_lo-bits_2",
+    "worst_value": 68.03419943501626
+  },
+  "DivMod32": {
+    "best_name": "lo-bits_+_self_1",
+    "best_value": 34.4364516727793,
+    "median_name": "lo-bits_+_lo-bits_2",
+    "median_value": 53.19047319740727,
+    "worst_name": "hi-bits_+_inv_self_1",
+    "worst_value": 71.81397820674036
+  },
+  "DivMod64": {
+    "best_name": "ufmbits_+_hi-bits_2",
+    "best_value": 34.03134305190072,
+    "median_name": "lo-bits_+_inv_self_4",
+    "median_value": 43.044397390132715,
+    "worst_name": "lo-bits_+_self_2",
+    "worst_value": 64.59673820370652
+  },
+  "DivMod8": {
+    "best_name": "ufmbits_+_inv_self_3",
+    "best_value": 30.346183997059256,
+    "median_name": "lo-bits_+_ufmbits_3",
+    "median_value": 43.29011722142261,
+    "worst_name": "hi-bits_+_lo-bits_4",
+    "worst_value": 69.90998845208534
+  },
+  "Divide16": {
+    "best_name": "hi-bits_+_hi-bits_1",
+    "best_value": 28.34853334115327,
+    "median_name": "ufmbits_+_self_0",
+    "median_value": 38.55957732254199,
+    "worst_name": "lo-bits_+_inv_self_2",
+    "worst_value": 58.14784961329238
+  },
+  "Divide32": {
+    "best_name": "ufmbits_+_inv_self_1",
+    "best_value": 30.264511233023526,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 43.97026488836832,
+    "worst_name": "lo-bits_+_self_2",
+    "worst_value": 59.03287306751417
+  },
+  "Divide64": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 31.54754492457042,
+    "median_name": "ufmbits_+_inv_self_0",
+    "median_value": 38.67881577181886,
+    "worst_name": "lo-bits_+_inv_self_2",
+    "worst_value": 53.95682103711165
+  },
+  "Divide8": {
+    "best_name": "lo-bits_+_inv_self_3",
+    "best_value": 29.16900430947983,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 42.1732355038931,
+    "worst_name": "lo-bits_+_hi-bits_2",
+    "worst_value": 67.75780253764945
+  },
+  "Divides16": {
+    "best_name": "hi-bits_+_self_2",
+    "best_value": 30.623648227592295,
+    "median_name": "lo-bits_+_hi-bits_2",
+    "median_value": 47.196282869516,
+    "worst_name": "hi-bits_+_inv_self_2",
+    "worst_value": 62.76204866384907
+  },
+  "Divides32": {
+    "best_name": "ufmbits_+_self_3",
+    "best_value": 26.13825865204317,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 41.13006201701248,
+    "worst_name": "lo-bits_+_ufmbits_0",
+    "worst_value": 52.70964835047321
+  },
+  "Divides64": {
+    "best_name": "ufmbits_+_self_1",
+    "best_value": 30.274290990899182,
+    "median_name": "hi-bits_+_hi-bits_3",
+    "median_value": 39.9387220824441,
+    "worst_name": "ufmbits_+_lo-bits_1",
+    "worst_value": 66.82650830514984
+  },
+  "Divides8": {
+    "best_name": "ufmbits_+_ufmbits_2",
+    "best_value": 28.608542961116083,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 40.41842666224974,
+    "worst_name": "hi-bits_+_self_4",
+    "worst_value": 50.678806642651615
+  },
+  "Eq1": {
+    "best_name": "ufmbits_+_hi-bits_2",
+    "best_value": 22.590077613341418,
+    "median_name": "lo-bits_+_ufmbits_4",
+    "median_value": 31.284809911966637,
+    "worst_name": "hi-bits_+_hi-bits_0",
+    "worst_value": 43.07627577694694
+  },
+  "Eq16": {
+    "best_name": "hi-bits_+_ufmbits_0",
+    "best_value": 26.94817025880549,
+    "median_name": "hi-bits_+_self_1",
+    "median_value": 37.58297398379116,
+    "worst_name": "hi-bits_+_hi-bits_0",
+    "worst_value": 48.35960050660297
+  },
+  "Eq256": {
+    "best_name": "lo-bits_+_hi-bits_1",
+    "best_value": 70.76214904112861,
+    "median_name": "ufmbits_+_ufmbits_1",
+    "median_value": 100.84162955688758,
+    "worst_name": "hi-bits_+_ufmbits_2",
+    "worst_value": 128.4262918666235
+  },
+  "Eq32": {
+    "best_name": "ufmbits_+_self_0",
+    "best_value": 25.914912820866938,
+    "median_name": "lo-bits_+_ufmbits_0",
+    "median_value": 40.55619280889985,
+    "worst_name": "hi-bits_+_inv_self_3",
+    "worst_value": 55.72593218628154
+  },
+  "Eq64": {
+    "best_name": "hi-bits_+_inv_self_2",
+    "best_value": 29.888469948430174,
+    "median_name": "ufmbits_+_ufmbits_3",
+    "median_value": 35.358984996572794,
+    "worst_name": "hi-bits_+_ufmbits_0",
+    "worst_value": 66.6992538614868
+  },
+  "Eq8": {
+    "best_name": "ufmbits_+_self_2",
+    "best_value": 25.733790510691176,
+    "median_name": "hi-bits_+_lo-bits_1",
+    "median_value": 33.34788766334086,
+    "worst_name": "lo-bits_+_hi-bits_1",
+    "worst_value": 48.97346328426309
+  },
+  "FeAdd": {
+    "best_name": "fe_lo-bits_+_self_1",
+    "best_value": 378.12376720898715,
+    "median_name": "fe_hi-bits_+_fe_hi-bits_1",
+    "median_value": 391.27925838804674,
+    "worst_name": "fe_outofrange_+_fe_hi-bits_4",
+    "worst_value": 417.51723050137605
+  },
+  "FeInvert": {
+    "best_name": "fe_outofrange_1",
+    "best_value": 1251.5259237226812,
+    "median_name": "fe_hi-bits_0",
+    "median_value": 1517.5875219399322,
+    "worst_name": "fe_ufmbits_0",
+    "worst_value": 1756.1574560186389
+  },
+  "FeIsOdd": {
+    "best_name": "fe_hi-bits_2",
+    "best_value": 145.8685794349447,
+    "median_name": "fe_ufmbits_0",
+    "median_value": 150.50860863261312,
+    "worst_name": "fe_outofrange_0",
+    "worst_value": 160.8443907492314
+  },
+  "FeIsZero": {
+    "best_name": "fe_ufmbits_4",
+    "best_value": 144.90772873283723,
+    "median_name": "fe_outofrange_0",
+    "median_value": 148.12046094035284,
+    "worst_name": "fe_lo-bits_0",
+    "worst_value": 152.04595505045287
+  },
+  "FeMultiply": {
+    "best_name": "fe_ufmbits_+_fe_ufmbits_2",
+    "best_value": 399.8532052846325,
+    "median_name": "fe_hi-bits_+_fe_outofrange_2",
+    "median_value": 409.94912711513024,
+    "worst_name": "fe_outofrange_+_inv_self_3",
+    "worst_value": 434.2638221853896
+  },
+  "FeMultiplyBeta": {
+    "best_name": "fe_ufmbits_4",
+    "best_value": 287.2847434668351,
+    "median_name": "fe_lo-bits_1",
+    "median_value": 297.564399654947,
+    "worst_name": "fe_outofrange_0",
+    "worst_value": 313.7216000417526
+  },
+  "FeNegate": {
+    "best_name": "fe_ufmbits_4",
+    "best_value": 264.19336119992005,
+    "median_name": "fe_outofrange_3",
+    "median_value": 284.0198730155772,
+    "worst_name": "fe_hi-bits_3",
+    "worst_value": 289.58836261605234
+  },
+  "FeNormalize": {
+    "best_name": "fe_ufmbits_2",
+    "best_value": 274.4779512143182,
+    "median_name": "fe_outofrange_1",
+    "median_value": 285.93615647129997,
+    "worst_name": "fe_hi-bits_3",
+    "worst_value": 289.39875897561114
+  },
+  "FeSquare": {
+    "best_name": "fe_ufmbits_1",
+    "best_value": 288.23585606277044,
+    "median_name": "fe_outofrange_1",
+    "median_value": 304.60893349370167,
+    "worst_name": "fe_outofrange_0",
+    "worst_value": 309.1586162352686
+  },
+  "FeSquareRoot": {
+    "best_name": "fe_ufmbits_4",
+    "best_value": 5610.006244836741,
+    "median_name": "fe_hi-bits_2",
+    "median_value": 5670.409349859018,
+    "worst_name": "fe_outofrange_4",
+    "worst_value": 5718.055423532759
+  },
+  "FullAdd16": {
+    "best_name": "0ufmbits_+_inv_self_2",
+    "best_value": 29.85514042089213,
+    "median_name": "0lo-bits_+_inv_self_4",
+    "median_value": 46.94238020795954,
+    "worst_name": "0ufmbits_+_ufmbits_2",
+    "worst_value": 70.6165901773465
+  },
+  "FullAdd32": {
+    "best_name": "0hi-bits_+_hi-bits_1",
+    "best_value": 29.18359794800582,
+    "median_name": "1ufmbits_+_hi-bits_4",
+    "median_value": 47.47391796388371,
+    "worst_name": "1ufmbits_+_self_3",
+    "worst_value": 66.47514858619118
+  },
+  "FullAdd64": {
+    "best_name": "0lo-bits_+_lo-bits_0",
+    "best_value": 33.5817437439075,
+    "median_name": "1lo-bits_+_lo-bits_3",
+    "median_value": 44.952937708131756,
+    "worst_name": "1ufmbits_+_hi-bits_3",
+    "worst_value": 67.78702097278945
+  },
+  "FullAdd8": {
+    "best_name": "1ufmbits_+_inv_self_3",
+    "best_value": 30.639788930646887,
+    "median_name": "0lo-bits_+_inv_self_3",
+    "median_value": 48.95521012157185,
+    "worst_name": "0ufmbits_+_self_0",
+    "worst_value": 72.60875200624247
+  },
+  "FullDecrement16": {
+    "best_name": "0hi-bits_4",
+    "best_value": 27.271708140313685,
+    "median_name": "1lo-bits_1",
+    "median_value": 30.688283359005045,
+    "worst_name": "0hi-bits_0",
+    "worst_value": 45.52214891722876
+  },
+  "FullDecrement32": {
+    "best_name": "0ufmbits_0",
+    "best_value": 27.815000483710115,
+    "median_name": "1lo-bits_4",
+    "median_value": 36.8309638734577,
+    "worst_name": "0lo-bits_0",
+    "worst_value": 46.023659117788895
+  },
+  "FullDecrement64": {
+    "best_name": "0ufmbits_4",
+    "best_value": 28.371518584030806,
+    "median_name": "1ufmbits_3",
+    "median_value": 36.95923767908259,
+    "worst_name": "1hi-bits_2",
+    "worst_value": 47.40239414850399
+  },
+  "FullDecrement8": {
+    "best_name": "0hi-bits_1",
+    "best_value": 28.063256223643066,
+    "median_name": "1ufmbits_1",
+    "median_value": 37.00876665142771,
+    "worst_name": "1lo-bits_2",
+    "worst_value": 42.3230166908851
+  },
+  "FullIncrement16": {
+    "best_name": "0ufmbits_4",
+    "best_value": 27.50287131726876,
+    "median_name": "1ufmbits_4",
+    "median_value": 29.153870199880174,
+    "worst_name": "1lo-bits_3",
+    "worst_value": 50.544570298000345
+  },
+  "FullIncrement32": {
+    "best_name": "0hi-bits_2",
+    "best_value": 27.366029353913767,
+    "median_name": "0lo-bits_0",
+    "median_value": 38.643784840617535,
+    "worst_name": "1lo-bits_0",
+    "worst_value": 49.47082176389551
+  },
+  "FullIncrement64": {
+    "best_name": "0hi-bits_3",
+    "best_value": 27.680364178569718,
+    "median_name": "1lo-bits_0",
+    "median_value": 40.363763644970454,
+    "worst_name": "1ufmbits_3",
+    "worst_value": 49.82074643438196
+  },
+  "FullIncrement8": {
+    "best_name": "1lo-bits_2",
+    "best_value": 28.52751098858125,
+    "median_name": "0lo-bits_2",
+    "median_value": 39.83681655911636,
+    "worst_name": "1hi-bits_0",
+    "worst_value": 51.987429761468135
+  },
+  "FullLeftShift16_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.171258240278814,
+    "median_name": "hi-bits_4",
+    "median_value": 35.536440931795994,
+    "worst_name": "ufmbits_1",
+    "worst_value": 43.418593978045564
+  },
+  "FullLeftShift16_2": {
+    "best_name": "hi-bits_4",
+    "best_value": 44.061667829635354,
+    "median_name": "lo-bits_4",
+    "median_value": 48.207605970319456,
+    "worst_name": "hi-bits_3",
+    "worst_value": 50.18076888649324
+  },
+  "FullLeftShift16_4": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.319229711491097,
+    "median_name": "hi-bits_3",
+    "median_value": 41.380421479824115,
+    "worst_name": "lo-bits_1",
+    "worst_value": 43.642721227034826
+  },
+  "FullLeftShift16_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 41.67080438972363,
+    "median_name": "ufmbits_3",
+    "median_value": 46.61782645038631,
+    "worst_name": "lo-bits_4",
+    "worst_value": 51.25244192111862
+  },
+  "FullLeftShift32_1": {
+    "best_name": "ufmbits_0",
+    "best_value": 41.254984637743085,
+    "median_name": "hi-bits_3",
+    "median_value": 43.2826930847888,
+    "worst_name": "hi-bits_1",
+    "worst_value": 46.93973502705942
+  },
+  "FullLeftShift32_16": {
+    "best_name": "ufmbits_1",
+    "best_value": 29.411353913360255,
+    "median_name": "hi-bits_3",
+    "median_value": 34.025316500108836,
+    "worst_name": "lo-bits_1",
+    "worst_value": 55.93780996708993
+  },
+  "FullLeftShift32_2": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.130348166819136,
+    "median_name": "lo-bits_3",
+    "median_value": 31.788767857429708,
+    "worst_name": "hi-bits_1",
+    "worst_value": 34.378320692689
+  },
+  "FullLeftShift32_4": {
+    "best_name": "hi-bits_2",
+    "best_value": 31.902714571006115,
+    "median_name": "lo-bits_1",
+    "median_value": 42.61279692775301,
+    "worst_name": "ufmbits_2",
+    "worst_value": 50.10846211477976
+  },
+  "FullLeftShift32_8": {
+    "best_name": "lo-bits_1",
+    "best_value": 30.761713264905314,
+    "median_name": "hi-bits_0",
+    "median_value": 49.659953285200906,
+    "worst_name": "hi-bits_2",
+    "worst_value": 73.77160837396418
+  },
+  "FullLeftShift64_1": {
+    "best_name": "hi-bits_1",
+    "best_value": 29.104177182762484,
+    "median_name": "lo-bits_2",
+    "median_value": 44.14801703510433,
+    "worst_name": "ufmbits_3",
+    "worst_value": 52.71266079096654
+  },
+  "FullLeftShift64_16": {
+    "best_name": "hi-bits_4",
+    "best_value": 47.11825651682498,
+    "median_name": "ufmbits_0",
+    "median_value": 52.07600833498339,
+    "worst_name": "lo-bits_4",
+    "worst_value": 56.618328652381685
+  },
+  "FullLeftShift64_2": {
+    "best_name": "lo-bits_3",
+    "best_value": 30.49550723891108,
+    "median_name": "hi-bits_4",
+    "median_value": 31.030739251291493,
+    "worst_name": "ufmbits_2",
+    "worst_value": 44.94504387519696
+  },
+  "FullLeftShift64_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 42.7052781050872,
+    "median_name": "lo-bits_2",
+    "median_value": 46.70106254749814,
+    "worst_name": "hi-bits_0",
+    "worst_value": 52.129356592565536
+  },
+  "FullLeftShift64_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 32.51376571630294,
+    "median_name": "lo-bits_4",
+    "median_value": 44.70740202685633,
+    "worst_name": "lo-bits_1",
+    "worst_value": 46.420040331524696
+  },
+  "FullLeftShift64_8": {
+    "best_name": "ufmbits_4",
+    "best_value": 35.96282508110053,
+    "median_name": "lo-bits_0",
+    "median_value": 42.65274473408669,
+    "worst_name": "hi-bits_4",
+    "worst_value": 44.51702410290297
+  },
+  "FullLeftShift8_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.680360961098053,
+    "median_name": "hi-bits_3",
+    "median_value": 28.248858376822295,
+    "worst_name": "ufmbits_2",
+    "worst_value": 43.070156342997855
+  },
+  "FullLeftShift8_2": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.2917120372058,
+    "median_name": "lo-bits_3",
+    "median_value": 34.3475096849884,
+    "worst_name": "hi-bits_0",
+    "worst_value": 43.63527490639047
+  },
+  "FullLeftShift8_4": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.00649467266622,
+    "median_name": "lo-bits_3",
+    "median_value": 35.707553242480955,
+    "worst_name": "hi-bits_4",
+    "worst_value": 40.51601011158293
+  },
+  "FullMultiply16": {
+    "best_name": "hi-bits_+_hi-bits_4",
+    "best_value": 33.78367421540215,
+    "median_name": "ufmbits_+_hi-bits_0",
+    "median_value": 48.104210982067606,
+    "worst_name": "lo-bits_+_ufmbits_2",
+    "worst_value": 65.73842316130298
+  },
+  "FullMultiply32": {
+    "best_name": "lo-bits_+_inv_self_4",
+    "best_value": 33.75313901462724,
+    "median_name": "hi-bits_+_lo-bits_1",
+    "median_value": 41.26113818433125,
+    "worst_name": "hi-bits_+_self_2",
+    "worst_value": 56.5247952542744
+  },
+  "FullMultiply64": {
+    "best_name": "hi-bits_+_lo-bits_2",
+    "best_value": 39.65107945895812,
+    "median_name": "ufmbits_+_lo-bits_1",
+    "median_value": 53.54594249872857,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 88.069307411204
+  },
+  "FullMultiply8": {
+    "best_name": "ufmbits_+_hi-bits_2",
+    "best_value": 34.73640951239665,
+    "median_name": "ufmbits_+_inv_self_4",
+    "median_value": 54.071196709152744,
+    "worst_name": "hi-bits_+_ufmbits_1",
+    "worst_value": 64.82584293323661
+  },
+  "FullRightShift16_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.378882445253684,
+    "median_name": "hi-bits_3",
+    "median_value": 28.475648956288083,
+    "worst_name": "ufmbits_1",
+    "worst_value": 44.98928806180913
+  },
+  "FullRightShift16_2": {
+    "best_name": "hi-bits_0",
+    "best_value": 26.20057853004031,
+    "median_name": "ufmbits_1",
+    "median_value": 36.00325690030059,
+    "worst_name": "lo-bits_2",
+    "worst_value": 39.46428863917301
+  },
+  "FullRightShift16_4": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.443391905572163,
+    "median_name": "hi-bits_4",
+    "median_value": 27.054851540366805,
+    "worst_name": "lo-bits_2",
+    "worst_value": 36.25833500235247
+  },
+  "FullRightShift16_8": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.732324972935672,
+    "median_name": "ufmbits_0",
+    "median_value": 33.174774898633544,
+    "worst_name": "hi-bits_1",
+    "worst_value": 40.98228308024532
+  },
+  "FullRightShift32_1": {
+    "best_name": "hi-bits_0",
+    "best_value": 30.947992546169008,
+    "median_name": "lo-bits_3",
+    "median_value": 41.77531363406747,
+    "worst_name": "lo-bits_4",
+    "worst_value": 44.42836913566853
+  },
+  "FullRightShift32_16": {
+    "best_name": "hi-bits_3",
+    "best_value": 31.077519932452045,
+    "median_name": "lo-bits_2",
+    "median_value": 33.94806134036312,
+    "worst_name": "ufmbits_0",
+    "worst_value": 48.49148926373205
+  },
+  "FullRightShift32_2": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.89962533811757,
+    "median_name": "hi-bits_1",
+    "median_value": 30.515583012396842,
+    "worst_name": "ufmbits_1",
+    "worst_value": 50.74788633495534
+  },
+  "FullRightShift32_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 30.058094387345427,
+    "median_name": "lo-bits_3",
+    "median_value": 34.228384019785665,
+    "worst_name": "ufmbits_0",
+    "worst_value": 47.77335917279703
+  },
+  "FullRightShift32_8": {
+    "best_name": "lo-bits_3",
+    "best_value": 29.998650764566463,
+    "median_name": "ufmbits_3",
+    "median_value": 37.38708061736188,
+    "worst_name": "hi-bits_0",
+    "worst_value": 52.80931871609402
+  },
+  "FullRightShift64_1": {
+    "best_name": "hi-bits_0",
+    "best_value": 35.73726148778305,
+    "median_name": "ufmbits_4",
+    "median_value": 44.118062542681564,
+    "worst_name": "lo-bits_4",
+    "worst_value": 57.353879120958574
+  },
+  "FullRightShift64_16": {
+    "best_name": "hi-bits_4",
+    "best_value": 29.99662442754253,
+    "median_name": "ufmbits_3",
+    "median_value": 45.008345930989655,
+    "worst_name": "lo-bits_0",
+    "worst_value": 54.37855440250373
+  },
+  "FullRightShift64_2": {
+    "best_name": "lo-bits_2",
+    "best_value": 39.55275276969633,
+    "median_name": "ufmbits_3",
+    "median_value": 48.696522507820426,
+    "worst_name": "hi-bits_1",
+    "worst_value": 56.00176195138319
+  },
+  "FullRightShift64_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 30.07988938628751,
+    "median_name": "ufmbits_0",
+    "median_value": 42.29834953130646,
+    "worst_name": "lo-bits_3",
+    "worst_value": 45.9351590383812
+  },
+  "FullRightShift64_4": {
+    "best_name": "lo-bits_1",
+    "best_value": 46.91042044505177,
+    "median_name": "hi-bits_0",
+    "median_value": 49.649648334429386,
+    "worst_name": "hi-bits_4",
+    "worst_value": 56.506289739757214
+  },
+  "FullRightShift64_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 33.87774764962701,
+    "median_name": "hi-bits_1",
+    "median_value": 50.07082400342088,
+    "worst_name": "lo-bits_4",
+    "worst_value": 62.505244565765715
+  },
+  "FullRightShift8_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.682804141624203,
+    "median_name": "ufmbits_3",
+    "median_value": 40.057244835134924,
+    "worst_name": "hi-bits_2",
+    "worst_value": 60.09111862850254
+  },
+  "FullRightShift8_2": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.212270441375125,
+    "median_name": "lo-bits_1",
+    "median_value": 38.962429755428886,
+    "worst_name": "hi-bits_4",
+    "worst_value": 42.76510576917889
+  },
+  "FullRightShift8_4": {
+    "best_name": "hi-bits_1",
+    "best_value": 25.146194823822665,
+    "median_name": "ufmbits_2",
+    "median_value": 41.441950855610145,
+    "worst_name": "lo-bits_1",
+    "worst_value": 44.22856593482136
+  },
+  "FullSubtract16": {
+    "best_name": "0ufmbits_+_self_0",
+    "best_value": 30.183564523354562,
+    "median_name": "1hi-bits_+_lo-bits_1",
+    "median_value": 50.193445672547895,
+    "worst_name": "1ufmbits_+_inv_self_3",
+    "worst_value": 68.0556456814119
+  },
+  "FullSubtract32": {
+    "best_name": "0ufmbits_+_self_0",
+    "best_value": 29.984275411993167,
+    "median_name": "0lo-bits_+_self_4",
+    "median_value": 46.51343438178178,
+    "worst_name": "0ufmbits_+_ufmbits_4",
+    "worst_value": 65.63001068357167
+  },
+  "FullSubtract64": {
+    "best_name": "0ufmbits_+_hi-bits_4",
+    "best_value": 33.24696718664882,
+    "median_name": "0ufmbits_+_inv_self_3",
+    "median_value": 41.03527177867695,
+    "worst_name": "1lo-bits_+_self_0",
+    "worst_value": 60.70104812071798
+  },
+  "FullSubtract8": {
+    "best_name": "1lo-bits_+_self_4",
+    "best_value": 29.924040789056793,
+    "median_name": "0lo-bits_+_ufmbits_1",
+    "median_value": 55.561784768820154,
+    "worst_name": "1lo-bits_+_ufmbits_4",
+    "worst_value": 75.1369577701631
+  },
+  "GeIsOnCurve": {
+    "best_name": "ge_offc_fe_lo-bits_1",
+    "best_value": 337.8799070285193,
+    "median_name": "ge_oncurve_1",
+    "median_value": 345.63391457470493,
+    "worst_name": "ge_offc_fe_outofrange_1",
+    "worst_value": 355.14024121006673
+  },
+  "GeNegate": {
+    "best_name": "ge_offc_fe_ufmbits_2",
+    "best_value": 501.5868549058529,
+    "median_name": "ge_offc_fe_ufmbits_3",
+    "median_value": 515.0967454026857,
+    "worst_name": "ge_offc_fe_lo-bits_2",
+    "worst_value": 536.8126563953377
+  },
+  "GejAdd": {
+    "best_name": "gej_zero_fe_ufmbits_+_gej_offc_fe_ufmbits_2",
+    "best_value": 1077.5574785290164,
+    "median_name": "gej_zero_fe_lo-bits_+_gej_zero_fe_outofrange_1",
+    "median_value": 1148.747118913871,
+    "worst_name": "gej_offc_fe_outofrange_+_gej_offc_fe_outofrange_4",
+    "worst_value": 1606.1652691506158
+  },
+  "GejDouble": {
+    "best_name": "gej_zero_fe_ufmbits_4",
+    "best_value": 733.2569058967964,
+    "median_name": "gej_offc_fe_lo-bits_1",
+    "median_value": 918.3714063740059,
+    "worst_name": "gej_offc_fe_outofrange_0",
+    "worst_value": 987.7293452301241
+  },
+  "GejEquiv": {
+    "best_name": "gej_zero_fe_ufmbits_+_gej_zero_fe_lo-bits_0",
+    "best_value": 711.9174579921906,
+    "median_name": "gej_zero_fe_outofrange_+_gej_zero_fe_lo-bits_0",
+    "median_value": 772.2146278954298,
+    "worst_name": "gej_offc_fe_outofrange_+_gej_offc_fe_outofrange_4",
+    "worst_value": 1235.1747785031941
+  },
+  "GejGeAdd": {
+    "best_name": "gej_zero_fe_ufmbits_+_ge_offc_fe_ufmbits_1",
+    "best_value": 949.6474722585425,
+    "median_name": "gej_offc_fe_ufmbits_+_ge_offc_fe_ufmbits_0",
+    "median_value": 1255.4232007885416,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_2",
+    "worst_value": 1388.6833166588985
+  },
+  "GejGeAddEx": {
+    "best_name": "gej_zero_fe_lo-bits_+_ge_offc_fe_lo-bits_0",
+    "best_value": 1047.9915106910967,
+    "median_name": "gej_offc_fe_lo-bits_+_ge_offc_fe_ufmbits_4",
+    "median_value": 1370.7204252537051,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_1",
+    "worst_value": 1501.4729085624408
+  },
+  "GejGeEquiv": {
+    "best_name": "gej_zero_fe_ufmbits_+_ge_oncurve_2",
+    "best_value": 620.058802824293,
+    "median_name": "gej_offc_fe_ufmbits_+_ge_offc_fe_ufmbits_4",
+    "median_value": 890.0545470464649,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_4",
+    "worst_value": 1007.7513377403083
+  },
+  "GejInfinity": {
+    "best_name": "unit_1",
+    "best_value": 377.44094125445366,
+    "median_name": "unit_2",
+    "median_value": 387.8469503991562,
+    "worst_name": "unit_4",
+    "worst_value": 389.07590612144975
+  },
+  "GejIsInfinity": {
+    "best_name": "gej_zero_fe_ufmbits_2",
+    "best_value": 352.0573668621726,
+    "median_name": "gej_zero_fe_hi-bits_0",
+    "median_value": 367.8357909728597,
+    "worst_name": "gej_oncurve_4",
+    "worst_value": 374.32130675269315
+  },
+  "GejIsOnCurve": {
+    "best_name": "gej_zero_fe_ufmbits_3",
+    "best_value": 512.645739058317,
+    "median_name": "gej_zero_fe_hi-bits_1",
+    "median_value": 539.7148254676989,
+    "worst_name": "gej_offc_fe_outofrange_3",
+    "worst_value": 559.7726036198599
+  },
+  "GejNegate": {
+    "best_name": "gej_zero_fe_ufmbits_4",
+    "best_value": 746.5983806096384,
+    "median_name": "gej_oncurve_0",
+    "median_value": 782.5797445620515,
+    "worst_name": "gej_offc_fe_outofrange_1",
+    "worst_value": 802.5625795728412
+  },
+  "GejNormalize": {
+    "best_name": "gej_zero_fe_ufmbits_2",
+    "best_value": 366.45424937981113,
+    "median_name": "gej_offc_fe_lo-bits_4",
+    "median_value": 1746.2042921115492,
+    "worst_name": "gej_oncurve_1",
+    "worst_value": 2280.0637874396016
+  },
+  "GejRescale": {
+    "best_name": "gej_zero_fe_lo-bits_+_fe_lo-bits_4",
+    "best_value": 974.724245409485,
+    "median_name": "gej_offc_fe_outofrange_+_fe_lo-bits_2",
+    "median_value": 1014.7900592599165,
+    "worst_name": "gej_zero_fe_outofrange_+_fe_ufmbits_3",
+    "worst_value": 1067.872665211341
+  },
+  "GejXEquiv": {
+    "best_name": "fe_ufmbits_+_gej_zero_fe_lo-bits_0",
+    "best_value": 477.05852546457436,
+    "median_name": "fe_outofrange_+_gej_offc_fe_lo-bits_4",
+    "median_value": 538.07086987095,
+    "worst_name": "fe_outofrange_+_gej_offc_fe_outofrange_3",
+    "worst_value": 575.6376393432541
+  },
+  "GejYIsOdd": {
+    "best_name": "gej_zero_fe_ufmbits_2",
+    "best_value": 363.2708967207405,
+    "median_name": "gej_offc_fe_outofrange_0",
+    "median_value": 1503.7671983556302,
+    "worst_name": "gej_oncurve_4",
+    "worst_value": 2019.178423146296
+  },
+  "Generate": {
+    "best_name": "sc_lo-bits_3",
+    "best_value": 15709.2896481366,
+    "median_name": "sc_hi-bits_3",
+    "median_value": 24868.830835961602,
+    "worst_name": "sc_ufmbits_3",
+    "worst_value": 27940.896637670892
+  },
+  "GenesisBlockHash": {
+    "best_name": "44",
+    "best_value": 42.99883718482313,
+    "median_name": "46",
+    "median_value": 53.69610202827932,
+    "worst_name": "34",
+    "worst_value": 77.75508479921861
+  },
+  "HashToCurve": {
+    "best_name": "hi-bits_4",
+    "best_value": 37628.4714425572,
+    "median_name": "lo-bits_3",
+    "median_value": 37654.62942183973,
+    "worst_name": "ufmbits_0",
+    "worst_value": 37720.323095689
+  },
+  "High1": {
+    "best_name": "unit_0",
+    "best_value": 27.591306763894615,
+    "median_name": "unit_4",
+    "median_value": 30.440276208657203,
+    "worst_name": "unit_3",
+    "worst_value": 32.13169762045902
+  },
+  "High16": {
+    "best_name": "unit_4",
+    "best_value": 24.45714075657291,
+    "median_name": "unit_3",
+    "median_value": 24.597072353356822,
+    "worst_name": "unit_2",
+    "worst_value": 25.437653125431623
+  },
+  "High32": {
+    "best_name": "unit_1",
+    "best_value": 32.07912983811914,
+    "median_name": "unit_0",
+    "median_value": 34.65168078136531,
+    "worst_name": "unit_4",
+    "worst_value": 35.72853516001585
+  },
+  "High64": {
+    "best_name": "unit_0",
+    "best_value": 23.778691337481764,
+    "median_name": "unit_4",
+    "median_value": 23.9693975290508,
+    "worst_name": "unit_1",
+    "worst_value": 24.31700488423272
+  },
+  "High8": {
+    "best_name": "unit_2",
+    "best_value": 23.89089159540107,
+    "median_name": "unit_1",
+    "median_value": 24.14412461406451,
+    "worst_name": "unit_4",
+    "worst_value": 25.234651307904336
+  },
+  "Increment16": {
+    "best_name": "lo-bits_2",
+    "best_value": 27.75867075185556,
+    "median_name": "lo-bits_4",
+    "median_value": 38.13123244541155,
+    "worst_name": "ufmbits_3",
+    "worst_value": 48.8594249744026
+  },
+  "Increment32": {
+    "best_name": "lo-bits_3",
+    "best_value": 27.370332428436686,
+    "median_name": "hi-bits_4",
+    "median_value": 28.88780634269319,
+    "worst_name": "lo-bits_2",
+    "worst_value": 32.88366006613396
+  },
+  "Increment64": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.401904805541093,
+    "median_name": "hi-bits_1",
+    "median_value": 30.99931180541569,
+    "worst_name": "ufmbits_4",
+    "worst_value": 44.004247420079984
+  },
+  "Increment8": {
+    "best_name": "lo-bits_2",
+    "best_value": 28.641407785685214,
+    "median_name": "hi-bits_4",
+    "median_value": 34.721739802218444,
+    "worst_name": "ufmbits_3",
+    "worst_value": 37.43640651348743
+  },
+  "InputAmountsHash": {
+    "best_name": "6",
+    "best_value": 40.3556753997387,
+    "median_name": "7",
+    "median_value": 51.13017977905766,
+    "worst_name": "67",
+    "worst_value": 71.69346690587541
+  },
+  "InputAnnexesHash": {
+    "best_name": "17",
+    "best_value": 40.92308296229633,
+    "median_name": "69",
+    "median_value": 55.64194109816313,
+    "worst_name": "80",
+    "worst_value": 75.28311029581201
+  },
+  "InputOutpointsHash": {
+    "best_name": "13",
+    "best_value": 40.539306868106905,
+    "median_name": "67",
+    "median_value": 52.821869376604106,
+    "worst_name": "48",
+    "worst_value": 78.1488519787418
+  },
+  "InputScriptSigsHash": {
+    "best_name": "81",
+    "best_value": 38.82154726938242,
+    "median_name": "78",
+    "median_value": 51.50967281860082,
+    "worst_name": "54",
+    "worst_value": 75.53635658967248
+  },
+  "InputScriptsHash": {
+    "best_name": "75",
+    "best_value": 38.8258785411508,
+    "median_name": "85",
+    "median_value": 53.17631558870549,
+    "worst_name": "34",
+    "worst_value": 72.96712280180809
+  },
+  "InputSequencesHash": {
+    "best_name": "41",
+    "best_value": 40.58753557090596,
+    "median_name": "24",
+    "median_value": 56.62554164992109,
+    "worst_name": "54",
+    "worst_value": 73.28373240853792
+  },
+  "InputUtxosHash": {
+    "best_name": "2",
+    "best_value": 39.65763535736712,
+    "median_name": "36",
+    "median_value": 52.51832525124844,
+    "worst_name": "29",
+    "worst_value": 71.01082647005843
+  },
+  "InputsHash": {
+    "best_name": "82",
+    "best_value": 38.736165256251894,
+    "median_name": "36",
+    "median_value": 50.458159048469305,
+    "worst_name": "49",
+    "worst_value": 73.2696100223016
+  },
+  "InternalKey": {
+    "best_name": "90",
+    "best_value": 39.745062821836875,
+    "median_name": "3",
+    "median_value": 52.67714302558508,
+    "worst_name": "56",
+    "worst_value": 75.44766414030477
+  },
+  "IsOne16": {
+    "best_name": "hi-bits_1",
+    "best_value": 39.281591840349556,
+    "median_name": "ufmbits_2",
+    "median_value": 41.39409538721141,
+    "worst_name": "lo-bits_3",
+    "worst_value": 49.73968322375209
+  },
+  "IsOne32": {
+    "best_name": "lo-bits_3",
+    "best_value": 28.417234329393473,
+    "median_name": "ufmbits_3",
+    "median_value": 43.357639445426614,
+    "worst_name": "hi-bits_0",
+    "worst_value": 49.02475154909595
+  },
+  "IsOne64": {
+    "best_name": "lo-bits_1",
+    "best_value": 28.910447904070875,
+    "median_name": "ufmbits_3",
+    "median_value": 39.24709031929027,
+    "worst_name": "hi-bits_4",
+    "worst_value": 46.64868526662566
+  },
+  "IsOne8": {
+    "best_name": "ufmbits_2",
+    "best_value": 29.674347944807067,
+    "median_name": "hi-bits_0",
+    "median_value": 43.25506992361261,
+    "worst_name": "lo-bits_4",
+    "worst_value": 50.74294666763885
+  },
+  "IsZero16": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.569257921802915,
+    "median_name": "lo-bits_1",
+    "median_value": 30.802596040479806,
+    "worst_name": "hi-bits_3",
+    "worst_value": 45.68423847671235
+  },
+  "IsZero32": {
+    "best_name": "ufmbits_2",
+    "best_value": 30.461114996937386,
+    "median_name": "hi-bits_2",
+    "median_value": 51.00948019579031,
+    "worst_name": "lo-bits_4",
+    "worst_value": 56.120674092643824
+  },
+  "IsZero64": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.435575021924965,
+    "median_name": "hi-bits_0",
+    "median_value": 29.906048969338762,
+    "worst_name": "lo-bits_4",
+    "worst_value": 53.91015710529782
+  },
+  "IsZero8": {
+    "best_name": "hi-bits_4",
+    "best_value": 27.85403525716155,
+    "median_name": "hi-bits_0",
+    "median_value": 33.79855182257809,
+    "worst_name": "lo-bits_4",
+    "worst_value": 51.70924454334877
+  },
+  "IssuanceAssetAmountsHash": {
+    "best_name": "98",
+    "best_value": 40.4962305307176,
+    "median_name": "10",
+    "median_value": 49.03166178908395,
+    "worst_name": "71",
+    "worst_value": 75.72407411580376
+  },
+  "IssuanceBlindingEntropyHash": {
+    "best_name": "80",
+    "best_value": 40.23913670511314,
+    "median_name": "4",
+    "median_value": 54.95779101869334,
+    "worst_name": "75",
+    "worst_value": 72.75226753502201
+  },
+  "IssuanceRangeProofsHash": {
+    "best_name": "5",
+    "best_value": 38.7040402421017,
+    "median_name": "31",
+    "median_value": 51.78171308899242,
+    "worst_name": "87",
+    "worst_value": 73.95560796755903
+  },
+  "IssuanceTokenAmountsHash": {
+    "best_name": "93",
+    "best_value": 38.88901438890955,
+    "median_name": "87",
+    "median_value": 51.00213817941559,
+    "worst_name": "97",
+    "worst_value": 73.78284390821575
+  },
+  "IssuancesHash": {
+    "best_name": "73",
+    "best_value": 38.69349203816794,
+    "median_name": "85",
+    "median_value": 51.98350036698837,
+    "worst_name": "59",
+    "worst_value": 74.83393232790067
+  },
+  "LbtcAsset": {
+    "best_name": "15",
+    "best_value": 44.109317527976756,
+    "median_name": "19",
+    "median_value": 62.12961330522515,
+    "worst_name": "60",
+    "worst_value": 80.15704529219734
+  },
+  "Le16": {
+    "best_name": "ufmbits_+_self_2",
+    "best_value": 26.19557732772635,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 45.59239120082439,
+    "worst_name": "ufmbits_+_ufmbits_3",
+    "worst_value": 67.87125535773998
+  },
+  "Le32": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 28.509566401005323,
+    "median_name": "ufmbits_+_lo-bits_3",
+    "median_value": 40.018392924808076,
+    "worst_name": "hi-bits_+_hi-bits_4",
+    "worst_value": 68.44442697228918
+  },
+  "Le64": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 30.218054581712064,
+    "median_name": "ufmbits_+_inv_self_1",
+    "median_value": 39.001652125378875,
+    "worst_name": "lo-bits_+_inv_self_4",
+    "worst_value": 52.60497940598762
+  },
+  "Le8": {
+    "best_name": "hi-bits_+_lo-bits_3",
+    "best_value": 34.197984519685974,
+    "median_name": "lo-bits_+_self_3",
+    "median_value": 47.41574022833459,
+    "worst_name": "lo-bits_+_lo-bits_1",
+    "worst_value": 64.7169588542029
+  },
+  "LeftExtend16_32": {
+    "best_name": "lo-bits_2",
+    "best_value": 26.651454658706676,
+    "median_name": "hi-bits_1",
+    "median_value": 28.08559075617968,
+    "worst_name": "lo-bits_1",
+    "worst_value": 40.84750826051931
+  },
+  "LeftExtend16_64": {
+    "best_name": "ufmbits_1",
+    "best_value": 31.331981616224923,
+    "median_name": "hi-bits_4",
+    "median_value": 48.237791787759676,
+    "worst_name": "lo-bits_3",
+    "worst_value": 61.09853317469145
+  },
+  "LeftExtend1_16": {
+    "best_name": "lo-bits_3",
+    "best_value": 21.734445918227085,
+    "median_name": "hi-bits_2",
+    "median_value": 33.38156118167774,
+    "worst_name": "ufmbits_0",
+    "worst_value": 35.42954065286943
+  },
+  "LeftExtend1_32": {
+    "best_name": "lo-bits_3",
+    "best_value": 22.514549848958428,
+    "median_name": "hi-bits_4",
+    "median_value": 31.536851113056567,
+    "worst_name": "ufmbits_0",
+    "worst_value": 34.237324672979256
+  },
+  "LeftExtend1_64": {
+    "best_name": "lo-bits_4",
+    "best_value": 23.12730451024051,
+    "median_name": "ufmbits_4",
+    "median_value": 24.569780388216937,
+    "worst_name": "ufmbits_3",
+    "worst_value": 29.578064002565693
+  },
+  "LeftExtend1_8": {
+    "best_name": "hi-bits_3",
+    "best_value": 33.03125098894296,
+    "median_name": "lo-bits_3",
+    "median_value": 39.52233344179954,
+    "worst_name": "ufmbits_3",
+    "worst_value": 42.086101561012555
+  },
+  "LeftExtend32_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 29.742036150223644,
+    "median_name": "lo-bits_3",
+    "median_value": 36.970412878489896,
+    "worst_name": "ufmbits_0",
+    "worst_value": 43.569778759196424
+  },
+  "LeftExtend8_16": {
+    "best_name": "hi-bits_1",
+    "best_value": 28.24506553969633,
+    "median_name": "lo-bits_3",
+    "median_value": 35.50688167322563,
+    "worst_name": "lo-bits_4",
+    "worst_value": 39.715286772882266
+  },
+  "LeftExtend8_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 48.0359593583346,
+    "median_name": "lo-bits_4",
+    "median_value": 53.44911739040809,
+    "worst_name": "ufmbits_3",
+    "worst_value": 60.24630665111138
+  },
+  "LeftExtend8_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 46.20724018375985,
+    "median_name": "ufmbits_2",
+    "median_value": 47.30348901177951,
+    "worst_name": "hi-bits_4",
+    "worst_value": 50.719623509598186
+  },
+  "LeftPadHigh16_32": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.614598132075425,
+    "median_name": "lo-bits_1",
+    "median_value": 48.41983316425003,
+    "worst_name": "hi-bits_4",
+    "worst_value": 56.975972618738595
+  },
+  "LeftPadHigh16_64": {
+    "best_name": "ufmbits_2",
+    "best_value": 40.2585341121703,
+    "median_name": "hi-bits_0",
+    "median_value": 48.46518339853637,
+    "worst_name": "lo-bits_0",
+    "worst_value": 51.40072907036014
+  },
+  "LeftPadHigh1_16": {
+    "best_name": "hi-bits_1",
+    "best_value": 51.648890578466926,
+    "median_name": "lo-bits_0",
+    "median_value": 62.74571735817174,
+    "worst_name": "ufmbits_4",
+    "worst_value": 89.51745627819578
+  },
+  "LeftPadHigh1_32": {
+    "best_name": "ufmbits_2",
+    "best_value": 84.72893925661234,
+    "median_name": "hi-bits_2",
+    "median_value": 98.21555890213148,
+    "worst_name": "lo-bits_2",
+    "worst_value": 107.57828275184876
+  },
+  "LeftPadHigh1_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 156.23332835122764,
+    "median_name": "ufmbits_1",
+    "median_value": 208.4782302981634,
+    "worst_name": "hi-bits_3",
+    "worst_value": 221.14036339499887
+  },
+  "LeftPadHigh1_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 32.81262815634911,
+    "median_name": "hi-bits_0",
+    "median_value": 42.690889635711386,
+    "worst_name": "lo-bits_1",
+    "worst_value": 50.727977484541604
+  },
+  "LeftPadHigh32_64": {
+    "best_name": "lo-bits_2",
+    "best_value": 30.76470139455958,
+    "median_name": "lo-bits_1",
+    "median_value": 37.05723865884556,
+    "worst_name": "lo-bits_0",
+    "worst_value": 39.700015933036966
+  },
+  "LeftPadHigh8_16": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.260180209372024,
+    "median_name": "lo-bits_4",
+    "median_value": 30.054105387113555,
+    "worst_name": "ufmbits_4",
+    "worst_value": 39.90983583575278
+  },
+  "LeftPadHigh8_32": {
+    "best_name": "lo-bits_2",
+    "best_value": 37.562278445285564,
+    "median_name": "lo-bits_4",
+    "median_value": 45.55299876314076,
+    "worst_name": "hi-bits_4",
+    "worst_value": 54.265437493136716
+  },
+  "LeftPadHigh8_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 46.96196256376964,
+    "median_name": "ufmbits_4",
+    "median_value": 47.667419604790055,
+    "worst_name": "hi-bits_3",
+    "worst_value": 85.07659041357105
+  },
+  "LeftPadLow16_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 25.451223225728132,
+    "median_name": "hi-bits_1",
+    "median_value": 35.15417770259389,
+    "worst_name": "lo-bits_3",
+    "worst_value": 39.48077126028267
+  },
+  "LeftPadLow16_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 37.35065486086073,
+    "median_name": "lo-bits_3",
+    "median_value": 41.30732783091461,
+    "worst_name": "hi-bits_0",
+    "worst_value": 45.11655216131774
+  },
+  "LeftPadLow1_16": {
+    "best_name": "ufmbits_3",
+    "best_value": 27.45327040889639,
+    "median_name": "hi-bits_1",
+    "median_value": 33.910770504945795,
+    "worst_name": "lo-bits_3",
+    "worst_value": 36.754831460140025
+  },
+  "LeftPadLow1_32": {
+    "best_name": "ufmbits_1",
+    "best_value": 25.229582304202992,
+    "median_name": "lo-bits_4",
+    "median_value": 30.07227818336682,
+    "worst_name": "hi-bits_1",
+    "worst_value": 41.62308123502083
+  },
+  "LeftPadLow1_64": {
+    "best_name": "ufmbits_3",
+    "best_value": 24.443396961420003,
+    "median_name": "lo-bits_2",
+    "median_value": 34.365477828724906,
+    "worst_name": "lo-bits_1",
+    "worst_value": 37.45929067100587
+  },
+  "LeftPadLow1_8": {
+    "best_name": "ufmbits_4",
+    "best_value": 23.28627445958008,
+    "median_name": "hi-bits_1",
+    "median_value": 31.420161776590998,
+    "worst_name": "lo-bits_4",
+    "worst_value": 38.89294929218326
+  },
+  "LeftPadLow32_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.88738992018783,
+    "median_name": "hi-bits_0",
+    "median_value": 36.828602902478394,
+    "worst_name": "ufmbits_2",
+    "worst_value": 49.276554793583294
+  },
+  "LeftPadLow8_16": {
+    "best_name": "lo-bits_3",
+    "best_value": 35.95140795361388,
+    "median_name": "ufmbits_0",
+    "median_value": 38.73082446211725,
+    "worst_name": "hi-bits_2",
+    "worst_value": 47.74166294136041
+  },
+  "LeftPadLow8_32": {
+    "best_name": "hi-bits_3",
+    "best_value": 31.67860354092418,
+    "median_name": "ufmbits_0",
+    "median_value": 32.664310456825795,
+    "worst_name": "lo-bits_4",
+    "worst_value": 52.49662509631502
+  },
+  "LeftPadLow8_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 43.55464389337372,
+    "median_name": "hi-bits_0",
+    "median_value": 45.2665168453436,
+    "worst_name": "lo-bits_2",
+    "worst_value": 72.45912680145513
+  },
+  "LeftRotate16": {
+    "best_name": "ufmbits_4",
+    "best_value": 28.97755946401581,
+    "median_name": "lo-bits_1",
+    "median_value": 34.26849927647209,
+    "worst_name": "hi-bits_0",
+    "worst_value": 49.98995729098037
+  },
+  "LeftRotate32": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.457502069848548,
+    "median_name": "hi-bits_1",
+    "median_value": 45.86614006181749,
+    "worst_name": "lo-bits_3",
+    "worst_value": 55.77608494968847
+  },
+  "LeftRotate64": {
+    "best_name": "lo-bits_3",
+    "best_value": 29.11815358845588,
+    "median_name": "hi-bits_1",
+    "median_value": 30.58459293279944,
+    "worst_name": "ufmbits_4",
+    "worst_value": 49.850616203616894
+  },
+  "LeftRotate8": {
+    "best_name": "lo-bits_0",
+    "best_value": 36.16727196247368,
+    "median_name": "lo-bits_2",
+    "median_value": 39.18046887442463,
+    "worst_name": "ufmbits_3",
+    "worst_value": 40.709658970447585
+  },
+  "LeftShift16": {
+    "best_name": "hi-bits_4",
+    "best_value": 34.608197334930466,
+    "median_name": "ufmbits_4",
+    "median_value": 44.775210966763154,
+    "worst_name": "lo-bits_4",
+    "worst_value": 56.414153971511624
+  },
+  "LeftShift32": {
+    "best_name": "ufmbits_0",
+    "best_value": 32.73662438911201,
+    "median_name": "hi-bits_4",
+    "median_value": 35.390188419827716,
+    "worst_name": "lo-bits_2",
+    "worst_value": 57.67799738852491
+  },
+  "LeftShift64": {
+    "best_name": "lo-bits_0",
+    "best_value": 33.457932021322705,
+    "median_name": "ufmbits_0",
+    "median_value": 47.27366977888638,
+    "worst_name": "hi-bits_3",
+    "worst_value": 57.141456714335675
+  },
+  "LeftShift8": {
+    "best_name": "hi-bits_3",
+    "best_value": 45.101000836135405,
+    "median_name": "lo-bits_0",
+    "median_value": 47.92648882136482,
+    "worst_name": "ufmbits_4",
+    "worst_value": 58.67561658956457
+  },
+  "LeftShiftWith16": {
+    "best_name": "hi-bits_1",
+    "best_value": 34.37343121245841,
+    "median_name": "ufmbits_3",
+    "median_value": 52.96069350839849,
+    "worst_name": "lo-bits_3",
+    "worst_value": 56.466017115608146
+  },
+  "LeftShiftWith32": {
+    "best_name": "hi-bits_0",
+    "best_value": 40.90109289341372,
+    "median_name": "lo-bits_1",
+    "median_value": 47.68754392668819,
+    "worst_name": "ufmbits_4",
+    "worst_value": 53.46417310989821
+  },
+  "LeftShiftWith64": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.46574635069572,
+    "median_name": "hi-bits_0",
+    "median_value": 46.79274810253023,
+    "worst_name": "ufmbits_0",
+    "worst_value": 57.43819550556459
+  },
+  "LeftShiftWith8": {
+    "best_name": "hi-bits_3",
+    "best_value": 33.779197014709645,
+    "median_name": "ufmbits_0",
+    "median_value": 48.370881519122705,
+    "worst_name": "lo-bits_1",
+    "worst_value": 56.51170807211076
+  },
+  "Leftmost16_1": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.571246438389313,
+    "median_name": "ufmbits_4",
+    "median_value": 31.511468281531734,
+    "worst_name": "lo-bits_1",
+    "worst_value": 44.71778047301082
+  },
+  "Leftmost16_2": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.655973338954727,
+    "median_name": "hi-bits_0",
+    "median_value": 38.022395113849655,
+    "worst_name": "ufmbits_3",
+    "worst_value": 47.79439078470026
+  },
+  "Leftmost16_4": {
+    "best_name": "ufmbits_3",
+    "best_value": 27.653996944615237,
+    "median_name": "lo-bits_2",
+    "median_value": 29.324952052939402,
+    "worst_name": "hi-bits_1",
+    "worst_value": 38.8176276820737
+  },
+  "Leftmost16_8": {
+    "best_name": "ufmbits_2",
+    "best_value": 25.562062344763284,
+    "median_name": "hi-bits_1",
+    "median_value": 30.880668580486912,
+    "worst_name": "lo-bits_0",
+    "worst_value": 41.365765151315436
+  },
+  "Leftmost32_1": {
+    "best_name": "hi-bits_2",
+    "best_value": 28.024686835811764,
+    "median_name": "hi-bits_3",
+    "median_value": 35.109037046030714,
+    "worst_name": "hi-bits_0",
+    "worst_value": 44.98048268276589
+  },
+  "Leftmost32_16": {
+    "best_name": "ufmbits_0",
+    "best_value": 23.487273715634657,
+    "median_name": "hi-bits_3",
+    "median_value": 32.355645013565415,
+    "worst_name": "lo-bits_4",
+    "worst_value": 49.04083715054513
+  },
+  "Leftmost32_2": {
+    "best_name": "hi-bits_0",
+    "best_value": 25.07273154568331,
+    "median_name": "ufmbits_0",
+    "median_value": 34.63834667623414,
+    "worst_name": "lo-bits_4",
+    "worst_value": 44.811475408457085
+  },
+  "Leftmost32_4": {
+    "best_name": "ufmbits_3",
+    "best_value": 25.127123291403105,
+    "median_name": "lo-bits_1",
+    "median_value": 32.27031616718069,
+    "worst_name": "hi-bits_1",
+    "worst_value": 46.9035524888905
+  },
+  "Leftmost32_8": {
+    "best_name": "ufmbits_3",
+    "best_value": 24.931736153638507,
+    "median_name": "lo-bits_1",
+    "median_value": 26.421703995487054,
+    "worst_name": "hi-bits_3",
+    "worst_value": 44.59901631840901
+  },
+  "Leftmost64_1": {
+    "best_name": "lo-bits_3",
+    "best_value": 24.698699587424912,
+    "median_name": "hi-bits_4",
+    "median_value": 39.102499584335575,
+    "worst_name": "ufmbits_2",
+    "worst_value": 43.05712836178437
+  },
+  "Leftmost64_16": {
+    "best_name": "lo-bits_3",
+    "best_value": 34.093127017136446,
+    "median_name": "lo-bits_1",
+    "median_value": 37.10918213226127,
+    "worst_name": "ufmbits_2",
+    "worst_value": 41.0382846702897
+  },
+  "Leftmost64_2": {
+    "best_name": "hi-bits_4",
+    "best_value": 25.22230239752319,
+    "median_name": "hi-bits_0",
+    "median_value": 28.37629802639807,
+    "worst_name": "ufmbits_3",
+    "worst_value": 40.43311519967219
+  },
+  "Leftmost64_32": {
+    "best_name": "lo-bits_4",
+    "best_value": 25.064537288814513,
+    "median_name": "ufmbits_2",
+    "median_value": 26.574353279423434,
+    "worst_name": "lo-bits_3",
+    "worst_value": 40.37718151285053
+  },
+  "Leftmost64_4": {
+    "best_name": "lo-bits_4",
+    "best_value": 25.22241319395406,
+    "median_name": "hi-bits_2",
+    "median_value": 38.3250466572467,
+    "worst_name": "ufmbits_0",
+    "worst_value": 43.29019926018031
+  },
+  "Leftmost64_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.514316677293504,
+    "median_name": "hi-bits_1",
+    "median_value": 38.846229901634864,
+    "worst_name": "ufmbits_3",
+    "worst_value": 45.53803688115321
+  },
+  "Leftmost8_1": {
+    "best_name": "lo-bits_3",
+    "best_value": 26.119668912109564,
+    "median_name": "ufmbits_2",
+    "median_value": 34.97089041078769,
+    "worst_name": "hi-bits_0",
+    "worst_value": 38.854682435518434
+  },
+  "Leftmost8_2": {
+    "best_name": "ufmbits_2",
+    "best_value": 35.23802445585842,
+    "median_name": "hi-bits_3",
+    "median_value": 38.10697296743109,
+    "worst_name": "lo-bits_4",
+    "worst_value": 46.39168478903928
+  },
+  "Leftmost8_4": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.294841601169423,
+    "median_name": "hi-bits_4",
+    "median_value": 38.067045604930314,
+    "worst_name": "ufmbits_4",
+    "worst_value": 39.7832673551694
+  },
+  "LinearCombination1": {
+    "best_name": "sc_ufmbits_+_gej_offc_fe_ufmbits_+_sc_ufmbits_2",
+    "best_value": 745.5999195534544,
+    "median_name": "sc_ufmbits_+_gej_zero_fe_outofrange_+_scalar_outofrange_2",
+    "median_value": 800.8622962351018,
+    "worst_name": "sc_hi-bits_+_gej_oncurve_+_sc_ufmbits_2",
+    "worst_value": 47276.742142512485
+  },
+  "LinearVerify1": {
+    "best_name": "scalar_outofrange_+_ge_offc_fe_ufmbits_+_sc_ufmbits_+_ge_offc_fe_3",
+    "best_value": 775.1823242304686,
+    "median_name": "sc_hi-bits_+_ge_offc_fe_lo-bits_+_scalar_outofrange_+_ge_offc_fe_14",
+    "median_value": 815.1759233524385,
+    "worst_name": "sc_hi-bits_+_ge_oncurve_+_sc_ufmbits_+_ge_oncurve_2",
+    "worst_value": 47990.73876983814
+  },
+  "LockTime": {
+    "best_name": "0",
+    "best_value": 23.22873186163504,
+    "median_name": "24",
+    "median_value": 32.06380605060392,
+    "worst_name": "62",
+    "worst_value": 46.274651831088974
+  },
+  "Low1": {
+    "best_name": "unit_1",
+    "best_value": 27.984177163396616,
+    "median_name": "unit_0",
+    "median_value": 28.38146289873833,
+    "worst_name": "unit_3",
+    "worst_value": 28.72577637552022
+  },
+  "Low16": {
+    "best_name": "unit_0",
+    "best_value": 25.00602633197807,
+    "median_name": "unit_2",
+    "median_value": 25.011722370237965,
+    "worst_name": "unit_1",
+    "worst_value": 25.85993476222947
+  },
+  "Low32": {
+    "best_name": "unit_3",
+    "best_value": 33.322449283205174,
+    "median_name": "unit_1",
+    "median_value": 34.50329751812945,
+    "worst_name": "unit_4",
+    "worst_value": 35.390892700265056
+  },
+  "Low64": {
+    "best_name": "unit_3",
+    "best_value": 26.77841152622247,
+    "median_name": "unit_1",
+    "median_value": 27.314230873288988,
+    "worst_name": "unit_2",
+    "worst_value": 27.79536146673133
+  },
+  "Low8": {
+    "best_name": "unit_2",
+    "best_value": 24.34679202477132,
+    "median_name": "unit_1",
+    "median_value": 24.725610044644018,
+    "worst_name": "unit_4",
+    "worst_value": 24.88531158016574
+  },
+  "Lt16": {
+    "best_name": "lo-bits_+_self_1",
+    "best_value": 27.14941854614459,
+    "median_name": "hi-bits_+_lo-bits_4",
+    "median_value": 39.674437408805,
+    "worst_name": "ufmbits_+_ufmbits_2",
+    "worst_value": 59.56594980893872
+  },
+  "Lt32": {
+    "best_name": "lo-bits_+_hi-bits_2",
+    "best_value": 26.618411725761327,
+    "median_name": "lo-bits_+_inv_self_0",
+    "median_value": 39.93923407831059,
+    "worst_name": "ufmbits_+_inv_self_3",
+    "worst_value": 56.8239094913804
+  },
+  "Lt64": {
+    "best_name": "ufmbits_+_self_0",
+    "best_value": 29.972882706380616,
+    "median_name": "hi-bits_+_lo-bits_2",
+    "median_value": 39.17520295608696,
+    "worst_name": "ufmbits_+_hi-bits_4",
+    "worst_value": 53.33976611351666
+  },
+  "Lt8": {
+    "best_name": "hi-bits_+_self_2",
+    "best_value": 25.115595613789797,
+    "median_name": "hi-bits_+_hi-bits_3",
+    "median_value": 37.849322017599825,
+    "worst_name": "lo-bits_+_ufmbits_1",
+    "worst_value": 64.12678984612026
+  },
+  "Maj1": {
+    "best_name": "hi-bits_0",
+    "best_value": 25.18399565549539,
+    "median_name": "ufmbits_2",
+    "median_value": 35.156634914932035,
+    "worst_name": "lo-bits_0",
+    "worst_value": 38.01343533016235
+  },
+  "Maj16": {
+    "best_name": "ufmbits_0",
+    "best_value": 33.003549918764776,
+    "median_name": "hi-bits_0",
+    "median_value": 46.771400714919835,
+    "worst_name": "lo-bits_2",
+    "worst_value": 56.952705763668284
+  },
+  "Maj32": {
+    "best_name": "hi-bits_2",
+    "best_value": 32.01832170324835,
+    "median_name": "hi-bits_0",
+    "median_value": 33.985287758087594,
+    "worst_name": "ufmbits_4",
+    "worst_value": 41.48425882952139
+  },
+  "Maj64": {
+    "best_name": "hi-bits_3",
+    "best_value": 35.09188017802831,
+    "median_name": "lo-bits_3",
+    "median_value": 39.10668507673226,
+    "worst_name": "ufmbits_4",
+    "worst_value": 58.920461852061266
+  },
+  "Maj8": {
+    "best_name": "lo-bits_3",
+    "best_value": 32.06384055154804,
+    "median_name": "lo-bits_1",
+    "median_value": 38.48642840803002,
+    "worst_name": "hi-bits_3",
+    "worst_value": 46.90466734631318
+  },
+  "Max16": {
+    "best_name": "ufmbits_+_hi-bits_2",
+    "best_value": 28.23979456836173,
+    "median_name": "hi-bits_+_inv_self_1",
+    "median_value": 42.19424040471538,
+    "worst_name": "lo-bits_+_self_4",
+    "worst_value": 51.37063047719108
+  },
+  "Max32": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 28.294449820051813,
+    "median_name": "lo-bits_+_ufmbits_0",
+    "median_value": 42.40545123901324,
+    "worst_name": "ufmbits_+_self_2",
+    "worst_value": 58.28222787049185
+  },
+  "Max64": {
+    "best_name": "hi-bits_+_ufmbits_0",
+    "best_value": 31.127039831196726,
+    "median_name": "hi-bits_+_hi-bits_0",
+    "median_value": 41.01877551587322,
+    "worst_name": "ufmbits_+_inv_self_3",
+    "worst_value": 58.015625367007715
+  },
+  "Max8": {
+    "best_name": "ufmbits_+_lo-bits_0",
+    "best_value": 30.96120612678708,
+    "median_name": "ufmbits_+_inv_self_0",
+    "median_value": 35.496094403433716,
+    "worst_name": "lo-bits_+_inv_self_0",
+    "worst_value": 59.61136664249585
+  },
+  "Median16": {
+    "best_name": "ufmbits_0",
+    "best_value": 41.148968289666875,
+    "median_name": "hi-bits_4",
+    "median_value": 50.01271273160279,
+    "worst_name": "lo-bits_1",
+    "worst_value": 54.29852495322064
+  },
+  "Median32": {
+    "best_name": "lo-bits_3",
+    "best_value": 52.24184918766363,
+    "median_name": "ufmbits_4",
+    "median_value": 56.25969567934345,
+    "worst_name": "hi-bits_2",
+    "worst_value": 63.61188232495434
+  },
+  "Median64": {
+    "best_name": "lo-bits_4",
+    "best_value": 39.32844766428517,
+    "median_name": "hi-bits_3",
+    "median_value": 45.400556442262804,
+    "worst_name": "ufmbits_3",
+    "worst_value": 73.40398070051421
+  },
+  "Median8": {
+    "best_name": "lo-bits_3",
+    "best_value": 37.28248414760205,
+    "median_name": "ufmbits_3",
+    "median_value": 45.404264847368175,
+    "worst_name": "hi-bits_0",
+    "worst_value": 50.2195074829099
+  },
+  "Min16": {
+    "best_name": "lo-bits_+_hi-bits_1",
+    "best_value": 29.01896382071438,
+    "median_name": "hi-bits_+_inv_self_1",
+    "median_value": 44.58734305467115,
+    "worst_name": "ufmbits_+_self_3",
+    "worst_value": 54.06118592810419
+  },
+  "Min32": {
+    "best_name": "lo-bits_+_hi-bits_0",
+    "best_value": 30.734501856179705,
+    "median_name": "lo-bits_+_lo-bits_3",
+    "median_value": 43.4673741968591,
+    "worst_name": "hi-bits_+_inv_self_4",
+    "worst_value": 60.89886542249762
+  },
+  "Min64": {
+    "best_name": "ufmbits_+_inv_self_0",
+    "best_value": 33.18369487469668,
+    "median_name": "lo-bits_+_hi-bits_3",
+    "median_value": 42.611777562408896,
+    "worst_name": "hi-bits_+_hi-bits_4",
+    "worst_value": 52.10890816463062
+  },
+  "Min8": {
+    "best_name": "lo-bits_+_ufmbits_2",
+    "best_value": 28.063784264062797,
+    "median_name": "lo-bits_+_hi-bits_4",
+    "median_value": 41.15294729060082,
+    "worst_name": "lo-bits_+_lo-bits_1",
+    "worst_value": 53.78577332678931
+  },
+  "Modulo16": {
+    "best_name": "ufmbits_+_ufmbits_4",
+    "best_value": 28.871132765704882,
+    "median_name": "lo-bits_+_ufmbits_2",
+    "median_value": 38.41439876123653,
+    "worst_name": "hi-bits_+_lo-bits_4",
+    "worst_value": 57.87294944007195
+  },
+  "Modulo32": {
+    "best_name": "lo-bits_+_ufmbits_0",
+    "best_value": 29.964361996631446,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 43.06316304580723,
+    "worst_name": "hi-bits_+_inv_self_3",
+    "worst_value": 51.42155790126757
+  },
+  "Modulo64": {
+    "best_name": "lo-bits_+_ufmbits_2",
+    "best_value": 33.590727582141795,
+    "median_name": "hi-bits_+_inv_self_2",
+    "median_value": 44.98033719690676,
+    "worst_name": "ufmbits_+_ufmbits_3",
+    "worst_value": 55.52357114074753
+  },
+  "Modulo8": {
+    "best_name": "ufmbits_+_ufmbits_2",
+    "best_value": 27.151852942756086,
+    "median_name": "hi-bits_+_ufmbits_4",
+    "median_value": 39.64501557545458,
+    "worst_name": "hi-bits_+_lo-bits_2",
+    "worst_value": 52.81715120055677
+  },
+  "Multiply16": {
+    "best_name": "hi-bits_+_inv_self_0",
+    "best_value": 28.307200077865126,
+    "median_name": "ufmbits_+_hi-bits_3",
+    "median_value": 42.987961821333,
+    "worst_name": "hi-bits_+_hi-bits_4",
+    "worst_value": 54.820485363255194
+  },
+  "Multiply32": {
+    "best_name": "ufmbits_+_lo-bits_3",
+    "best_value": 28.63732289765382,
+    "median_name": "hi-bits_+_hi-bits_1",
+    "median_value": 41.89085879617396,
+    "worst_name": "hi-bits_+_lo-bits_1",
+    "worst_value": 50.2223858767499
+  },
+  "Multiply64": {
+    "best_name": "lo-bits_+_ufmbits_2",
+    "best_value": 33.793368033400846,
+    "median_name": "lo-bits_+_hi-bits_1",
+    "median_value": 45.73192175641885,
+    "worst_name": "lo-bits_+_self_2",
+    "worst_value": 52.92370716507161
+  },
+  "Multiply8": {
+    "best_name": "lo-bits_+_inv_self_0",
+    "best_value": 27.771104617084607,
+    "median_name": "lo-bits_+_ufmbits_0",
+    "median_value": 41.286754405619114,
+    "worst_name": "hi-bits_+_hi-bits_2",
+    "worst_value": 53.5956094951297
+  },
+  "Negate16": {
+    "best_name": "ufmbits_3",
+    "best_value": 26.670834958849415,
+    "median_name": "lo-bits_1",
+    "median_value": 37.62481350438233,
+    "worst_name": "ufmbits_0",
+    "worst_value": 46.76769994287756
+  },
+  "Negate32": {
+    "best_name": "lo-bits_1",
+    "best_value": 28.449018125915327,
+    "median_name": "hi-bits_3",
+    "median_value": 44.767130967413365,
+    "worst_name": "ufmbits_1",
+    "worst_value": 47.49621479149563
+  },
+  "Negate64": {
+    "best_name": "hi-bits_4",
+    "best_value": 28.487731729919737,
+    "median_name": "hi-bits_0",
+    "median_value": 29.660329118838217,
+    "worst_name": "ufmbits_1",
+    "worst_value": 37.873344512890775
+  },
+  "Negate8": {
+    "best_name": "hi-bits_3",
+    "best_value": 26.704622581193124,
+    "median_name": "hi-bits_0",
+    "median_value": 35.10960025059677,
+    "worst_name": "ufmbits_4",
+    "worst_value": 47.74555805216589
+  },
+  "NumInputs": {
+    "best_name": "7",
+    "best_value": 22.93145257962073,
+    "median_name": "57",
+    "median_value": 30.20069713016757,
+    "worst_name": "51",
+    "worst_value": 43.12952696181167
+  },
+  "NumOutputs": {
+    "best_name": "97",
+    "best_value": 23.44609330884529,
+    "median_name": "38",
+    "median_value": 33.03887216727469,
+    "worst_name": "51",
+    "worst_value": 44.05949310741831
+  },
+  "One16": {
+    "best_name": "unit_0",
+    "best_value": 37.155864077561,
+    "median_name": "unit_4",
+    "median_value": 38.14226931690132,
+    "worst_name": "unit_3",
+    "worst_value": 39.47511529349589
+  },
+  "One32": {
+    "best_name": "unit_2",
+    "best_value": 37.11540090855393,
+    "median_name": "unit_3",
+    "median_value": 37.2560008698082,
+    "worst_name": "unit_1",
+    "worst_value": 37.851934664789695
+  },
+  "One64": {
+    "best_name": "unit_1",
+    "best_value": 37.41112862829113,
+    "median_name": "unit_2",
+    "median_value": 41.09104815466535,
+    "worst_name": "unit_4",
+    "worst_value": 46.61464843901273
+  },
+  "One8": {
+    "best_name": "unit_3",
+    "best_value": 35.48410400327889,
+    "median_name": "unit_1",
+    "median_value": 38.93857735675017,
+    "worst_name": "unit_2",
+    "worst_value": 40.1203165674613
+  },
+  "Or1": {
+    "best_name": "hi-bits_+_hi-bits_3",
+    "best_value": 22.990707506623515,
+    "median_name": "ufmbits_+_inv_self_0",
+    "median_value": 30.1728523462356,
+    "worst_name": "ufmbits_+_self_2",
+    "worst_value": 41.34832892925895
+  },
+  "Or16": {
+    "best_name": "lo-bits_+_inv_self_4",
+    "best_value": 28.219734198462398,
+    "median_name": "lo-bits_+_hi-bits_1",
+    "median_value": 43.67454952141321,
+    "worst_name": "ufmbits_+_self_0",
+    "worst_value": 57.23527731221071
+  },
+  "Or32": {
+    "best_name": "lo-bits_+_hi-bits_4",
+    "best_value": 27.96915570521914,
+    "median_name": "ufmbits_+_lo-bits_4",
+    "median_value": 40.212802331231586,
+    "worst_name": "hi-bits_+_lo-bits_2",
+    "worst_value": 49.796147348631855
+  },
+  "Or64": {
+    "best_name": "ufmbits_+_lo-bits_1",
+    "best_value": 31.055255514851552,
+    "median_name": "lo-bits_+_self_2",
+    "median_value": 40.06147427415378,
+    "worst_name": "lo-bits_+_ufmbits_0",
+    "worst_value": 56.23795288905616
+  },
+  "Or8": {
+    "best_name": "hi-bits_+_ufmbits_4",
+    "best_value": 29.381612309278168,
+    "median_name": "ufmbits_+_ufmbits_1",
+    "median_value": 43.81707890637411,
+    "worst_name": "lo-bits_+_inv_self_1",
+    "worst_value": 55.344051674766014
+  },
+  "OutputAmountsHash": {
+    "best_name": "56",
+    "best_value": 40.50099228740931,
+    "median_name": "89",
+    "median_value": 54.305224265274354,
+    "worst_name": "65",
+    "worst_value": 74.98784946005296
+  },
+  "OutputNoncesHash": {
+    "best_name": "81",
+    "best_value": 38.845155513748715,
+    "median_name": "4",
+    "median_value": 53.664377108786965,
+    "worst_name": "33",
+    "worst_value": 78.68453665433017
+  },
+  "OutputRangeProofsHash": {
+    "best_name": "15",
+    "best_value": 39.33832236191973,
+    "median_name": "21",
+    "median_value": 54.6958710393194,
+    "worst_name": "32",
+    "worst_value": 82.92212157109506
+  },
+  "OutputScriptsHash": {
+    "best_name": "95",
+    "best_value": 38.84376622452387,
+    "median_name": "86",
+    "median_value": 50.74336052419554,
+    "worst_name": "57",
+    "worst_value": 73.03721842505149
+  },
+  "OutputSurjectionProofsHash": {
+    "best_name": "80",
+    "best_value": 40.78771196561575,
+    "median_name": "65",
+    "median_value": 52.43553190208296,
+    "worst_name": "53",
+    "worst_value": 76.9531032440363
+  },
+  "OutputsHash": {
+    "best_name": "82",
+    "best_value": 41.245996809894834,
+    "median_name": "10",
+    "median_value": 53.83373008007381,
+    "worst_name": "6",
+    "worst_value": 77.49875917512558
+  },
+  "ParseLock": {
+    "best_name": "hi-bits_2",
+    "best_value": 34.70662895461519,
+    "median_name": "ufmbits_2",
+    "median_value": 41.183594807380516,
+    "worst_name": "lo-bits_0",
+    "worst_value": 57.889989249632706
+  },
+  "ParseSequence": {
+    "best_name": "0hi-bits_0",
+    "best_value": 32.307292691686655,
+    "median_name": "0lo-bits_4",
+    "median_value": 43.41066819899769,
+    "worst_name": "1ufmbits_4",
+    "worst_value": 67.22804210458766
+  },
+  "PointVerify1": {
+    "best_name": "sc_lo-bits_+_pt_ge_offc_fe_lo-bits_+_sc_lo-bits_+_pt_ge_offc_fe__10",
+    "best_value": 14533.892362595467,
+    "median_name": "sc_hi-bits_+_pt_ge_offc_fe_hi-bits_+_sc_lo-bits_+_pt_ge_offc_fe__4",
+    "median_value": 20697.85898120386,
+    "worst_name": "sc_hi-bits_+_pt_ge_oncurve_+_sc_ufmbits_+_pt_ge_oncurve_4",
+    "worst_value": 45384.38437811863
+  },
+  "RightExtend16_32": {
+    "best_name": "hi-bits_3",
+    "best_value": 28.051345374577476,
+    "median_name": "lo-bits_3",
+    "median_value": 28.44920400383587,
+    "worst_name": "hi-bits_4",
+    "worst_value": 28.961518220337293
+  },
+  "RightExtend16_64": {
+    "best_name": "lo-bits_4",
+    "best_value": 31.98812451841525,
+    "median_name": "hi-bits_3",
+    "median_value": 41.61543297275646,
+    "worst_name": "ufmbits_2",
+    "worst_value": 47.93059422939316
+  },
+  "RightExtend32_64": {
+    "best_name": "hi-bits_2",
+    "best_value": 28.100911205676518,
+    "median_name": "lo-bits_3",
+    "median_value": 33.24996866911172,
+    "worst_name": "ufmbits_1",
+    "worst_value": 36.36956641867721
+  },
+  "RightExtend8_16": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.796686600979022,
+    "median_name": "hi-bits_2",
+    "median_value": 36.352804215929396,
+    "worst_name": "ufmbits_3",
+    "worst_value": 40.462117678577556
+  },
+  "RightExtend8_32": {
+    "best_name": "ufmbits_4",
+    "best_value": 44.570497809950936,
+    "median_name": "lo-bits_3",
+    "median_value": 55.32714213404666,
+    "worst_name": "lo-bits_4",
+    "worst_value": 60.07138951465133
+  },
+  "RightExtend8_64": {
+    "best_name": "hi-bits_0",
+    "best_value": 58.26908222837673,
+    "median_name": "lo-bits_0",
+    "median_value": 64.57696010937497,
+    "worst_name": "ufmbits_1",
+    "worst_value": 74.78824387835621
+  },
+  "RightPadHigh16_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.216749048976894,
+    "median_name": "ufmbits_4",
+    "median_value": 42.07566302622338,
+    "worst_name": "lo-bits_3",
+    "worst_value": 50.672607064911496
+  },
+  "RightPadHigh16_64": {
+    "best_name": "ufmbits_3",
+    "best_value": 30.966976627832874,
+    "median_name": "hi-bits_1",
+    "median_value": 34.59515240092076,
+    "worst_name": "lo-bits_3",
+    "worst_value": 55.09045869683678
+  },
+  "RightPadHigh1_16": {
+    "best_name": "lo-bits_1",
+    "best_value": 51.519593876432246,
+    "median_name": "hi-bits_2",
+    "median_value": 67.74996665999319,
+    "worst_name": "ufmbits_4",
+    "worst_value": 74.86519442317402
+  },
+  "RightPadHigh1_32": {
+    "best_name": "ufmbits_4",
+    "best_value": 96.29730259323163,
+    "median_name": "hi-bits_0",
+    "median_value": 104.72415332903228,
+    "worst_name": "lo-bits_2",
+    "worst_value": 123.46749341435343
+  },
+  "RightPadHigh1_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 159.62047550780298,
+    "median_name": "ufmbits_0",
+    "median_value": 250.1620119868898,
+    "worst_name": "lo-bits_4",
+    "worst_value": 265.0321290711149
+  },
+  "RightPadHigh1_8": {
+    "best_name": "hi-bits_1",
+    "best_value": 44.07824145570736,
+    "median_name": "hi-bits_4",
+    "median_value": 50.60990846352106,
+    "worst_name": "ufmbits_4",
+    "worst_value": 61.81704398867082
+  },
+  "RightPadHigh32_64": {
+    "best_name": "ufmbits_2",
+    "best_value": 27.206526514653525,
+    "median_name": "lo-bits_1",
+    "median_value": 35.01135654725761,
+    "worst_name": "ufmbits_4",
+    "worst_value": 51.455495728481225
+  },
+  "RightPadHigh8_16": {
+    "best_name": "lo-bits_3",
+    "best_value": 31.92879425847401,
+    "median_name": "ufmbits_4",
+    "median_value": 48.31865956267968,
+    "worst_name": "hi-bits_2",
+    "worst_value": 57.06138528585335
+  },
+  "RightPadHigh8_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 35.203115748096124,
+    "median_name": "hi-bits_1",
+    "median_value": 46.44045455019345,
+    "worst_name": "ufmbits_0",
+    "worst_value": 48.69088090770141
+  },
+  "RightPadHigh8_64": {
+    "best_name": "hi-bits_2",
+    "best_value": 45.82674852039316,
+    "median_name": "lo-bits_1",
+    "median_value": 49.5970873284128,
+    "worst_name": "hi-bits_0",
+    "worst_value": 53.00913175899028
+  },
+  "RightPadLow16_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 27.852863149939612,
+    "median_name": "hi-bits_4",
+    "median_value": 28.22387894805706,
+    "worst_name": "ufmbits_1",
+    "worst_value": 41.87807907146489
+  },
+  "RightPadLow16_64": {
+    "best_name": "hi-bits_3",
+    "best_value": 38.407600720022536,
+    "median_name": "lo-bits_1",
+    "median_value": 48.816136837874055,
+    "worst_name": "ufmbits_2",
+    "worst_value": 56.3821965223649
+  },
+  "RightPadLow1_16": {
+    "best_name": "ufmbits_4",
+    "best_value": 27.193316456565196,
+    "median_name": "hi-bits_1",
+    "median_value": 34.1727215977094,
+    "worst_name": "hi-bits_2",
+    "worst_value": 35.87393581096219
+  },
+  "RightPadLow1_32": {
+    "best_name": "hi-bits_1",
+    "best_value": 23.653180392275967,
+    "median_name": "ufmbits_0",
+    "median_value": 29.56990999722512,
+    "worst_name": "lo-bits_0",
+    "worst_value": 33.61443364690187
+  },
+  "RightPadLow1_64": {
+    "best_name": "hi-bits_2",
+    "best_value": 24.887007303028874,
+    "median_name": "lo-bits_2",
+    "median_value": 34.00625321339801,
+    "worst_name": "ufmbits_4",
+    "worst_value": 35.21876903388093
+  },
+  "RightPadLow1_8": {
+    "best_name": "hi-bits_2",
+    "best_value": 23.218840146617357,
+    "median_name": "ufmbits_2",
+    "median_value": 35.5463096560058,
+    "worst_name": "lo-bits_1",
+    "worst_value": 44.08731669363392
+  },
+  "RightPadLow32_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.960185003258164,
+    "median_name": "hi-bits_1",
+    "median_value": 35.05649451653056,
+    "worst_name": "lo-bits_3",
+    "worst_value": 52.7679845375817
+  },
+  "RightPadLow8_16": {
+    "best_name": "hi-bits_3",
+    "best_value": 27.643511828337815,
+    "median_name": "lo-bits_0",
+    "median_value": 37.783190535680454,
+    "worst_name": "ufmbits_3",
+    "worst_value": 45.45090164296464
+  },
+  "RightPadLow8_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.50430419733799,
+    "median_name": "ufmbits_4",
+    "median_value": 48.36240677418891,
+    "worst_name": "hi-bits_1",
+    "worst_value": 52.06514650280465
+  },
+  "RightPadLow8_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 43.69135949463469,
+    "median_name": "lo-bits_3",
+    "median_value": 74.00789769527381,
+    "worst_name": "lo-bits_4",
+    "worst_value": 78.31652637986083
+  },
+  "RightRotate16": {
+    "best_name": "hi-bits_2",
+    "best_value": 33.65861931363629,
+    "median_name": "ufmbits_1",
+    "median_value": 49.04099295178084,
+    "worst_name": "lo-bits_0",
+    "worst_value": 66.38448985023012
+  },
+  "RightRotate32": {
+    "best_name": "hi-bits_4",
+    "best_value": 27.96691009238896,
+    "median_name": "lo-bits_3",
+    "median_value": 39.84643164223864,
+    "worst_name": "ufmbits_1",
+    "worst_value": 48.7124166295447
+  },
+  "RightRotate64": {
+    "best_name": "hi-bits_1",
+    "best_value": 37.19588815503416,
+    "median_name": "lo-bits_4",
+    "median_value": 43.500441814517714,
+    "worst_name": "ufmbits_3",
+    "worst_value": 46.87584745916871
+  },
+  "RightRotate8": {
+    "best_name": "ufmbits_0",
+    "best_value": 36.93014802612929,
+    "median_name": "hi-bits_1",
+    "median_value": 38.99749351068706,
+    "worst_name": "hi-bits_0",
+    "worst_value": 42.49562508779621
+  },
+  "RightShift16": {
+    "best_name": "lo-bits_1",
+    "best_value": 32.46139628116743,
+    "median_name": "ufmbits_1",
+    "median_value": 34.77982258032865,
+    "worst_name": "ufmbits_3",
+    "worst_value": 36.358847342589414
+  },
+  "RightShift32": {
+    "best_name": "ufmbits_0",
+    "best_value": 30.749759266363796,
+    "median_name": "lo-bits_4",
+    "median_value": 33.945335209243304,
+    "worst_name": "lo-bits_1",
+    "worst_value": 38.372271330214055
+  },
+  "RightShift64": {
+    "best_name": "hi-bits_4",
+    "best_value": 41.54136067925306,
+    "median_name": "hi-bits_0",
+    "median_value": 47.759751450678706,
+    "worst_name": "lo-bits_4",
+    "worst_value": 57.83782072853807
+  },
+  "RightShift8": {
+    "best_name": "ufmbits_0",
+    "best_value": 31.764334871907426,
+    "median_name": "ufmbits_4",
+    "median_value": 32.31593959464157,
+    "worst_name": "hi-bits_0",
+    "worst_value": 43.717955338906386
+  },
+  "RightShiftWith16": {
+    "best_name": "hi-bits_1",
+    "best_value": 30.988525732992347,
+    "median_name": "hi-bits_3",
+    "median_value": 40.24565562406746,
+    "worst_name": "lo-bits_3",
+    "worst_value": 54.033723823280205
+  },
+  "RightShiftWith32": {
+    "best_name": "lo-bits_4",
+    "best_value": 28.864663065646795,
+    "median_name": "hi-bits_3",
+    "median_value": 31.326291356856395,
+    "worst_name": "ufmbits_2",
+    "worst_value": 53.81122489354712
+  },
+  "RightShiftWith64": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.713555991934175,
+    "median_name": "hi-bits_3",
+    "median_value": 44.880091059042805,
+    "worst_name": "ufmbits_2",
+    "worst_value": 61.955714691358395
+  },
+  "RightShiftWith8": {
+    "best_name": "hi-bits_1",
+    "best_value": 32.95319020850508,
+    "median_name": "lo-bits_3",
+    "median_value": 52.69241439142943,
+    "worst_name": "ufmbits_4",
+    "worst_value": 64.16442161557397
+  },
+  "Rightmost16_1": {
+    "best_name": "ufmbits_0",
+    "best_value": 34.75608867272256,
+    "median_name": "ufmbits_4",
+    "median_value": 39.66503060651378,
+    "worst_name": "lo-bits_1",
+    "worst_value": 45.1224696086378
+  },
+  "Rightmost16_2": {
+    "best_name": "hi-bits_0",
+    "best_value": 25.93192579384249,
+    "median_name": "lo-bits_4",
+    "median_value": 31.906650263287915,
+    "worst_name": "lo-bits_2",
+    "worst_value": 37.91080917167732
+  },
+  "Rightmost16_4": {
+    "best_name": "lo-bits_1",
+    "best_value": 25.359837660421363,
+    "median_name": "hi-bits_2",
+    "median_value": 36.26116122770164,
+    "worst_name": "hi-bits_0",
+    "worst_value": 37.85067553798616
+  },
+  "Rightmost16_8": {
+    "best_name": "lo-bits_3",
+    "best_value": 26.313319772718025,
+    "median_name": "hi-bits_3",
+    "median_value": 27.070607192974215,
+    "worst_name": "ufmbits_1",
+    "worst_value": 44.99862192788657
+  },
+  "Rightmost32_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 26.604118400290663,
+    "median_name": "ufmbits_4",
+    "median_value": 38.41733478483962,
+    "worst_name": "ufmbits_2",
+    "worst_value": 41.723326834484205
+  },
+  "Rightmost32_16": {
+    "best_name": "hi-bits_0",
+    "best_value": 26.811111173661267,
+    "median_name": "ufmbits_4",
+    "median_value": 35.406095871745485,
+    "worst_name": "lo-bits_4",
+    "worst_value": 38.52439896058829
+  },
+  "Rightmost32_2": {
+    "best_name": "ufmbits_4",
+    "best_value": 36.40313579309458,
+    "median_name": "ufmbits_1",
+    "median_value": 39.510783209454125,
+    "worst_name": "lo-bits_2",
+    "worst_value": 47.993480253097644
+  },
+  "Rightmost32_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 25.5429901269559,
+    "median_name": "ufmbits_0",
+    "median_value": 33.54227227580828,
+    "worst_name": "lo-bits_0",
+    "worst_value": 41.82057505130104
+  },
+  "Rightmost32_8": {
+    "best_name": "hi-bits_4",
+    "best_value": 25.99302221713491,
+    "median_name": "lo-bits_4",
+    "median_value": 32.43503475167352,
+    "worst_name": "ufmbits_4",
+    "worst_value": 40.23328765204041
+  },
+  "Rightmost64_1": {
+    "best_name": "lo-bits_3",
+    "best_value": 27.677915546366194,
+    "median_name": "lo-bits_2",
+    "median_value": 38.50458780604682,
+    "worst_name": "ufmbits_3",
+    "worst_value": 42.2508973592911
+  },
+  "Rightmost64_16": {
+    "best_name": "hi-bits_3",
+    "best_value": 24.40378218461238,
+    "median_name": "lo-bits_2",
+    "median_value": 30.76054618415464,
+    "worst_name": "ufmbits_0",
+    "worst_value": 38.992306611203226
+  },
+  "Rightmost64_2": {
+    "best_name": "ufmbits_1",
+    "best_value": 26.939163288364266,
+    "median_name": "lo-bits_0",
+    "median_value": 28.136960681655225,
+    "worst_name": "lo-bits_2",
+    "worst_value": 35.53421254066384
+  },
+  "Rightmost64_32": {
+    "best_name": "hi-bits_3",
+    "best_value": 24.59961463604735,
+    "median_name": "lo-bits_1",
+    "median_value": 34.677113819461596,
+    "worst_name": "ufmbits_4",
+    "worst_value": 40.718447718384255
+  },
+  "Rightmost64_4": {
+    "best_name": "hi-bits_1",
+    "best_value": 33.728267951729904,
+    "median_name": "ufmbits_3",
+    "median_value": 43.87732490499612,
+    "worst_name": "lo-bits_4",
+    "worst_value": 49.910719075035374
+  },
+  "Rightmost64_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 34.717874112225516,
+    "median_name": "lo-bits_1",
+    "median_value": 43.241469401009034,
+    "worst_name": "hi-bits_0",
+    "worst_value": 51.41812593186903
+  },
+  "Rightmost8_1": {
+    "best_name": "hi-bits_0",
+    "best_value": 26.00005724928301,
+    "median_name": "ufmbits_0",
+    "median_value": 32.64648750995441,
+    "worst_name": "lo-bits_0",
+    "worst_value": 41.92864912290331
+  },
+  "Rightmost8_2": {
+    "best_name": "lo-bits_4",
+    "best_value": 25.417429813986963,
+    "median_name": "ufmbits_1",
+    "median_value": 34.5947293127912,
+    "worst_name": "hi-bits_3",
+    "worst_value": 45.97475366619882
+  },
+  "Rightmost8_4": {
+    "best_name": "ufmbits_1",
+    "best_value": 26.494845825276958,
+    "median_name": "lo-bits_0",
+    "median_value": 36.40847293052987,
+    "worst_name": "hi-bits_0",
+    "worst_value": 41.52598656724415
+  },
+  "ScalarAdd": {
+    "best_name": "sc_hi-bits_+_inv_self_4",
+    "best_value": 366.63468888150567,
+    "median_name": "sc_ufmbits_+_self_2",
+    "median_value": 384.6094194123375,
+    "worst_name": "sc_lo-bits_+_sc_hi-bits_0",
+    "worst_value": 393.66905356137147
+  },
+  "ScalarInvert": {
+    "best_name": "sc_lo-bits_0",
+    "best_value": 1380.1681445761396,
+    "median_name": "scalar_outofrange_2",
+    "median_value": 1754.9470823323632,
+    "worst_name": "sc_hi-bits_4",
+    "worst_value": 1776.958603630786
+  },
+  "ScalarIsZero": {
+    "best_name": "sc_hi-bits_4",
+    "best_value": 142.46549720523862,
+    "median_name": "sc_ufmbits_1",
+    "median_value": 144.5896200059993,
+    "worst_name": "sc_lo-bits_2",
+    "worst_value": 153.45604379026182
+  },
+  "ScalarMultiply": {
+    "best_name": "sc_hi-bits_+_sc_hi-bits_2",
+    "best_value": 415.8099656815245,
+    "median_name": "sc_lo-bits_+_sc_ufmbits_0",
+    "median_value": 430.4736108728202,
+    "worst_name": "sc_lo-bits_+_sc_hi-bits_4",
+    "worst_value": 443.2993736249116
+  },
+  "ScalarMultiplyLambda": {
+    "best_name": "sc_ufmbits_4",
+    "best_value": 293.2124528737862,
+    "median_name": "sc_lo-bits_1",
+    "median_value": 306.614047698986,
+    "worst_name": "sc_hi-bits_3",
+    "worst_value": 311.13326566426827
+  },
+  "ScalarNegate": {
+    "best_name": "sc_lo-bits_0",
+    "best_value": 262.1087432042228,
+    "median_name": "sc_ufmbits_3",
+    "median_value": 264.0102066877352,
+    "worst_name": "scalar_outofrange_0",
+    "worst_value": 272.8486874173019
+  },
+  "ScalarNormalize": {
+    "best_name": "scalar_outofrange_1",
+    "best_value": 253.77300171320374,
+    "median_name": "sc_ufmbits_3",
+    "median_value": 258.2994292193642,
+    "worst_name": "sc_lo-bits_0",
+    "worst_value": 263.56928162391057
+  },
+  "ScalarSquare": {
+    "best_name": "sc_ufmbits_1",
+    "best_value": 294.1601589332402,
+    "median_name": "scalar_outofrange_4",
+    "median_value": 302.1933266169372,
+    "worst_name": "sc_lo-bits_4",
+    "worst_value": 312.5093445218787
+  },
+  "Scale": {
+    "best_name": "sc_lo-bits_+_gej_zero_fe_hi-bits_0",
+    "best_value": 620.0093282766169,
+    "median_name": "scalar_outofrange_+_gej_zero_fe_outofrange_1",
+    "median_value": 642.1592096481778,
+    "worst_name": "sc_ufmbits_+_gej_oncurve_1",
+    "worst_value": 40511.837265665075
+  },
+  "ScriptCMR": {
+    "best_name": "71",
+    "best_value": 40.45085433399812,
+    "median_name": "46",
+    "median_value": 54.153222766649534,
+    "worst_name": "70",
+    "worst_value": 76.80001608368794
+  },
+  "Sha256Block": {
+    "best_name": "ufmbits_0",
+    "best_value": 396.02646139116916,
+    "median_name": "lo-bits_1",
+    "median_value": 413.47382297852056,
+    "worst_name": "hi-bits_0",
+    "worst_value": 420.86250661454716
+  },
+  "Sha256Ctx8Add1": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_hi-bits_0",
+    "best_value": 71.39423794381665,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_lo-bits_+_lo-bits_1",
+    "median_value": 210.3955994580737,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_ufmbits_2",
+    "worst_value": 342.3609005091255
+  },
+  "Sha256Ctx8Add128": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_ufmbits_1",
+    "best_value": 65.68262142488409,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_lo-bits_4",
+    "median_value": 209.3582574434603,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_ufmbits_4",
+    "worst_value": 983.1567249280705
+  },
+  "Sha256Ctx8Add16": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_ufmbits_2",
+    "best_value": 64.29560266237613,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_lo-bits_3",
+    "median_value": 206.86421612399937,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_ufmbits_2",
+    "worst_value": 415.96103688284796
+  },
+  "Sha256Ctx8Add2": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_ufmbits_+_hi-bits_0",
+    "best_value": 71.41211713477682,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_ufmbits_0",
+    "median_value": 211.41052109133892,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_lo-bits_2",
+    "worst_value": 352.14837387720564
+  },
+  "Sha256Ctx8Add256": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_+_ufmbits_1",
+    "best_value": 64.89863381465896,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_ufmbits_1",
+    "median_value": 215.94029648460022,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_ufmbits_4",
+    "worst_value": 1667.4568579353465
+  },
+  "Sha256Ctx8Add32": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_+_lo-bits_2",
+    "best_value": 64.40856728735871,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_ufmbits_+_hi-bits_3",
+    "median_value": 215.90993056699935,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_lo-bits_1",
+    "worst_value": 500.39188206176766
+  },
+  "Sha256Ctx8Add4": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_+_hi-bits_0",
+    "best_value": 65.43647307685892,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_ufmbits_1",
+    "median_value": 205.0862185642543,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_0",
+    "worst_value": 352.227122742626
+  },
+  "Sha256Ctx8Add512": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_lo-bits_4",
+    "best_value": 66.51644755867689,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_lo-bits_+_lo-bits_4",
+    "median_value": 217.12303951320922,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_ufmbits_+_lo-bits_4",
+    "worst_value": 2939.933154482157
+  },
+  "Sha256Ctx8Add64": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_+_ufmbits_3",
+    "best_value": 65.38398397041355,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_lo-bits_3",
+    "median_value": 212.47361498205117,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_2",
+    "worst_value": 654.0690326086036
+  },
+  "Sha256Ctx8Add8": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_+_ufmbits_3",
+    "best_value": 64.28653725685157,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_+_hi-bits_4",
+    "median_value": 204.45458727301914,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_1",
+    "worst_value": 373.0969537340054
+  },
+  "Sha256Ctx8AddBuffer511": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_lo-bits_3",
+    "best_value": 71.46494058760506,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_lo-bits_4",
+    "median_value": 211.98674712319405,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_ufmbits_+_hi-bits_0",
+    "worst_value": 2810.640729385066
+  },
+  "Sha256Ctx8Finalize": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_0",
+    "best_value": 61.687335933253536,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_3",
+    "median_value": 203.60872360762224,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_1",
+    "worst_value": 461.4092553775997
+  },
+  "Sha256Ctx8Init": {
+    "best_name": "unit_1",
+    "best_value": 61.70312164069723,
+    "median_name": "unit_2",
+    "median_value": 62.106785502712285,
+    "worst_name": "unit_0",
+    "worst_value": 62.31768476520993
+  },
+  "Sha256Iv": {
+    "best_name": "unit_3",
+    "best_value": 45.497825217363726,
+    "median_name": "unit_1",
+    "median_value": 45.56202205066185,
+    "worst_name": "unit_2",
+    "worst_value": 46.10108029786615
+  },
+  "SigAllHash": {
+    "best_name": "72",
+    "best_value": 38.79963911834138,
+    "median_name": "68",
+    "median_value": 47.77364042322746,
+    "worst_name": "57",
+    "worst_value": 74.04657175412328
+  },
+  "Some1": {
+    "best_name": "ufmbits_2",
+    "best_value": 24.69221682704194,
+    "median_name": "hi-bits_2",
+    "median_value": 29.082702793751867,
+    "worst_name": "lo-bits_3",
+    "worst_value": 33.15801192381312
+  },
+  "Some16": {
+    "best_name": "hi-bits_3",
+    "best_value": 28.945575669128257,
+    "median_name": "ufmbits_3",
+    "median_value": 40.684150177873214,
+    "worst_name": "lo-bits_4",
+    "worst_value": 49.742023953321905
+  },
+  "Some32": {
+    "best_name": "ufmbits_2",
+    "best_value": 25.115191057601134,
+    "median_name": "hi-bits_4",
+    "median_value": 27.38377478255394,
+    "worst_name": "lo-bits_4",
+    "worst_value": 45.187096620184036
+  },
+  "Some64": {
+    "best_name": "ufmbits_2",
+    "best_value": 37.88677278754602,
+    "median_name": "lo-bits_3",
+    "median_value": 40.48719767196053,
+    "worst_name": "hi-bits_4",
+    "worst_value": 42.5919973369279
+  },
+  "Some8": {
+    "best_name": "ufmbits_4",
+    "best_value": 29.9674401604381,
+    "median_name": "hi-bits_4",
+    "median_value": 34.05988066050645,
+    "worst_name": "lo-bits_1",
+    "worst_value": 45.66040335774032
+  },
+  "Subtract16": {
+    "best_name": "ufmbits_+_self_2",
+    "best_value": 29.96504488472109,
+    "median_name": "lo-bits_+_lo-bits_4",
+    "median_value": 44.8315691634783,
+    "worst_name": "ufmbits_+_inv_self_1",
+    "worst_value": 62.12512831748214
+  },
+  "Subtract32": {
+    "best_name": "lo-bits_+_inv_self_4",
+    "best_value": 30.07472552374434,
+    "median_name": "lo-bits_+_self_3",
+    "median_value": 47.799480319573256,
+    "worst_name": "lo-bits_+_lo-bits_2",
+    "worst_value": 59.03783794991331
+  },
+  "Subtract64": {
+    "best_name": "lo-bits_+_ufmbits_1",
+    "best_value": 32.487420407236684,
+    "median_name": "hi-bits_+_self_4",
+    "median_value": 41.33721347442049,
+    "worst_name": "hi-bits_+_hi-bits_1",
+    "worst_value": 58.33587688702622
+  },
+  "Subtract8": {
+    "best_name": "ufmbits_+_self_1",
+    "best_value": 32.53113161796621,
+    "median_name": "hi-bits_+_self_2",
+    "median_value": 47.90737022487845,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 68.81574035366128
+  },
+  "Swu": {
+    "best_name": "lo-bits_2",
+    "best_value": 17613.75665663553,
+    "median_name": "hi-bits_1",
+    "median_value": 17784.240260883544,
+    "worst_name": "ufmbits_3",
+    "worst_value": 17847.45639649952
+  },
+  "TapEnvHash": {
+    "best_name": "13",
+    "best_value": 40.23078133031039,
+    "median_name": "27",
+    "median_value": 54.372954822706944,
+    "worst_name": "96",
+    "worst_value": 71.05379946781427
+  },
+  "TapdataInit": {
+    "best_name": "unit_2",
+    "best_value": 630.355508333529,
+    "median_name": "unit_3",
+    "median_value": 654.1267159364477,
+    "worst_name": "unit_1",
+    "worst_value": 654.8088901361084
+  },
+  "TapleafHash": {
+    "best_name": "76",
+    "best_value": 40.00083499353474,
+    "median_name": "48",
+    "median_value": 55.93741052122472,
+    "worst_name": "75",
+    "worst_value": 73.46645430033509
+  },
+  "TapleafVersion": {
+    "best_name": "14",
+    "best_value": 25.959974875723134,
+    "median_name": "83",
+    "median_value": 33.96651524170994,
+    "worst_name": "95",
+    "worst_value": 49.18071611218778
+  },
+  "TappathHash": {
+    "best_name": "68",
+    "best_value": 38.633212256048466,
+    "median_name": "48",
+    "median_value": 54.3801299420782,
+    "worst_name": "83",
+    "worst_value": 72.54217339059936
+  },
+  "TotalFee": {
+    "best_name": "74",
+    "best_value": 122.93,
+    "median_name": "56",
+    "median_value": 138.76,
+    "worst_name": "29",
+    "worst_value": 167.56
+  },
+  "TransactionId": {
+    "best_name": "88",
+    "best_value": 39.74760457744131,
+    "median_name": "85",
+    "median_value": 50.61159133278254,
+    "worst_name": "57",
+    "worst_value": 82.59292477164315
+  },
+  "TxHash": {
+    "best_name": "6",
+    "best_value": 38.73618099629116,
+    "median_name": "98",
+    "median_value": 52.75650116623685,
+    "worst_name": "11",
+    "worst_value": 71.09189177844797
+  },
+  "TxIsFinal": {
+    "best_name": "73",
+    "best_value": 21.730856148551833,
+    "median_name": "63",
+    "median_value": 29.777600683091922,
+    "worst_name": "29",
+    "worst_value": 40.952474350974576
+  },
+  "TxLockDistance": {
+    "best_name": "67",
+    "best_value": 23.953543862009287,
+    "median_name": "34",
+    "median_value": 33.97197120454679,
+    "worst_name": "61",
+    "worst_value": 46.47616820330703
+  },
+  "TxLockDuration": {
+    "best_name": "93",
+    "best_value": 22.771751211440527,
+    "median_name": "62",
+    "median_value": 33.01343222732025,
+    "worst_name": "44",
+    "worst_value": 44.72035868458299
+  },
+  "TxLockHeight": {
+    "best_name": "5",
+    "best_value": 23.1180271942485,
+    "median_name": "75",
+    "median_value": 31.71044281081426,
+    "worst_name": "34",
+    "worst_value": 46.81015448225102
+  },
+  "TxLockTime": {
+    "best_name": "56",
+    "best_value": 25.496590779177986,
+    "median_name": "52",
+    "median_value": 33.96637480412725,
+    "worst_name": "42",
+    "worst_value": 50.146960912461516
+  },
+  "Verify": {
+    "best_name": "hi-bits_3",
+    "best_value": 18.181956394851216,
+    "median_name": "lo-bits_2",
+    "median_value": 19.737074766128377,
+    "worst_name": "ufmbits_4",
+    "worst_value": 21.388183003149557
+  },
+  "Version": {
+    "best_name": "97",
+    "best_value": 25.421286983151035,
+    "median_name": "38",
+    "median_value": 32.06755290690639,
+    "worst_name": "8",
+    "worst_value": 45.91263086806686
+  },
+  "Xor1": {
+    "best_name": "lo-bits_+_hi-bits_3",
+    "best_value": 20.86617062912087,
+    "median_name": "lo-bits_+_ufmbits_0",
+    "median_value": 29.168388323117266,
+    "worst_name": "lo-bits_+_ufmbits_1",
+    "worst_value": 54.909707961486305
+  },
+  "Xor16": {
+    "best_name": "hi-bits_+_inv_self_2",
+    "best_value": 28.610477578909236,
+    "median_name": "hi-bits_+_lo-bits_1",
+    "median_value": 42.90885804996883,
+    "worst_name": "lo-bits_+_inv_self_4",
+    "worst_value": 53.46347380262184
+  },
+  "Xor32": {
+    "best_name": "hi-bits_+_inv_self_1",
+    "best_value": 28.23933318686233,
+    "median_name": "lo-bits_+_inv_self_4",
+    "median_value": 42.44450893276417,
+    "worst_name": "lo-bits_+_self_3",
+    "worst_value": 51.562397373035964
+  },
+  "Xor64": {
+    "best_name": "ufmbits_+_hi-bits_3",
+    "best_value": 30.179718226305553,
+    "median_name": "lo-bits_+_hi-bits_0",
+    "median_value": 41.37693988027392,
+    "worst_name": "hi-bits_+_ufmbits_0",
+    "worst_value": 59.79586660690974
+  },
+  "Xor8": {
+    "best_name": "ufmbits_+_self_0",
+    "best_value": 26.601078052393746,
+    "median_name": "hi-bits_+_inv_self_4",
+    "median_value": 38.50273214077238,
+    "worst_name": "ufmbits_+_inv_self_1",
+    "worst_value": 55.754956947387974
+  },
+  "XorXor1": {
+    "best_name": "hi-bits_1",
+    "best_value": 27.370100360828083,
+    "median_name": "ufmbits_1",
+    "median_value": 33.311390400454776,
+    "worst_name": "ufmbits_3",
+    "worst_value": 37.08900578107954
+  },
+  "XorXor16": {
+    "best_name": "ufmbits_4",
+    "best_value": 32.81671336067475,
+    "median_name": "lo-bits_4",
+    "median_value": 34.48664576922421,
+    "worst_name": "hi-bits_0",
+    "worst_value": 46.52446600936971
+  },
+  "XorXor32": {
+    "best_name": "lo-bits_1",
+    "best_value": 31.969493139313776,
+    "median_name": "ufmbits_1",
+    "median_value": 45.78209671399571,
+    "worst_name": "hi-bits_4",
+    "worst_value": 50.65817023356257
+  },
+  "XorXor64": {
+    "best_name": "lo-bits_3",
+    "best_value": 41.2867063865078,
+    "median_name": "hi-bits_3",
+    "median_value": 46.17564027618359,
+    "worst_name": "ufmbits_2",
+    "worst_value": 60.51170492082903
+  },
+  "XorXor8": {
+    "best_name": "ufmbits_3",
+    "best_value": 33.04721071886364,
+    "median_name": "hi-bits_2",
+    "median_value": 47.77558962209507,
+    "worst_name": "lo-bits_0",
+    "worst_value": 54.040717526677966
+  }
+}

--- a/data/jet_bench_2025-10-09_14-34-26.json
+++ b/data/jet_bench_2025-10-09_14-34-26.json
@@ -1,0 +1,3426 @@
+{
+  "Add16": {
+    "best_name": "ufmbits_+_inv_self_1",
+    "best_value": 30.54274513832705,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 34.77545805276187,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 42.14243553534482
+  },
+  "Add32": {
+    "best_name": "lo-bits_+_inv_self_4",
+    "best_value": 29.842262626375323,
+    "median_name": "hi-bits_+_inv_self_2",
+    "median_value": 34.82027366667382,
+    "worst_name": "ufmbits_+_self_3",
+    "worst_value": 50.87297184583992
+  },
+  "Add64": {
+    "best_name": "lo-bits_+_inv_self_1",
+    "best_value": 28.88712565958825,
+    "median_name": "lo-bits_+_self_4",
+    "median_value": 33.93848796541304,
+    "worst_name": "ufmbits_+_self_3",
+    "worst_value": 57.20832090418327
+  },
+  "Add8": {
+    "best_name": "ufmbits_+_inv_self_2",
+    "best_value": 30.50164272202414,
+    "median_name": "lo-bits_+_lo-bits_4",
+    "median_value": 40.07633397110171,
+    "worst_name": "ufmbits_+_hi-bits_3",
+    "worst_value": 54.339223290125226
+  },
+  "All16": {
+    "best_name": "ufmbits_2",
+    "best_value": 26.50448758402306,
+    "median_name": "hi-bits_2",
+    "median_value": 27.633928599144056,
+    "worst_name": "hi-bits_1",
+    "worst_value": 36.409748192219546
+  },
+  "All32": {
+    "best_name": "lo-bits_2",
+    "best_value": 24.050778387153876,
+    "median_name": "hi-bits_0",
+    "median_value": 26.31081664254647,
+    "worst_name": "lo-bits_0",
+    "worst_value": 33.93416046389811
+  },
+  "All64": {
+    "best_name": "ufmbits_4",
+    "best_value": 23.968356667648685,
+    "median_name": "ufmbits_1",
+    "median_value": 26.471696884678032,
+    "worst_name": "lo-bits_1",
+    "worst_value": 36.02710909656352
+  },
+  "All8": {
+    "best_name": "lo-bits_4",
+    "best_value": 24.11440019603338,
+    "median_name": "hi-bits_0",
+    "median_value": 27.355163204753058,
+    "worst_name": "ufmbits_4",
+    "worst_value": 35.33621032632306
+  },
+  "And1": {
+    "best_name": "hi-bits_+_self_2",
+    "best_value": 22.93980299931319,
+    "median_name": "lo-bits_+_hi-bits_1",
+    "median_value": 29.25719295776589,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 35.728526924253785
+  },
+  "And16": {
+    "best_name": "hi-bits_+_hi-bits_1",
+    "best_value": 31.079751505790735,
+    "median_name": "hi-bits_+_lo-bits_2",
+    "median_value": 33.517569368031886,
+    "worst_name": "lo-bits_+_self_2",
+    "worst_value": 62.993997708933385
+  },
+  "And32": {
+    "best_name": "ufmbits_+_ufmbits_4",
+    "best_value": 30.910487617953827,
+    "median_name": "hi-bits_+_self_2",
+    "median_value": 33.55123364901296,
+    "worst_name": "hi-bits_+_ufmbits_2",
+    "worst_value": 45.73368082951875
+  },
+  "And64": {
+    "best_name": "lo-bits_+_self_0",
+    "best_value": 28.808427367127297,
+    "median_name": "ufmbits_+_lo-bits_4",
+    "median_value": 33.010029170516674,
+    "worst_name": "ufmbits_+_ufmbits_4",
+    "worst_value": 41.20002362541709
+  },
+  "And8": {
+    "best_name": "ufmbits_+_lo-bits_3",
+    "best_value": 28.339226798323374,
+    "median_name": "ufmbits_+_inv_self_4",
+    "median_value": 32.338025475187,
+    "worst_name": "ufmbits_+_hi-bits_4",
+    "worst_value": 41.10484986203378
+  },
+  "AnnexHash": {
+    "best_name": "98",
+    "best_value": 525.691403645886,
+    "median_name": "26",
+    "median_value": 550.26625,
+    "worst_name": "95",
+    "worst_value": 572.5105555555554
+  },
+  "Bip0340Verify": {
+    "best_name": "bip340_valid_3",
+    "best_value": 53436.38665147113,
+    "median_name": "bip340_valid_1",
+    "median_value": 53571.615336657065,
+    "worst_name": "bip340_invalid_0",
+    "worst_value": 53936.54201363749
+  },
+  "BuildTapbranch": {
+    "best_name": "36",
+    "best_value": 1268.7200000000005,
+    "median_name": "60",
+    "median_value": 1300.66,
+    "worst_name": "13",
+    "worst_value": 1390.81
+  },
+  "BuildTapleafSimplicity": {
+    "best_name": "3",
+    "best_value": 971.0500000000009,
+    "median_name": "0",
+    "median_value": 977.59,
+    "worst_name": "61",
+    "worst_value": 1030.07
+  },
+  "BuildTaptweak": {
+    "best_name": "fe_outofrange_+_sc_hi-bits_2",
+    "best_value": 722.8253820142544,
+    "median_name": "fe_hi-bits_+_sc_lo-bits_4",
+    "median_value": 20407.190714285724,
+    "worst_name": "fe_ufmbits_+_sc_hi-bits_1",
+    "worst_value": 25190.60699999999
+  },
+  "Ch1": {
+    "best_name": "hi-bits_1",
+    "best_value": 21.86343018057876,
+    "median_name": "lo-bits_0",
+    "median_value": 22.078875378560756,
+    "worst_name": "ufmbits_1",
+    "worst_value": 24.73511023163681
+  },
+  "Ch16": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.218589312180498,
+    "median_name": "lo-bits_2",
+    "median_value": 33.13298441291092,
+    "worst_name": "hi-bits_3",
+    "worst_value": 43.66225776092232
+  },
+  "Ch32": {
+    "best_name": "hi-bits_3",
+    "best_value": 31.987477494390305,
+    "median_name": "lo-bits_1",
+    "median_value": 33.82052029272835,
+    "worst_name": "hi-bits_0",
+    "worst_value": 43.238927875166844
+  },
+  "Ch64": {
+    "best_name": "lo-bits_4",
+    "best_value": 39.43452224046617,
+    "median_name": "lo-bits_0",
+    "median_value": 41.32524994297982,
+    "worst_name": "ufmbits_0",
+    "worst_value": 50.83030923128159
+  },
+  "Ch8": {
+    "best_name": "lo-bits_4",
+    "best_value": 30.903790051792598,
+    "median_name": "lo-bits_0",
+    "median_value": 32.57304835139982,
+    "worst_name": "hi-bits_2",
+    "worst_value": 33.76322005841177
+  },
+  "CheckLockDistance": {
+    "best_name": "84",
+    "best_value": 32.089713789869464,
+    "median_name": "92",
+    "median_value": 38.03808495212356,
+    "worst_name": "64",
+    "worst_value": 42.94929487149456
+  },
+  "CheckLockDuration": {
+    "best_name": "20",
+    "best_value": 33.30579536169238,
+    "median_name": "27",
+    "median_value": 38.594766083941956,
+    "worst_name": "83",
+    "worst_value": 44.80514318285762
+  },
+  "CheckLockHeight": {
+    "best_name": "76",
+    "best_value": 37.611258534649785,
+    "median_name": "38",
+    "median_value": 48.34833333333333,
+    "worst_name": "46",
+    "worst_value": 58.49555555555552
+  },
+  "CheckLockTime": {
+    "best_name": "72",
+    "best_value": 37.561930594989896,
+    "median_name": "4",
+    "median_value": 48.69444444444445,
+    "worst_name": "58",
+    "worst_value": 56.04470588235292
+  },
+  "CheckSigVerify": {
+    "best_name": "checksig_valid_1",
+    "best_value": 47884.61473908914,
+    "median_name": "checksig_invalid_1",
+    "median_value": 54122.91576212311,
+    "worst_name": "checksig_invalid_0",
+    "worst_value": 54442.786718941104
+  },
+  "Complement1": {
+    "best_name": "lo-bits_3",
+    "best_value": 26.570043799513613,
+    "median_name": "ufmbits_1",
+    "median_value": 27.093193416570617,
+    "worst_name": "hi-bits_3",
+    "worst_value": 28.90235338060259
+  },
+  "Complement16": {
+    "best_name": "ufmbits_0",
+    "best_value": 33.9053082861979,
+    "median_name": "lo-bits_1",
+    "median_value": 34.83494643480001,
+    "worst_name": "lo-bits_0",
+    "worst_value": 36.390961492591984
+  },
+  "Complement32": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.887596315754305,
+    "median_name": "hi-bits_3",
+    "median_value": 31.371785003190894,
+    "worst_name": "lo-bits_4",
+    "worst_value": 40.698460517560555
+  },
+  "Complement64": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.815885581156284,
+    "median_name": "ufmbits_3",
+    "median_value": 30.008560102650595,
+    "worst_name": "hi-bits_2",
+    "worst_value": 32.962320504965476
+  },
+  "Complement8": {
+    "best_name": "ufmbits_1",
+    "best_value": 31.562814443264948,
+    "median_name": "lo-bits_3",
+    "median_value": 32.94333830057635,
+    "worst_name": "hi-bits_1",
+    "worst_value": 41.79416497753918
+  },
+  "CurrentAnnexHash": {
+    "best_name": "75",
+    "best_value": 28.172116467292778,
+    "median_name": "46",
+    "median_value": 29.70971360071134,
+    "worst_name": "61",
+    "worst_value": 39.81999854796762
+  },
+  "CurrentIndex": {
+    "best_name": "1",
+    "best_value": 27.482591677377595,
+    "median_name": "45",
+    "median_value": 28.781458619785557,
+    "worst_name": "46",
+    "worst_value": 39.96474854536649
+  },
+  "CurrentPrevOutpoint": {
+    "best_name": "82",
+    "best_value": 54.39619314032004,
+    "median_name": "76",
+    "median_value": 55.74068654956923,
+    "worst_name": "35",
+    "worst_value": 74.68664583502465
+  },
+  "CurrentScriptHash": {
+    "best_name": "0",
+    "best_value": 50.649975915756784,
+    "median_name": "37",
+    "median_value": 52.62735538842708,
+    "worst_name": "90",
+    "worst_value": 68.14432820991378
+  },
+  "CurrentScriptSigHash": {
+    "best_name": "56",
+    "best_value": 51.04792011344008,
+    "median_name": "96",
+    "median_value": 52.471830933164156,
+    "worst_name": "50",
+    "worst_value": 70.06532799710058
+  },
+  "CurrentSequence": {
+    "best_name": "28",
+    "best_value": 27.868353555257254,
+    "median_name": "90",
+    "median_value": 28.672851274707792,
+    "worst_name": "49",
+    "worst_value": 36.61666717728874
+  },
+  "CurrentValue": {
+    "best_name": "83",
+    "best_value": 27.66183928269257,
+    "median_name": "38",
+    "median_value": 28.398182840266102,
+    "worst_name": "9",
+    "worst_value": 38.20683853947587
+  },
+  "Decompress": {
+    "best_name": "pt_ge_offc_fe_lo-bits_2",
+    "best_value": 5567.919022796728,
+    "median_name": "pt_ge_offc_fe_outofrange_0",
+    "median_value": 5600.628738460476,
+    "worst_name": "pt_ge_oncurve_3",
+    "worst_value": 5732.276452961657
+  },
+  "Decrement16": {
+    "best_name": "ufmbits_3",
+    "best_value": 28.807951517654143,
+    "median_name": "hi-bits_3",
+    "median_value": 29.628956901958354,
+    "worst_name": "lo-bits_2",
+    "worst_value": 39.28301731294992
+  },
+  "Decrement32": {
+    "best_name": "hi-bits_2",
+    "best_value": 27.58107945874981,
+    "median_name": "lo-bits_3",
+    "median_value": 29.369430008139425,
+    "worst_name": "ufmbits_2",
+    "worst_value": 35.85234953360015
+  },
+  "Decrement64": {
+    "best_name": "hi-bits_1",
+    "best_value": 26.947176374781858,
+    "median_name": "ufmbits_2",
+    "median_value": 28.41378112659656,
+    "worst_name": "lo-bits_0",
+    "worst_value": 38.34572884371904
+  },
+  "Decrement8": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.352859284829535,
+    "median_name": "lo-bits_0",
+    "median_value": 29.28952879930958,
+    "worst_name": "lo-bits_2",
+    "worst_value": 39.736266074450334
+  },
+  "DivMod128_64": {
+    "best_name": "lo-bits_+_lo-bits_1",
+    "best_value": 38.57861169722092,
+    "median_name": "hi-bits_+_hi-bits_4",
+    "median_value": 54.995647479988435,
+    "worst_name": "ufmbits_+_hi-bits_0",
+    "worst_value": 91.99627299653388
+  },
+  "DivMod16": {
+    "best_name": "hi-bits_+_hi-bits_4",
+    "best_value": 32.941307910200024,
+    "median_name": "hi-bits_+_lo-bits_2",
+    "median_value": 35.708552347017374,
+    "worst_name": "lo-bits_+_hi-bits_1",
+    "worst_value": 58.70835012653315
+  },
+  "DivMod32": {
+    "best_name": "ufmbits_+_ufmbits_3",
+    "best_value": 33.42223264353188,
+    "median_name": "ufmbits_+_inv_self_4",
+    "median_value": 36.59383139028467,
+    "worst_name": "hi-bits_+_inv_self_2",
+    "worst_value": 47.586257162135006
+  },
+  "DivMod64": {
+    "best_name": "lo-bits_+_ufmbits_1",
+    "best_value": 31.887153067528565,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 34.85198091773168,
+    "worst_name": "ufmbits_+_lo-bits_3",
+    "worst_value": 39.89628191022503
+  },
+  "DivMod8": {
+    "best_name": "lo-bits_+_inv_self_2",
+    "best_value": 42.689033954671096,
+    "median_name": "ufmbits_+_lo-bits_0",
+    "median_value": 45.60525368168808,
+    "worst_name": "hi-bits_+_inv_self_1",
+    "worst_value": 61.59910560744507
+  },
+  "Divide16": {
+    "best_name": "lo-bits_+_inv_self_4",
+    "best_value": 33.14696786052944,
+    "median_name": "hi-bits_+_self_1",
+    "median_value": 37.86986244152333,
+    "worst_name": "hi-bits_+_hi-bits_4",
+    "worst_value": 47.80377516113033
+  },
+  "Divide32": {
+    "best_name": "ufmbits_+_ufmbits_3",
+    "best_value": 30.632754978981385,
+    "median_name": "ufmbits_+_inv_self_4",
+    "median_value": 33.08072290442642,
+    "worst_name": "lo-bits_+_self_3",
+    "worst_value": 41.932006928125844
+  },
+  "Divide64": {
+    "best_name": "lo-bits_+_inv_self_2",
+    "best_value": 28.63124445108157,
+    "median_name": "ufmbits_+_inv_self_4",
+    "median_value": 34.01209536556471,
+    "worst_name": "hi-bits_+_ufmbits_2",
+    "worst_value": 44.99991528913441
+  },
+  "Divide8": {
+    "best_name": "ufmbits_+_ufmbits_3",
+    "best_value": 30.261539558736473,
+    "median_name": "hi-bits_+_ufmbits_2",
+    "median_value": 34.60959149487368,
+    "worst_name": "ufmbits_+_hi-bits_1",
+    "worst_value": 44.65549965441594
+  },
+  "Divides16": {
+    "best_name": "ufmbits_+_ufmbits_1",
+    "best_value": 30.09518038951295,
+    "median_name": "lo-bits_+_ufmbits_1",
+    "median_value": 33.377478895457564,
+    "worst_name": "hi-bits_+_inv_self_4",
+    "worst_value": 41.93387202032629
+  },
+  "Divides32": {
+    "best_name": "hi-bits_+_ufmbits_0",
+    "best_value": 27.616729611059792,
+    "median_name": "ufmbits_+_lo-bits_4",
+    "median_value": 31.93836646668629,
+    "worst_name": "lo-bits_+_ufmbits_1",
+    "worst_value": 42.560182110310635
+  },
+  "Divides64": {
+    "best_name": "hi-bits_+_self_1",
+    "best_value": 27.625491196448124,
+    "median_name": "lo-bits_+_inv_self_4",
+    "median_value": 33.586772904053994,
+    "worst_name": "ufmbits_+_ufmbits_3",
+    "worst_value": 41.16781967126917
+  },
+  "Divides8": {
+    "best_name": "ufmbits_+_self_3",
+    "best_value": 29.778587480759015,
+    "median_name": "lo-bits_+_hi-bits_0",
+    "median_value": 33.91776479766995,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 45.40445764734143
+  },
+  "Eq1": {
+    "best_name": "hi-bits_+_lo-bits_1",
+    "best_value": 22.135302998509065,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 25.159896821663907,
+    "worst_name": "hi-bits_+_ufmbits_3",
+    "worst_value": 36.06381228867028
+  },
+  "Eq16": {
+    "best_name": "ufmbits_+_hi-bits_1",
+    "best_value": 30.282952417701846,
+    "median_name": "ufmbits_+_inv_self_0",
+    "median_value": 33.596564120359616,
+    "worst_name": "lo-bits_+_inv_self_1",
+    "worst_value": 42.9891939073337
+  },
+  "Eq256": {
+    "best_name": "hi-bits_+_inv_self_1",
+    "best_value": 71.96714966196575,
+    "median_name": "lo-bits_+_ufmbits_1",
+    "median_value": 79.43973793746453,
+    "worst_name": "ufmbits_+_self_1",
+    "worst_value": 103.77875875772743
+  },
+  "Eq32": {
+    "best_name": "lo-bits_+_hi-bits_3",
+    "best_value": 26.783635772064994,
+    "median_name": "ufmbits_+_self_0",
+    "median_value": 29.86900689068092,
+    "worst_name": "lo-bits_+_self_4",
+    "worst_value": 38.173166181867025
+  },
+  "Eq64": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 28.540557500507038,
+    "median_name": "ufmbits_+_inv_self_1",
+    "median_value": 32.141439107245645,
+    "worst_name": "lo-bits_+_inv_self_3",
+    "worst_value": 41.24127247085227
+  },
+  "Eq8": {
+    "best_name": "lo-bits_+_ufmbits_4",
+    "best_value": 27.517699886037285,
+    "median_name": "hi-bits_+_ufmbits_2",
+    "median_value": 29.375522436266877,
+    "worst_name": "lo-bits_+_inv_self_3",
+    "worst_value": 37.08761188217497
+  },
+  "FeAdd": {
+    "best_name": "fe_ufmbits_+_fe_ufmbits_3",
+    "best_value": 413.61031585291306,
+    "median_name": "fe_hi-bits_+_fe_hi-bits_4",
+    "median_value": 420.3130561203605,
+    "worst_name": "fe_lo-bits_+_fe_outofrange_3",
+    "worst_value": 438.8366458263261
+  },
+  "FeInvert": {
+    "best_name": "fe_outofrange_0",
+    "best_value": 1279.3094464262472,
+    "median_name": "fe_hi-bits_0",
+    "median_value": 1552.410392136811,
+    "worst_name": "fe_ufmbits_2",
+    "worst_value": 1750.3641152509765
+  },
+  "FeIsOdd": {
+    "best_name": "fe_lo-bits_0",
+    "best_value": 146.1370779406038,
+    "median_name": "fe_ufmbits_0",
+    "median_value": 152.96577679353507,
+    "worst_name": "fe_outofrange_0",
+    "worst_value": 161.21925080419703
+  },
+  "FeIsZero": {
+    "best_name": "fe_ufmbits_1",
+    "best_value": 146.24914142817477,
+    "median_name": "fe_hi-bits_3",
+    "median_value": 148.66934615071855,
+    "worst_name": "fe_outofrange_4",
+    "worst_value": 156.2704273510151
+  },
+  "FeMultiply": {
+    "best_name": "fe_ufmbits_+_fe_ufmbits_1",
+    "best_value": 430.01753673056487,
+    "median_name": "fe_hi-bits_+_self_0",
+    "median_value": 438.3457881494754,
+    "worst_name": "fe_lo-bits_+_fe_outofrange_0",
+    "worst_value": 453.6337373092332
+  },
+  "FeMultiplyBeta": {
+    "best_name": "fe_ufmbits_1",
+    "best_value": 317.8080734393228,
+    "median_name": "fe_hi-bits_4",
+    "median_value": 320.61895781107654,
+    "worst_name": "fe_lo-bits_2",
+    "worst_value": 326.6586473666981
+  },
+  "FeNegate": {
+    "best_name": "fe_ufmbits_1",
+    "best_value": 297.7706246367618,
+    "median_name": "fe_hi-bits_1",
+    "median_value": 306.00047981952287,
+    "worst_name": "fe_hi-bits_4",
+    "worst_value": 310.529768028185
+  },
+  "FeNormalize": {
+    "best_name": "fe_lo-bits_4",
+    "best_value": 300.35125472006314,
+    "median_name": "fe_outofrange_3",
+    "median_value": 305.30887410943575,
+    "worst_name": "fe_outofrange_2",
+    "worst_value": 311.0678074466106
+  },
+  "FeSquare": {
+    "best_name": "fe_ufmbits_3",
+    "best_value": 312.26112158207115,
+    "median_name": "fe_hi-bits_0",
+    "median_value": 316.1719217639471,
+    "worst_name": "fe_outofrange_3",
+    "worst_value": 322.1946313864297
+  },
+  "FeSquareRoot": {
+    "best_name": "fe_ufmbits_0",
+    "best_value": 5461.603000850575,
+    "median_name": "fe_hi-bits_0",
+    "median_value": 5475.898056222459,
+    "worst_name": "fe_lo-bits_1",
+    "worst_value": 5514.4528461636955
+  },
+  "Fee": {
+    "best_name": "29",
+    "best_value": 27.087348919245347,
+    "median_name": "25",
+    "median_value": 27.71900963918587,
+    "worst_name": "74",
+    "worst_value": 42.329524078671184
+  },
+  "FullAdd16": {
+    "best_name": "0ufmbits_+_inv_self_1",
+    "best_value": 31.053597600025693,
+    "median_name": "0lo-bits_+_self_3",
+    "median_value": 36.33262591430302,
+    "worst_name": "1hi-bits_+_ufmbits_1",
+    "worst_value": 53.93158629448344
+  },
+  "FullAdd32": {
+    "best_name": "0hi-bits_+_hi-bits_2",
+    "best_value": 30.644435365361,
+    "median_name": "1ufmbits_+_lo-bits_2",
+    "median_value": 34.85158475812231,
+    "worst_name": "1ufmbits_+_self_2",
+    "worst_value": 54.46372771248674
+  },
+  "FullAdd64": {
+    "best_name": "1lo-bits_+_inv_self_3",
+    "best_value": 40.80720039077264,
+    "median_name": "1ufmbits_+_hi-bits_0",
+    "median_value": 43.78297612502874,
+    "worst_name": "0ufmbits_+_ufmbits_1",
+    "worst_value": 63.783724120738626
+  },
+  "FullAdd8": {
+    "best_name": "1lo-bits_+_inv_self_0",
+    "best_value": 31.276072945242326,
+    "median_name": "1hi-bits_+_lo-bits_1",
+    "median_value": 39.7133067756379,
+    "worst_name": "0ufmbits_+_hi-bits_4",
+    "worst_value": 55.93709355714499
+  },
+  "FullDecrement16": {
+    "best_name": "0ufmbits_1",
+    "best_value": 27.693682868224798,
+    "median_name": "1ufmbits_0",
+    "median_value": 29.144504540790628,
+    "worst_name": "0hi-bits_2",
+    "worst_value": 40.17711852391381
+  },
+  "FullDecrement32": {
+    "best_name": "0ufmbits_0",
+    "best_value": 27.67271884282421,
+    "median_name": "0hi-bits_1",
+    "median_value": 28.76696665241551,
+    "worst_name": "1lo-bits_1",
+    "worst_value": 37.855059878947735
+  },
+  "FullDecrement64": {
+    "best_name": "0lo-bits_0",
+    "best_value": 26.48047663287494,
+    "median_name": "1hi-bits_1",
+    "median_value": 29.382440845375246,
+    "worst_name": "0hi-bits_1",
+    "worst_value": 41.708190136479786
+  },
+  "FullDecrement8": {
+    "best_name": "0hi-bits_4",
+    "best_value": 29.35324871441428,
+    "median_name": "0lo-bits_1",
+    "median_value": 30.552717402777436,
+    "worst_name": "0ufmbits_0",
+    "worst_value": 32.657438985826175
+  },
+  "FullIncrement16": {
+    "best_name": "0ufmbits_0",
+    "best_value": 29.01844085607629,
+    "median_name": "1ufmbits_4",
+    "median_value": 30.518052139662508,
+    "worst_name": "0lo-bits_3",
+    "worst_value": 37.609611799916564
+  },
+  "FullIncrement32": {
+    "best_name": "0lo-bits_4",
+    "best_value": 28.141183166254127,
+    "median_name": "1lo-bits_4",
+    "median_value": 30.25343649268556,
+    "worst_name": "0lo-bits_1",
+    "worst_value": 37.10037569188533
+  },
+  "FullIncrement64": {
+    "best_name": "0hi-bits_3",
+    "best_value": 26.935338576668403,
+    "median_name": "1hi-bits_0",
+    "median_value": 28.618292336829978,
+    "worst_name": "1lo-bits_1",
+    "worst_value": 30.197556369817825
+  },
+  "FullIncrement8": {
+    "best_name": "0ufmbits_0",
+    "best_value": 28.776214713909162,
+    "median_name": "1hi-bits_2",
+    "median_value": 30.259797925968147,
+    "worst_name": "1ufmbits_2",
+    "worst_value": 39.94923986257831
+  },
+  "FullLeftShift16_1": {
+    "best_name": "hi-bits_1",
+    "best_value": 25.062285060320256,
+    "median_name": "lo-bits_1",
+    "median_value": 26.27852690874624,
+    "worst_name": "lo-bits_0",
+    "worst_value": 32.84220158574558
+  },
+  "FullLeftShift16_2": {
+    "best_name": "hi-bits_4",
+    "best_value": 25.04532386424379,
+    "median_name": "ufmbits_1",
+    "median_value": 26.982887099098463,
+    "worst_name": "lo-bits_4",
+    "worst_value": 31.8684208576131
+  },
+  "FullLeftShift16_4": {
+    "best_name": "lo-bits_3",
+    "best_value": 24.381061309409365,
+    "median_name": "hi-bits_4",
+    "median_value": 25.313327421304265,
+    "worst_name": "ufmbits_4",
+    "worst_value": 31.427909768559594
+  },
+  "FullLeftShift16_8": {
+    "best_name": "hi-bits_3",
+    "best_value": 24.994129864426732,
+    "median_name": "ufmbits_0",
+    "median_value": 25.89926855248763,
+    "worst_name": "lo-bits_3",
+    "worst_value": 27.730529342548223
+  },
+  "FullLeftShift32_1": {
+    "best_name": "hi-bits_4",
+    "best_value": 24.963813453220713,
+    "median_name": "hi-bits_0",
+    "median_value": 25.285039905653242,
+    "worst_name": "hi-bits_1",
+    "worst_value": 27.052507103077396
+  },
+  "FullLeftShift32_16": {
+    "best_name": "lo-bits_1",
+    "best_value": 24.80630784363435,
+    "median_name": "hi-bits_3",
+    "median_value": 26.234316695774815,
+    "worst_name": "ufmbits_2",
+    "worst_value": 34.95680061803768
+  },
+  "FullLeftShift32_2": {
+    "best_name": "lo-bits_4",
+    "best_value": 24.68034716736366,
+    "median_name": "ufmbits_1",
+    "median_value": 25.999552030814662,
+    "worst_name": "hi-bits_4",
+    "worst_value": 37.43893570032783
+  },
+  "FullLeftShift32_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 24.67616312510339,
+    "median_name": "ufmbits_1",
+    "median_value": 25.83863306842341,
+    "worst_name": "lo-bits_4",
+    "worst_value": 33.48690892519787
+  },
+  "FullLeftShift32_8": {
+    "best_name": "lo-bits_1",
+    "best_value": 24.76946433781706,
+    "median_name": "lo-bits_2",
+    "median_value": 25.925883558460217,
+    "worst_name": "hi-bits_0",
+    "worst_value": 28.57287696033875
+  },
+  "FullLeftShift64_1": {
+    "best_name": "lo-bits_1",
+    "best_value": 29.3006869943975,
+    "median_name": "hi-bits_4",
+    "median_value": 32.61915063587,
+    "worst_name": "ufmbits_0",
+    "worst_value": 38.69592021765163
+  },
+  "FullLeftShift64_16": {
+    "best_name": "hi-bits_4",
+    "best_value": 27.474429410237377,
+    "median_name": "lo-bits_4",
+    "median_value": 35.921288830232825,
+    "worst_name": "ufmbits_3",
+    "worst_value": 40.427521768452586
+  },
+  "FullLeftShift64_2": {
+    "best_name": "ufmbits_2",
+    "best_value": 28.81395152060945,
+    "median_name": "ufmbits_4",
+    "median_value": 30.459750646002398,
+    "worst_name": "hi-bits_2",
+    "worst_value": 40.932247782139264
+  },
+  "FullLeftShift64_32": {
+    "best_name": "hi-bits_3",
+    "best_value": 28.00237155620279,
+    "median_name": "ufmbits_2",
+    "median_value": 30.380143161019024,
+    "worst_name": "hi-bits_2",
+    "worst_value": 37.50524867492622
+  },
+  "FullLeftShift64_4": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.016945245382306,
+    "median_name": "lo-bits_3",
+    "median_value": 30.094847306536675,
+    "worst_name": "ufmbits_2",
+    "worst_value": 35.8904076744826
+  },
+  "FullLeftShift64_8": {
+    "best_name": "ufmbits_1",
+    "best_value": 30.355841969750166,
+    "median_name": "hi-bits_2",
+    "median_value": 33.17435605508793,
+    "worst_name": "lo-bits_0",
+    "worst_value": 36.075339299019
+  },
+  "FullLeftShift8_1": {
+    "best_name": "ufmbits_1",
+    "best_value": 23.80591234925531,
+    "median_name": "ufmbits_2",
+    "median_value": 24.95832310964454,
+    "worst_name": "hi-bits_2",
+    "worst_value": 25.462147279941032
+  },
+  "FullLeftShift8_2": {
+    "best_name": "hi-bits_3",
+    "best_value": 24.81625489732369,
+    "median_name": "lo-bits_2",
+    "median_value": 25.18330720409111,
+    "worst_name": "lo-bits_1",
+    "worst_value": 36.20344948262388
+  },
+  "FullLeftShift8_4": {
+    "best_name": "hi-bits_1",
+    "best_value": 24.3284022467341,
+    "median_name": "lo-bits_2",
+    "median_value": 25.122672211639337,
+    "worst_name": "hi-bits_2",
+    "worst_value": 26.856937916097127
+  },
+  "FullMultiply16": {
+    "best_name": "lo-bits_+_inv_self_1",
+    "best_value": 37.203480887662664,
+    "median_name": "ufmbits_+_inv_self_2",
+    "median_value": 39.411776808387984,
+    "worst_name": "lo-bits_+_lo-bits_0",
+    "worst_value": 58.38237551609295
+  },
+  "FullMultiply32": {
+    "best_name": "hi-bits_+_self_1",
+    "best_value": 33.591125294676914,
+    "median_name": "lo-bits_+_self_0",
+    "median_value": 37.388901851856396,
+    "worst_name": "hi-bits_+_ufmbits_0",
+    "worst_value": 40.847894360192306
+  },
+  "FullMultiply64": {
+    "best_name": "lo-bits_+_inv_self_0",
+    "best_value": 36.85222822281866,
+    "median_name": "ufmbits_+_inv_self_3",
+    "median_value": 41.57850539485468,
+    "worst_name": "lo-bits_+_self_4",
+    "worst_value": 53.894240780870724
+  },
+  "FullMultiply8": {
+    "best_name": "lo-bits_+_self_0",
+    "best_value": 36.245111898970976,
+    "median_name": "lo-bits_+_inv_self_1",
+    "median_value": 39.60634660187219,
+    "worst_name": "lo-bits_+_lo-bits_2",
+    "worst_value": 48.32156629549052
+  },
+  "FullRightShift16_1": {
+    "best_name": "ufmbits_4",
+    "best_value": 25.046808818564745,
+    "median_name": "ufmbits_3",
+    "median_value": 26.75690300807879,
+    "worst_name": "lo-bits_4",
+    "worst_value": 31.745783190692794
+  },
+  "FullRightShift16_2": {
+    "best_name": "ufmbits_3",
+    "best_value": 25.519205746991585,
+    "median_name": "lo-bits_1",
+    "median_value": 26.197826327209132,
+    "worst_name": "hi-bits_4",
+    "worst_value": 30.38801764412314
+  },
+  "FullRightShift16_4": {
+    "best_name": "hi-bits_3",
+    "best_value": 25.796259237721856,
+    "median_name": "hi-bits_4",
+    "median_value": 27.90311987117264,
+    "worst_name": "lo-bits_3",
+    "worst_value": 38.57253463235107
+  },
+  "FullRightShift16_8": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.32333195125683,
+    "median_name": "ufmbits_2",
+    "median_value": 26.820858957615656,
+    "worst_name": "hi-bits_0",
+    "worst_value": 36.90241696820045
+  },
+  "FullRightShift32_1": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.02363162518446,
+    "median_name": "hi-bits_1",
+    "median_value": 28.268401498057386,
+    "worst_name": "ufmbits_2",
+    "worst_value": 32.703674434527876
+  },
+  "FullRightShift32_16": {
+    "best_name": "ufmbits_2",
+    "best_value": 28.289949555270855,
+    "median_name": "hi-bits_4",
+    "median_value": 30.715230814663986,
+    "worst_name": "lo-bits_4",
+    "worst_value": 34.03207377241897
+  },
+  "FullRightShift32_2": {
+    "best_name": "ufmbits_3",
+    "best_value": 27.30005806755807,
+    "median_name": "ufmbits_1",
+    "median_value": 28.579230782222744,
+    "worst_name": "hi-bits_1",
+    "worst_value": 29.66609074303199
+  },
+  "FullRightShift32_4": {
+    "best_name": "ufmbits_2",
+    "best_value": 27.226427362849176,
+    "median_name": "hi-bits_3",
+    "median_value": 28.74599259278063,
+    "worst_name": "ufmbits_0",
+    "worst_value": 56.562126910632124
+  },
+  "FullRightShift32_8": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.843105434502213,
+    "median_name": "hi-bits_1",
+    "median_value": 29.809161543262565,
+    "worst_name": "lo-bits_2",
+    "worst_value": 36.89045658227049
+  },
+  "FullRightShift64_1": {
+    "best_name": "ufmbits_0",
+    "best_value": 30.911316775596177,
+    "median_name": "lo-bits_2",
+    "median_value": 33.68712014911933,
+    "worst_name": "hi-bits_1",
+    "worst_value": 38.95304929066349
+  },
+  "FullRightShift64_16": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.66568901637665,
+    "median_name": "ufmbits_4",
+    "median_value": 30.764179528133116,
+    "worst_name": "hi-bits_1",
+    "worst_value": 37.25208701115482
+  },
+  "FullRightShift64_2": {
+    "best_name": "hi-bits_3",
+    "best_value": 27.392937312311165,
+    "median_name": "ufmbits_2",
+    "median_value": 34.087979575312595,
+    "worst_name": "ufmbits_1",
+    "worst_value": 36.458412895680404
+  },
+  "FullRightShift64_32": {
+    "best_name": "lo-bits_3",
+    "best_value": 29.480386759278822,
+    "median_name": "ufmbits_4",
+    "median_value": 31.8337169364016,
+    "worst_name": "lo-bits_4",
+    "worst_value": 37.19808242332449
+  },
+  "FullRightShift64_4": {
+    "best_name": "lo-bits_4",
+    "best_value": 28.27748788621578,
+    "median_name": "hi-bits_4",
+    "median_value": 29.489132962525208,
+    "worst_name": "ufmbits_2",
+    "worst_value": 40.34362257996955
+  },
+  "FullRightShift64_8": {
+    "best_name": "hi-bits_2",
+    "best_value": 28.049505720061365,
+    "median_name": "hi-bits_4",
+    "median_value": 29.594823994861603,
+    "worst_name": "lo-bits_3",
+    "worst_value": 39.470623791625464
+  },
+  "FullRightShift8_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 24.656167979509387,
+    "median_name": "hi-bits_1",
+    "median_value": 26.53990613414494,
+    "worst_name": "hi-bits_4",
+    "worst_value": 31.816499475123013
+  },
+  "FullRightShift8_2": {
+    "best_name": "lo-bits_1",
+    "best_value": 24.14093768779649,
+    "median_name": "ufmbits_3",
+    "median_value": 24.973816021392835,
+    "worst_name": "hi-bits_1",
+    "worst_value": 27.112147046126655
+  },
+  "FullRightShift8_4": {
+    "best_name": "lo-bits_4",
+    "best_value": 27.79471720563507,
+    "median_name": "hi-bits_2",
+    "median_value": 28.963500272041706,
+    "worst_name": "ufmbits_1",
+    "worst_value": 36.84245055971786
+  },
+  "FullSubtract16": {
+    "best_name": "1hi-bits_+_self_2",
+    "best_value": 31.630855205696868,
+    "median_name": "1ufmbits_+_lo-bits_3",
+    "median_value": 39.62152412768696,
+    "worst_name": "1ufmbits_+_ufmbits_2",
+    "worst_value": 55.623896589421726
+  },
+  "FullSubtract32": {
+    "best_name": "1lo-bits_+_hi-bits_0",
+    "best_value": 32.43763403241118,
+    "median_name": "0hi-bits_+_ufmbits_3",
+    "median_value": 36.416396975639834,
+    "worst_name": "1ufmbits_+_ufmbits_2",
+    "worst_value": 51.616212989006456
+  },
+  "FullSubtract64": {
+    "best_name": "0lo-bits_+_hi-bits_3",
+    "best_value": 29.906646703036564,
+    "median_name": "0ufmbits_+_self_0",
+    "median_value": 32.80306038423194,
+    "worst_name": "1ufmbits_+_inv_self_0",
+    "worst_value": 54.967410316201295
+  },
+  "FullSubtract8": {
+    "best_name": "1lo-bits_+_self_4",
+    "best_value": 31.097305094843982,
+    "median_name": "0hi-bits_+_ufmbits_3",
+    "median_value": 39.5730108780589,
+    "worst_name": "1ufmbits_+_lo-bits_4",
+    "worst_value": 61.51792187912283
+  },
+  "GeIsOnCurve": {
+    "best_name": "ge_offc_fe_ufmbits_3",
+    "best_value": 353.82379393337584,
+    "median_name": "ge_offc_fe_hi-bits_3",
+    "median_value": 358.3881202218841,
+    "worst_name": "ge_offc_fe_outofrange_1",
+    "worst_value": 372.59440640105504
+  },
+  "GeNegate": {
+    "best_name": "ge_offc_fe_ufmbits_4",
+    "best_value": 557.0185208867863,
+    "median_name": "ge_offc_fe_hi-bits_2",
+    "median_value": 570.2297000755913,
+    "worst_name": "ge_offc_fe_outofrange_3",
+    "worst_value": 581.595755721832
+  },
+  "GejAdd": {
+    "best_name": "gej_zero_fe_lo-bits_+_gej_zero_fe_ufmbits_0",
+    "best_value": 1138.1412952383464,
+    "median_name": "gej_zero_fe_hi-bits_+_gej_zero_fe_outofrange_0",
+    "median_value": 1164.3049814107765,
+    "worst_name": "gej_offc_fe_outofrange_+_gej_offc_fe_outofrange_0",
+    "worst_value": 1657.760148571044
+  },
+  "GejDouble": {
+    "best_name": "gej_zero_fe_lo-bits_1",
+    "best_value": 796.9517054566229,
+    "median_name": "gej_offc_fe_lo-bits_3",
+    "median_value": 965.8108447372655,
+    "worst_name": "gej_offc_fe_outofrange_4",
+    "worst_value": 1011.2252782615327
+  },
+  "GejEquiv": {
+    "best_name": "gej_offc_fe_ufmbits_+_gej_zero_fe_ufmbits_1",
+    "best_value": 783.3577072316341,
+    "median_name": "gej_offc_fe_lo-bits_+_gej_zero_fe_outofrange_3",
+    "median_value": 807.2950511070411,
+    "worst_name": "gej_offc_fe_outofrange_+_gej_offc_fe_outofrange_2",
+    "worst_value": 1255.7459175163508
+  },
+  "GejGeAdd": {
+    "best_name": "gej_zero_fe_ufmbits_+_ge_offc_fe_ufmbits_4",
+    "best_value": 1028.7480839382838,
+    "median_name": "gej_offc_fe_lo-bits_+_ge_offc_fe_hi-bits_4",
+    "median_value": 1332.2667634722588,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_2",
+    "worst_value": 1438.8378191549323
+  },
+  "GejGeAddEx": {
+    "best_name": "gej_zero_fe_lo-bits_+_ge_offc_fe_ufmbits_0",
+    "best_value": 1153.7455614767935,
+    "median_name": "gej_offc_fe_lo-bits_+_ge_offc_fe_lo-bits_4",
+    "median_value": 1454.6975903474656,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_1",
+    "worst_value": 1557.934082829787
+  },
+  "GejGeEquiv": {
+    "best_name": "gej_zero_fe_hi-bits_+_ge_offc_fe_lo-bits_0",
+    "best_value": 632.6853700923862,
+    "median_name": "gej_offc_fe_lo-bits_+_ge_offc_fe_hi-bits_0",
+    "median_value": 912.1714177974519,
+    "worst_name": "gej_offc_fe_outofrange_+_ge_offc_fe_outofrange_2",
+    "worst_value": 1030.9450856936335
+  },
+  "GejInfinity": {
+    "best_name": "unit_2",
+    "best_value": 415.3351976014112,
+    "median_name": "unit_3",
+    "median_value": 417.81374727341563,
+    "worst_name": "unit_4",
+    "worst_value": 418.56445868023417
+  },
+  "GejIsInfinity": {
+    "best_name": "gej_zero_fe_ufmbits_3",
+    "best_value": 365.0138169358251,
+    "median_name": "gej_offc_fe_lo-bits_3",
+    "median_value": 367.2657845354594,
+    "worst_name": "gej_offc_fe_outofrange_4",
+    "worst_value": 379.3872302811702
+  },
+  "GejIsOnCurve": {
+    "best_name": "gej_zero_fe_ufmbits_3",
+    "best_value": 509.9883814482404,
+    "median_name": "gej_oncurve_4",
+    "median_value": 525.7299820227814,
+    "worst_name": "gej_offc_fe_outofrange_3",
+    "worst_value": 565.2506465055541
+  },
+  "GejNegate": {
+    "best_name": "gej_zero_fe_ufmbits_1",
+    "best_value": 814.7811361857869,
+    "median_name": "gej_oncurve_2",
+    "median_value": 826.0703382876811,
+    "worst_name": "gej_offc_fe_outofrange_2",
+    "worst_value": 853.0569406125574
+  },
+  "GejNormalize": {
+    "best_name": "gej_zero_fe_lo-bits_0",
+    "best_value": 381.20144273485187,
+    "median_name": "gej_offc_fe_outofrange_4",
+    "median_value": 1799.2338486049377,
+    "worst_name": "gej_oncurve_4",
+    "worst_value": 2296.431562500827
+  },
+  "GejRescale": {
+    "best_name": "gej_offc_fe_ufmbits_+_fe_ufmbits_4",
+    "best_value": 1015.3435158893693,
+    "median_name": "gej_zero_fe_lo-bits_+_fe_outofrange_0",
+    "median_value": 1027.4329081161188,
+    "worst_name": "gej_offc_fe_outofrange_+_fe_outofrange_1",
+    "worst_value": 1057.761537145273
+  },
+  "GejXEquiv": {
+    "best_name": "fe_ufmbits_+_gej_zero_fe_ufmbits_4",
+    "best_value": 493.27603031144145,
+    "median_name": "fe_lo-bits_+_gej_offc_fe_lo-bits_4",
+    "median_value": 546.3437653396105,
+    "worst_name": "fe_outofrange_+_gej_offc_fe_outofrange_1",
+    "worst_value": 594.4774443814613
+  },
+  "GejYIsOdd": {
+    "best_name": "gej_zero_fe_ufmbits_0",
+    "best_value": 372.3775177068044,
+    "median_name": "gej_offc_fe_outofrange_3",
+    "median_value": 1531.3815940088361,
+    "worst_name": "gej_oncurve_4",
+    "worst_value": 2037.0036184177516
+  },
+  "Generate": {
+    "best_name": "sc_lo-bits_1",
+    "best_value": 15543.415858780389,
+    "median_name": "scalar_outofrange_1",
+    "median_value": 24306.48321734035,
+    "worst_name": "sc_ufmbits_2",
+    "worst_value": 27379.692773958795
+  },
+  "HashToCurve": {
+    "best_name": "lo-bits_3",
+    "best_value": 38002.885560034614,
+    "median_name": "hi-bits_0",
+    "median_value": 38076.139762107305,
+    "worst_name": "ufmbits_4",
+    "worst_value": 38215.521833816994
+  },
+  "High1": {
+    "best_name": "unit_3",
+    "best_value": 22.299643619939847,
+    "median_name": "unit_1",
+    "median_value": 22.51449298502087,
+    "worst_name": "unit_0",
+    "worst_value": 23.45186140927267
+  },
+  "High16": {
+    "best_name": "unit_0",
+    "best_value": 27.765071598851268,
+    "median_name": "unit_1",
+    "median_value": 27.961503598819554,
+    "worst_name": "unit_2",
+    "worst_value": 28.11107932368974
+  },
+  "High32": {
+    "best_name": "unit_2",
+    "best_value": 29.18574313186135,
+    "median_name": "unit_1",
+    "median_value": 29.737848861262655,
+    "worst_name": "unit_0",
+    "worst_value": 31.009241390774033
+  },
+  "High64": {
+    "best_name": "unit_2",
+    "best_value": 29.00410487323586,
+    "median_name": "unit_3",
+    "median_value": 30.168794305597384,
+    "worst_name": "unit_1",
+    "worst_value": 30.61124234275793
+  },
+  "High8": {
+    "best_name": "unit_2",
+    "best_value": 23.73189846341212,
+    "median_name": "unit_4",
+    "median_value": 23.843076007407664,
+    "worst_name": "unit_3",
+    "worst_value": 26.011697831867977
+  },
+  "Increment16": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.031384234390863,
+    "median_name": "hi-bits_3",
+    "median_value": 30.585636694541744,
+    "worst_name": "lo-bits_1",
+    "worst_value": 38.47791117640849
+  },
+  "Increment32": {
+    "best_name": "ufmbits_3",
+    "best_value": 27.450794711260745,
+    "median_name": "ufmbits_4",
+    "median_value": 29.88565216143787,
+    "worst_name": "hi-bits_4",
+    "worst_value": 38.894105963964655
+  },
+  "Increment64": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.69935916853435,
+    "median_name": "lo-bits_4",
+    "median_value": 28.53312502908017,
+    "worst_name": "ufmbits_1",
+    "worst_value": 35.033229747156405
+  },
+  "Increment8": {
+    "best_name": "ufmbits_4",
+    "best_value": 27.66100277030423,
+    "median_name": "hi-bits_4",
+    "median_value": 30.287965879827812,
+    "worst_name": "lo-bits_2",
+    "worst_value": 40.35944926782277
+  },
+  "InputAnnexHash": {
+    "best_name": "17",
+    "best_value": 30.94790317884429,
+    "median_name": "74",
+    "median_value": 32.75880073832902,
+    "worst_name": "49",
+    "worst_value": 48.32008720302806
+  },
+  "InputAnnexesHash": {
+    "best_name": "18",
+    "best_value": 49.381809416828126,
+    "median_name": "77",
+    "median_value": 53.72726882653371,
+    "worst_name": "60",
+    "worst_value": 71.74222740313621
+  },
+  "InputHash": {
+    "best_name": "32",
+    "best_value": 359.8667377877019,
+    "median_name": "15",
+    "median_value": 364.1748929066421,
+    "worst_name": "70",
+    "worst_value": 466.68778406637216
+  },
+  "InputOutpointsHash": {
+    "best_name": "22",
+    "best_value": 49.66532833916388,
+    "median_name": "48",
+    "median_value": 53.045805641748366,
+    "worst_name": "96",
+    "worst_value": 67.32901893885486
+  },
+  "InputPrevOutpoint": {
+    "best_name": "6",
+    "best_value": 57.63480450861496,
+    "median_name": "38",
+    "median_value": 59.49846735630188,
+    "worst_name": "50",
+    "worst_value": 79.74256377732539
+  },
+  "InputScriptHash": {
+    "best_name": "93",
+    "best_value": 55.35046672741386,
+    "median_name": "92",
+    "median_value": 57.21419451978855,
+    "worst_name": "97",
+    "worst_value": 76.52397922526384
+  },
+  "InputScriptSigHash": {
+    "best_name": "68",
+    "best_value": 55.414497246570434,
+    "median_name": "6",
+    "median_value": 57.39930045654788,
+    "worst_name": "37",
+    "worst_value": 74.22276906690661
+  },
+  "InputScriptSigsHash": {
+    "best_name": "32",
+    "best_value": 49.561745111175306,
+    "median_name": "61",
+    "median_value": 53.88759223627982,
+    "worst_name": "90",
+    "worst_value": 71.3426523963421
+  },
+  "InputScriptsHash": {
+    "best_name": "2",
+    "best_value": 49.258799937337315,
+    "median_name": "83",
+    "median_value": 53.76582202655576,
+    "worst_name": "67",
+    "worst_value": 71.30187824028059
+  },
+  "InputSequence": {
+    "best_name": "8",
+    "best_value": 31.64010747918926,
+    "median_name": "60",
+    "median_value": 33.48957815218833,
+    "worst_name": "76",
+    "worst_value": 43.66468311984165
+  },
+  "InputSequencesHash": {
+    "best_name": "26",
+    "best_value": 49.520531708806594,
+    "median_name": "88",
+    "median_value": 53.886909711773235,
+    "worst_name": "46",
+    "worst_value": 66.68500865655754
+  },
+  "InputUtxoHash": {
+    "best_name": "2",
+    "best_value": 347.38240207122993,
+    "median_name": "17",
+    "median_value": 351.8921975637911,
+    "worst_name": "62",
+    "worst_value": 470.04251677363
+  },
+  "InputUtxosHash": {
+    "best_name": "42",
+    "best_value": 49.33388479032081,
+    "median_name": "24",
+    "median_value": 50.3864721808284,
+    "worst_name": "2",
+    "worst_value": 65.89473860472546
+  },
+  "InputValue": {
+    "best_name": "20",
+    "best_value": 30.700995608649723,
+    "median_name": "89",
+    "median_value": 33.050478038995905,
+    "worst_name": "83",
+    "worst_value": 43.803311015667674
+  },
+  "InputValuesHash": {
+    "best_name": "26",
+    "best_value": 49.7014998870719,
+    "median_name": "61",
+    "median_value": 54.426375746718556,
+    "worst_name": "99",
+    "worst_value": 70.22091376957377
+  },
+  "InputsHash": {
+    "best_name": "78",
+    "best_value": 49.30839750538625,
+    "median_name": "35",
+    "median_value": 50.14698259509657,
+    "worst_name": "24",
+    "worst_value": 65.87543158350655
+  },
+  "InternalKey": {
+    "best_name": "18",
+    "best_value": 49.650819625864614,
+    "median_name": "45",
+    "median_value": 51.603759226698855,
+    "worst_name": "92",
+    "worst_value": 67.9965331206053
+  },
+  "IsOne16": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.973157147849903,
+    "median_name": "hi-bits_4",
+    "median_value": 30.382579958277198,
+    "worst_name": "lo-bits_0",
+    "worst_value": 40.23637063102173
+  },
+  "IsOne32": {
+    "best_name": "ufmbits_2",
+    "best_value": 27.882036002498463,
+    "median_name": "hi-bits_1",
+    "median_value": 28.60707020429615,
+    "worst_name": "lo-bits_4",
+    "worst_value": 37.052822710619516
+  },
+  "IsOne64": {
+    "best_name": "hi-bits_2",
+    "best_value": 27.86062039042845,
+    "median_name": "lo-bits_0",
+    "median_value": 28.767791184925432,
+    "worst_name": "hi-bits_3",
+    "worst_value": 36.538731330607156
+  },
+  "IsOne8": {
+    "best_name": "ufmbits_0",
+    "best_value": 28.166168061060045,
+    "median_name": "lo-bits_2",
+    "median_value": 29.028966010842392,
+    "worst_name": "hi-bits_4",
+    "worst_value": 38.790886768678035
+  },
+  "IsZero16": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.725861845182738,
+    "median_name": "ufmbits_1",
+    "median_value": 31.776939263380086,
+    "worst_name": "lo-bits_2",
+    "worst_value": 32.623688065519815
+  },
+  "IsZero32": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.616179905150588,
+    "median_name": "lo-bits_2",
+    "median_value": 30.922433664187853,
+    "worst_name": "lo-bits_0",
+    "worst_value": 39.52703231960411
+  },
+  "IsZero64": {
+    "best_name": "hi-bits_3",
+    "best_value": 27.851036663213357,
+    "median_name": "lo-bits_0",
+    "median_value": 30.65806025359903,
+    "worst_name": "hi-bits_2",
+    "worst_value": 35.89261053309649
+  },
+  "IsZero8": {
+    "best_name": "ufmbits_2",
+    "best_value": 27.376453320375628,
+    "median_name": "lo-bits_3",
+    "median_value": 29.944527443390083,
+    "worst_name": "ufmbits_4",
+    "worst_value": 35.78171630693194
+  },
+  "Le16": {
+    "best_name": "ufmbits_+_self_4",
+    "best_value": 27.92796587350836,
+    "median_name": "hi-bits_+_self_4",
+    "median_value": 35.022005786641046,
+    "worst_name": "hi-bits_+_hi-bits_2",
+    "worst_value": 50.199686012655796
+  },
+  "Le32": {
+    "best_name": "lo-bits_+_hi-bits_0",
+    "best_value": 26.431907065951904,
+    "median_name": "hi-bits_+_inv_self_3",
+    "median_value": 30.448057106837904,
+    "worst_name": "ufmbits_+_inv_self_1",
+    "worst_value": 46.60434071450076
+  },
+  "Le64": {
+    "best_name": "hi-bits_+_self_2",
+    "best_value": 26.716436224843434,
+    "median_name": "ufmbits_+_self_3",
+    "median_value": 31.547139999999366,
+    "worst_name": "ufmbits_+_ufmbits_4",
+    "worst_value": 47.95736356357402
+  },
+  "Le8": {
+    "best_name": "lo-bits_+_self_2",
+    "best_value": 29.366080622337233,
+    "median_name": "ufmbits_+_hi-bits_1",
+    "median_value": 36.55449552402957,
+    "worst_name": "lo-bits_+_inv_self_2",
+    "worst_value": 53.31805571943979
+  },
+  "LeftExtend16_32": {
+    "best_name": "lo-bits_4",
+    "best_value": 28.972550009678592,
+    "median_name": "lo-bits_2",
+    "median_value": 30.11556881590642,
+    "worst_name": "ufmbits_4",
+    "worst_value": 31.438885778413393
+  },
+  "LeftExtend16_64": {
+    "best_name": "hi-bits_2",
+    "best_value": 33.92003241088647,
+    "median_name": "ufmbits_1",
+    "median_value": 35.76253416080938,
+    "worst_name": "ufmbits_0",
+    "worst_value": 43.559310764192816
+  },
+  "LeftExtend1_16": {
+    "best_name": "hi-bits_1",
+    "best_value": 23.932712181015404,
+    "median_name": "hi-bits_4",
+    "median_value": 25.435445110474912,
+    "worst_name": "ufmbits_1",
+    "worst_value": 33.67991797292207
+  },
+  "LeftExtend1_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 22.195803800557005,
+    "median_name": "ufmbits_2",
+    "median_value": 23.46390360887348,
+    "worst_name": "lo-bits_1",
+    "worst_value": 24.640263205890605
+  },
+  "LeftExtend1_64": {
+    "best_name": "hi-bits_1",
+    "best_value": 21.691513062260878,
+    "median_name": "lo-bits_3",
+    "median_value": 22.30365814479359,
+    "worst_name": "ufmbits_4",
+    "worst_value": 25.039437823075605
+  },
+  "LeftExtend1_8": {
+    "best_name": "ufmbits_3",
+    "best_value": 22.206462162095335,
+    "median_name": "hi-bits_0",
+    "median_value": 23.298780575814952,
+    "worst_name": "hi-bits_3",
+    "worst_value": 27.065629878078983
+  },
+  "LeftExtend32_64": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.73076928375196,
+    "median_name": "hi-bits_0",
+    "median_value": 29.20801514302782,
+    "worst_name": "lo-bits_3",
+    "worst_value": 30.566886374167456
+  },
+  "LeftExtend8_16": {
+    "best_name": "ufmbits_2",
+    "best_value": 27.974716141969957,
+    "median_name": "hi-bits_0",
+    "median_value": 29.020654201478152,
+    "worst_name": "ufmbits_0",
+    "worst_value": 38.81615933153458
+  },
+  "LeftExtend8_32": {
+    "best_name": "ufmbits_1",
+    "best_value": 34.72950508925983,
+    "median_name": "lo-bits_0",
+    "median_value": 36.19046358144753,
+    "worst_name": "hi-bits_2",
+    "worst_value": 38.15415974814403
+  },
+  "LeftExtend8_64": {
+    "best_name": "hi-bits_2",
+    "best_value": 49.79871969839609,
+    "median_name": "ufmbits_3",
+    "median_value": 52.017116102271736,
+    "worst_name": "lo-bits_3",
+    "worst_value": 53.936390100656666
+  },
+  "LeftPadHigh16_32": {
+    "best_name": "lo-bits_4",
+    "best_value": 29.662569067000298,
+    "median_name": "lo-bits_3",
+    "median_value": 30.91730281929867,
+    "worst_name": "hi-bits_4",
+    "worst_value": 36.45336517219934
+  },
+  "LeftPadHigh16_64": {
+    "best_name": "lo-bits_0",
+    "best_value": 38.99337715958087,
+    "median_name": "ufmbits_1",
+    "median_value": 40.18053607516153,
+    "worst_name": "hi-bits_1",
+    "worst_value": 52.71940373384631
+  },
+  "LeftPadHigh1_16": {
+    "best_name": "lo-bits_3",
+    "best_value": 53.60134187638946,
+    "median_name": "ufmbits_4",
+    "median_value": 54.96934336959359,
+    "worst_name": "hi-bits_0",
+    "worst_value": 64.03469751379582
+  },
+  "LeftPadHigh1_32": {
+    "best_name": "ufmbits_0",
+    "best_value": 89.87510756995373,
+    "median_name": "hi-bits_1",
+    "median_value": 93.20554989302931,
+    "worst_name": "hi-bits_0",
+    "worst_value": 116.32204813437987
+  },
+  "LeftPadHigh1_64": {
+    "best_name": "lo-bits_3",
+    "best_value": 161.3267468783336,
+    "median_name": "hi-bits_2",
+    "median_value": 162.84107343931382,
+    "worst_name": "ufmbits_4",
+    "worst_value": 204.55969274538245
+  },
+  "LeftPadHigh1_8": {
+    "best_name": "lo-bits_0",
+    "best_value": 35.56298688090474,
+    "median_name": "ufmbits_1",
+    "median_value": 36.212901008162994,
+    "worst_name": "ufmbits_0",
+    "worst_value": 42.002677113359695
+  },
+  "LeftPadHigh32_64": {
+    "best_name": "lo-bits_0",
+    "best_value": 30.115340271236622,
+    "median_name": "hi-bits_1",
+    "median_value": 34.9957108857454,
+    "worst_name": "hi-bits_3",
+    "worst_value": 37.995210174806715
+  },
+  "LeftPadHigh8_16": {
+    "best_name": "hi-bits_0",
+    "best_value": 36.998754751365354,
+    "median_name": "ufmbits_3",
+    "median_value": 37.64961760075175,
+    "worst_name": "lo-bits_0",
+    "worst_value": 52.749173455767384
+  },
+  "LeftPadHigh8_32": {
+    "best_name": "hi-bits_3",
+    "best_value": 43.33245672425131,
+    "median_name": "ufmbits_1",
+    "median_value": 45.35941956924248,
+    "worst_name": "lo-bits_4",
+    "worst_value": 48.2009398803875
+  },
+  "LeftPadHigh8_64": {
+    "best_name": "ufmbits_1",
+    "best_value": 50.16641007801979,
+    "median_name": "lo-bits_4",
+    "median_value": 52.29316056051543,
+    "worst_name": "hi-bits_0",
+    "worst_value": 66.08289310568132
+  },
+  "LeftPadLow16_32": {
+    "best_name": "ufmbits_3",
+    "best_value": 27.607487580761017,
+    "median_name": "hi-bits_3",
+    "median_value": 28.969932906177725,
+    "worst_name": "ufmbits_2",
+    "worst_value": 41.350363241455405
+  },
+  "LeftPadLow16_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 33.23745478209719,
+    "median_name": "hi-bits_1",
+    "median_value": 34.22091585435592,
+    "worst_name": "ufmbits_1",
+    "worst_value": 35.332778138400414
+  },
+  "LeftPadLow1_16": {
+    "best_name": "ufmbits_4",
+    "best_value": 22.209721719626337,
+    "median_name": "ufmbits_0",
+    "median_value": 23.539972794734844,
+    "worst_name": "lo-bits_0",
+    "worst_value": 25.352187843273622
+  },
+  "LeftPadLow1_32": {
+    "best_name": "hi-bits_1",
+    "best_value": 22.307585216676447,
+    "median_name": "ufmbits_0",
+    "median_value": 25.193226348604718,
+    "worst_name": "lo-bits_4",
+    "worst_value": 26.758500427448265
+  },
+  "LeftPadLow1_64": {
+    "best_name": "lo-bits_1",
+    "best_value": 22.10478087309454,
+    "median_name": "ufmbits_4",
+    "median_value": 23.88746068474562,
+    "worst_name": "lo-bits_2",
+    "worst_value": 32.355820832552034
+  },
+  "LeftPadLow1_8": {
+    "best_name": "lo-bits_0",
+    "best_value": 21.803998537259446,
+    "median_name": "lo-bits_2",
+    "median_value": 24.91981989727577,
+    "worst_name": "ufmbits_4",
+    "worst_value": 32.94821125113322
+  },
+  "LeftPadLow32_64": {
+    "best_name": "ufmbits_2",
+    "best_value": 28.112067349780208,
+    "median_name": "hi-bits_4",
+    "median_value": 28.46376377811367,
+    "worst_name": "hi-bits_0",
+    "worst_value": 30.723009379193225
+  },
+  "LeftPadLow8_16": {
+    "best_name": "lo-bits_2",
+    "best_value": 26.725854396340466,
+    "median_name": "ufmbits_1",
+    "median_value": 36.048837202121156,
+    "worst_name": "hi-bits_2",
+    "worst_value": 39.72627165532422
+  },
+  "LeftPadLow8_32": {
+    "best_name": "ufmbits_3",
+    "best_value": 32.66957436335178,
+    "median_name": "lo-bits_2",
+    "median_value": 35.02904461217318,
+    "worst_name": "ufmbits_0",
+    "worst_value": 44.46426932405703
+  },
+  "LeftPadLow8_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 46.48507954102645,
+    "median_name": "lo-bits_3",
+    "median_value": 48.16144453147444,
+    "worst_name": "ufmbits_2",
+    "worst_value": 63.81352280486447
+  },
+  "LeftRotate16": {
+    "best_name": "hi-bits_3",
+    "best_value": 30.297565649883133,
+    "median_name": "ufmbits_1",
+    "median_value": 31.60601025186517,
+    "worst_name": "lo-bits_0",
+    "worst_value": 46.659418700819096
+  },
+  "LeftRotate32": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.41932882717346,
+    "median_name": "lo-bits_1",
+    "median_value": 34.58594378076936,
+    "worst_name": "hi-bits_3",
+    "worst_value": 39.303050701671175
+  },
+  "LeftRotate64": {
+    "best_name": "hi-bits_1",
+    "best_value": 28.41924740893881,
+    "median_name": "hi-bits_0",
+    "median_value": 29.533899613894945,
+    "worst_name": "lo-bits_0",
+    "worst_value": 37.49751609704187
+  },
+  "LeftRotate8": {
+    "best_name": "hi-bits_3",
+    "best_value": 28.25553539227856,
+    "median_name": "hi-bits_4",
+    "median_value": 29.256560896569873,
+    "worst_name": "hi-bits_1",
+    "worst_value": 30.846338944961705
+  },
+  "LeftShift16": {
+    "best_name": "ufmbits_2",
+    "best_value": 34.94323201589267,
+    "median_name": "ufmbits_1",
+    "median_value": 35.815237102906224,
+    "worst_name": "hi-bits_0",
+    "worst_value": 38.456865343264006
+  },
+  "LeftShift32": {
+    "best_name": "hi-bits_0",
+    "best_value": 29.8225373141846,
+    "median_name": "lo-bits_2",
+    "median_value": 31.530996780531105,
+    "worst_name": "lo-bits_0",
+    "worst_value": 41.43346189246683
+  },
+  "LeftShift64": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.04821715901116,
+    "median_name": "lo-bits_1",
+    "median_value": 29.1446840400573,
+    "worst_name": "ufmbits_3",
+    "worst_value": 30.740209132269907
+  },
+  "LeftShift8": {
+    "best_name": "lo-bits_4",
+    "best_value": 31.936510788696502,
+    "median_name": "ufmbits_2",
+    "median_value": 34.89935032298454,
+    "worst_name": "ufmbits_0",
+    "worst_value": 44.07170600600044
+  },
+  "LeftShiftWith16": {
+    "best_name": "lo-bits_0",
+    "best_value": 32.36826621290135,
+    "median_name": "hi-bits_2",
+    "median_value": 34.611184552618056,
+    "worst_name": "lo-bits_1",
+    "worst_value": 42.75802295100243
+  },
+  "LeftShiftWith32": {
+    "best_name": "lo-bits_2",
+    "best_value": 30.896821383689485,
+    "median_name": "hi-bits_2",
+    "median_value": 32.72445998454135,
+    "worst_name": "ufmbits_0",
+    "worst_value": 47.50071202148396
+  },
+  "LeftShiftWith64": {
+    "best_name": "lo-bits_4",
+    "best_value": 32.99097130751444,
+    "median_name": "ufmbits_2",
+    "median_value": 38.729988878783935,
+    "worst_name": "lo-bits_1",
+    "worst_value": 41.69394384233441
+  },
+  "LeftShiftWith8": {
+    "best_name": "lo-bits_3",
+    "best_value": 34.43215004108189,
+    "median_name": "hi-bits_1",
+    "median_value": 35.565239561111284,
+    "worst_name": "ufmbits_3",
+    "worst_value": 40.95723180078758
+  },
+  "Leftmost16_1": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.044981853526984,
+    "median_name": "lo-bits_0",
+    "median_value": 26.906527008719713,
+    "worst_name": "hi-bits_4",
+    "worst_value": 29.066768518337454
+  },
+  "Leftmost16_2": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.090626881159313,
+    "median_name": "hi-bits_4",
+    "median_value": 31.073453213821743,
+    "worst_name": "ufmbits_4",
+    "worst_value": 36.07235177162623
+  },
+  "Leftmost16_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 28.403646462651285,
+    "median_name": "hi-bits_1",
+    "median_value": 28.97163402543919,
+    "worst_name": "ufmbits_4",
+    "worst_value": 29.92268220161827
+  },
+  "Leftmost16_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.66807811484587,
+    "median_name": "ufmbits_2",
+    "median_value": 28.49912423698764,
+    "worst_name": "ufmbits_4",
+    "worst_value": 36.78287649109752
+  },
+  "Leftmost32_1": {
+    "best_name": "lo-bits_0",
+    "best_value": 28.116292443838873,
+    "median_name": "hi-bits_4",
+    "median_value": 29.676657172977052,
+    "worst_name": "ufmbits_3",
+    "worst_value": 32.51374018946871
+  },
+  "Leftmost32_16": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.65272792811637,
+    "median_name": "lo-bits_3",
+    "median_value": 29.338322939707766,
+    "worst_name": "hi-bits_3",
+    "worst_value": 39.27373417614524
+  },
+  "Leftmost32_2": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.180701221831473,
+    "median_name": "hi-bits_2",
+    "median_value": 29.12128260171338,
+    "worst_name": "hi-bits_4",
+    "worst_value": 29.987099963517792
+  },
+  "Leftmost32_4": {
+    "best_name": "lo-bits_1",
+    "best_value": 28.058053462568378,
+    "median_name": "lo-bits_2",
+    "median_value": 29.517694007947252,
+    "worst_name": "ufmbits_2",
+    "worst_value": 33.87813882375988
+  },
+  "Leftmost32_8": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.755627579825806,
+    "median_name": "hi-bits_2",
+    "median_value": 29.385527084900477,
+    "worst_name": "ufmbits_0",
+    "worst_value": 35.49839679349175
+  },
+  "Leftmost64_1": {
+    "best_name": "ufmbits_1",
+    "best_value": 27.969944199699203,
+    "median_name": "ufmbits_4",
+    "median_value": 29.184577603360285,
+    "worst_name": "lo-bits_4",
+    "worst_value": 33.91825138884263
+  },
+  "Leftmost64_16": {
+    "best_name": "hi-bits_2",
+    "best_value": 25.73970401782861,
+    "median_name": "lo-bits_0",
+    "median_value": 30.29130664104698,
+    "worst_name": "ufmbits_0",
+    "worst_value": 37.18143747485129
+  },
+  "Leftmost64_2": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.331834929396532,
+    "median_name": "hi-bits_1",
+    "median_value": 28.838009094276682,
+    "worst_name": "lo-bits_2",
+    "worst_value": 30.094946836071536
+  },
+  "Leftmost64_32": {
+    "best_name": "lo-bits_1",
+    "best_value": 26.703870639021833,
+    "median_name": "hi-bits_3",
+    "median_value": 27.546440869557486,
+    "worst_name": "ufmbits_3",
+    "worst_value": 29.620830478396343
+  },
+  "Leftmost64_4": {
+    "best_name": "ufmbits_4",
+    "best_value": 28.588434372554037,
+    "median_name": "lo-bits_4",
+    "median_value": 29.74921406065665,
+    "worst_name": "lo-bits_1",
+    "worst_value": 37.3876211230469
+  },
+  "Leftmost64_8": {
+    "best_name": "ufmbits_0",
+    "best_value": 27.827178251156315,
+    "median_name": "lo-bits_3",
+    "median_value": 29.388486251428432,
+    "worst_name": "hi-bits_0",
+    "worst_value": 33.68162103632444
+  },
+  "Leftmost8_1": {
+    "best_name": "lo-bits_2",
+    "best_value": 25.316768540516737,
+    "median_name": "hi-bits_4",
+    "median_value": 26.652332505372364,
+    "worst_name": "hi-bits_1",
+    "worst_value": 28.00933298468944
+  },
+  "Leftmost8_2": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.891666442513113,
+    "median_name": "hi-bits_1",
+    "median_value": 28.118279610529868,
+    "worst_name": "hi-bits_3",
+    "worst_value": 35.48801877238981
+  },
+  "Leftmost8_4": {
+    "best_name": "hi-bits_0",
+    "best_value": 25.288776129969364,
+    "median_name": "hi-bits_1",
+    "median_value": 27.521784636594237,
+    "worst_name": "ufmbits_0",
+    "worst_value": 31.25153481180549
+  },
+  "LinearCombination1": {
+    "best_name": "sc_ufmbits_+_gej_offc_fe_ufmbits_+_sc_ufmbits_3",
+    "best_value": 772.8134767677141,
+    "median_name": "sc_hi-bits_+_gej_zero_fe_hi-bits_+_sc_hi-bits_4",
+    "median_value": 802.6728864893978,
+    "worst_name": "sc_ufmbits_+_gej_oncurve_+_sc_ufmbits_2",
+    "worst_value": 47125.84949536951
+  },
+  "LinearVerify1": {
+    "best_name": "scalar_outofrange_+_ge_offc_fe_lo-bits_+_scalar_outofrange_+_ge__6",
+    "best_value": 827.2094206549624,
+    "median_name": "sc_ufmbits_+_ge_offc_fe_ufmbits_+_sc_ufmbits_+_ge_offc_fe_hi-bit_4",
+    "median_value": 844.2434578759087,
+    "worst_name": "sc_hi-bits_+_ge_oncurve_+_sc_ufmbits_+_ge_oncurve_2",
+    "worst_value": 48069.049867485504
+  },
+  "LockTime": {
+    "best_name": "59",
+    "best_value": 27.474551488809038,
+    "median_name": "78",
+    "median_value": 28.066833962780724,
+    "worst_name": "94",
+    "worst_value": 37.83093201967008
+  },
+  "Low1": {
+    "best_name": "unit_0",
+    "best_value": 22.679099356581943,
+    "median_name": "unit_1",
+    "median_value": 24.155644617237375,
+    "worst_name": "unit_3",
+    "worst_value": 24.481354264080416
+  },
+  "Low16": {
+    "best_name": "unit_3",
+    "best_value": 25.753137792072494,
+    "median_name": "unit_0",
+    "median_value": 25.98799773325223,
+    "worst_name": "unit_2",
+    "worst_value": 26.812925671194485
+  },
+  "Low32": {
+    "best_name": "unit_0",
+    "best_value": 27.145385422141604,
+    "median_name": "unit_1",
+    "median_value": 28.99170604384236,
+    "worst_name": "unit_4",
+    "worst_value": 29.624900618827567
+  },
+  "Low64": {
+    "best_name": "unit_2",
+    "best_value": 26.99485527842568,
+    "median_name": "unit_3",
+    "median_value": 28.831510145473214,
+    "worst_name": "unit_1",
+    "worst_value": 30.133567240483636
+  },
+  "Low8": {
+    "best_name": "unit_2",
+    "best_value": 25.892626099575427,
+    "median_name": "unit_4",
+    "median_value": 26.04500851388457,
+    "worst_name": "unit_0",
+    "worst_value": 26.888782913816
+  },
+  "Lt16": {
+    "best_name": "ufmbits_+_self_3",
+    "best_value": 29.452997556497948,
+    "median_name": "hi-bits_+_ufmbits_0",
+    "median_value": 35.623628291433526,
+    "worst_name": "hi-bits_+_inv_self_2",
+    "worst_value": 46.56111643859773
+  },
+  "Lt32": {
+    "best_name": "lo-bits_+_self_3",
+    "best_value": 27.276498077770192,
+    "median_name": "ufmbits_+_hi-bits_4",
+    "median_value": 33.81688202115011,
+    "worst_name": "lo-bits_+_lo-bits_3",
+    "worst_value": 48.26496714945273
+  },
+  "Lt64": {
+    "best_name": "lo-bits_+_hi-bits_2",
+    "best_value": 26.514308837266434,
+    "median_name": "hi-bits_+_lo-bits_4",
+    "median_value": 30.127048084993806,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 39.79169854395137
+  },
+  "Lt8": {
+    "best_name": "hi-bits_+_self_1",
+    "best_value": 29.213662440078068,
+    "median_name": "lo-bits_+_inv_self_1",
+    "median_value": 34.65931405553561,
+    "worst_name": "lo-bits_+_ufmbits_1",
+    "worst_value": 43.279217924354896
+  },
+  "Maj1": {
+    "best_name": "hi-bits_2",
+    "best_value": 22.262903655724262,
+    "median_name": "lo-bits_0",
+    "median_value": 23.1180965737752,
+    "worst_name": "lo-bits_2",
+    "worst_value": 24.169455557000777
+  },
+  "Maj16": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.904789641341207,
+    "median_name": "ufmbits_3",
+    "median_value": 34.03184364091939,
+    "worst_name": "lo-bits_4",
+    "worst_value": 41.25037368584844
+  },
+  "Maj32": {
+    "best_name": "lo-bits_2",
+    "best_value": 31.268582847034672,
+    "median_name": "ufmbits_1",
+    "median_value": 34.19129408149181,
+    "worst_name": "lo-bits_3",
+    "worst_value": 43.701318728894854
+  },
+  "Maj64": {
+    "best_name": "hi-bits_2",
+    "best_value": 30.252583711094218,
+    "median_name": "hi-bits_1",
+    "median_value": 32.486186300382435,
+    "worst_name": "ufmbits_4",
+    "worst_value": 36.34663411597296
+  },
+  "Maj8": {
+    "best_name": "lo-bits_0",
+    "best_value": 31.59170897414952,
+    "median_name": "ufmbits_1",
+    "median_value": 33.06178852131773,
+    "worst_name": "hi-bits_0",
+    "worst_value": 38.21863075381438
+  },
+  "Max16": {
+    "best_name": "lo-bits_+_ufmbits_4",
+    "best_value": 28.883808677705748,
+    "median_name": "lo-bits_+_ufmbits_2",
+    "median_value": 31.70301525436378,
+    "worst_name": "ufmbits_+_lo-bits_1",
+    "worst_value": 76.30831275036252
+  },
+  "Max32": {
+    "best_name": "hi-bits_+_ufmbits_0",
+    "best_value": 28.481809422183563,
+    "median_name": "hi-bits_+_hi-bits_0",
+    "median_value": 31.08556934777927,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 40.18583556165997
+  },
+  "Max64": {
+    "best_name": "lo-bits_+_self_0",
+    "best_value": 33.980670608844335,
+    "median_name": "ufmbits_+_hi-bits_3",
+    "median_value": 36.35402228616656,
+    "worst_name": "ufmbits_+_inv_self_1",
+    "worst_value": 49.799894662863224
+  },
+  "Max8": {
+    "best_name": "ufmbits_+_self_2",
+    "best_value": 26.969640408862666,
+    "median_name": "lo-bits_+_lo-bits_0",
+    "median_value": 32.581265149774225,
+    "worst_name": "lo-bits_+_self_1",
+    "worst_value": 43.107878126082134
+  },
+  "Median16": {
+    "best_name": "lo-bits_3",
+    "best_value": 40.85872230612034,
+    "median_name": "lo-bits_1",
+    "median_value": 42.276226186235725,
+    "worst_name": "ufmbits_1",
+    "worst_value": 57.09912092788068
+  },
+  "Median32": {
+    "best_name": "hi-bits_4",
+    "best_value": 36.73258028066777,
+    "median_name": "ufmbits_3",
+    "median_value": 40.32074737207238,
+    "worst_name": "lo-bits_4",
+    "worst_value": 47.528406934070674
+  },
+  "Median64": {
+    "best_name": "lo-bits_4",
+    "best_value": 36.88279489605743,
+    "median_name": "ufmbits_2",
+    "median_value": 39.2618747344671,
+    "worst_name": "ufmbits_3",
+    "worst_value": 42.640961760305906
+  },
+  "Median8": {
+    "best_name": "ufmbits_4",
+    "best_value": 43.42693525668619,
+    "median_name": "lo-bits_2",
+    "median_value": 45.11056470559151,
+    "worst_name": "hi-bits_4",
+    "worst_value": 57.9836980977018
+  },
+  "Min16": {
+    "best_name": "ufmbits_+_inv_self_3",
+    "best_value": 30.401153014413723,
+    "median_name": "hi-bits_+_lo-bits_4",
+    "median_value": 34.67223817550963,
+    "worst_name": "hi-bits_+_self_0",
+    "worst_value": 44.01671500882819
+  },
+  "Min32": {
+    "best_name": "ufmbits_+_ufmbits_0",
+    "best_value": 30.666300953974726,
+    "median_name": "hi-bits_+_lo-bits_1",
+    "median_value": 32.63378477809471,
+    "worst_name": "ufmbits_+_lo-bits_2",
+    "worst_value": 41.396985728881184
+  },
+  "Min64": {
+    "best_name": "lo-bits_+_hi-bits_0",
+    "best_value": 28.471638296017773,
+    "median_name": "ufmbits_+_lo-bits_3",
+    "median_value": 30.69989510527431,
+    "worst_name": "ufmbits_+_hi-bits_1",
+    "worst_value": 37.950363367677376
+  },
+  "Min8": {
+    "best_name": "ufmbits_+_ufmbits_1",
+    "best_value": 32.665082902338334,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 35.45810425080893,
+    "worst_name": "ufmbits_+_inv_self_4",
+    "worst_value": 43.752395860816094
+  },
+  "Modulo16": {
+    "best_name": "lo-bits_+_hi-bits_4",
+    "best_value": 30.332934011706097,
+    "median_name": "lo-bits_+_lo-bits_4",
+    "median_value": 33.75462358562454,
+    "worst_name": "hi-bits_+_self_0",
+    "worst_value": 47.85531520777763
+  },
+  "Modulo32": {
+    "best_name": "hi-bits_+_hi-bits_0",
+    "best_value": 30.938291080313082,
+    "median_name": "lo-bits_+_self_3",
+    "median_value": 33.35328679154348,
+    "worst_name": "lo-bits_+_hi-bits_1",
+    "worst_value": 42.86132698325572
+  },
+  "Modulo64": {
+    "best_name": "ufmbits_+_ufmbits_1",
+    "best_value": 30.296586991666196,
+    "median_name": "lo-bits_+_self_3",
+    "median_value": 34.4779185316878,
+    "worst_name": "ufmbits_+_ufmbits_2",
+    "worst_value": 41.193237533931715
+  },
+  "Modulo8": {
+    "best_name": "lo-bits_+_hi-bits_3",
+    "best_value": 29.6090787015576,
+    "median_name": "hi-bits_+_lo-bits_2",
+    "median_value": 33.29457313528445,
+    "worst_name": "lo-bits_+_ufmbits_2",
+    "worst_value": 42.812087208634374
+  },
+  "Multiply16": {
+    "best_name": "ufmbits_+_hi-bits_3",
+    "best_value": 29.345738393784714,
+    "median_name": "ufmbits_+_self_2",
+    "median_value": 32.034425350737145,
+    "worst_name": "hi-bits_+_lo-bits_0",
+    "worst_value": 41.15544251979778
+  },
+  "Multiply32": {
+    "best_name": "hi-bits_+_ufmbits_2",
+    "best_value": 27.824742817517336,
+    "median_name": "lo-bits_+_inv_self_2",
+    "median_value": 30.729955835488255,
+    "worst_name": "ufmbits_+_self_4",
+    "worst_value": 38.3353788276212
+  },
+  "Multiply64": {
+    "best_name": "ufmbits_+_hi-bits_0",
+    "best_value": 31.676063517187636,
+    "median_name": "hi-bits_+_hi-bits_1",
+    "median_value": 33.29783438913482,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 46.97836039841965
+  },
+  "Multiply8": {
+    "best_name": "ufmbits_+_ufmbits_3",
+    "best_value": 28.062244572904547,
+    "median_name": "lo-bits_+_self_1",
+    "median_value": 30.345846111119823,
+    "worst_name": "ufmbits_+_inv_self_0",
+    "worst_value": 40.5452617478648
+  },
+  "Negate16": {
+    "best_name": "hi-bits_1",
+    "best_value": 27.497513947864782,
+    "median_name": "hi-bits_2",
+    "median_value": 30.49642356107227,
+    "worst_name": "ufmbits_2",
+    "worst_value": 38.1357237046367
+  },
+  "Negate32": {
+    "best_name": "ufmbits_2",
+    "best_value": 26.568828279989706,
+    "median_name": "lo-bits_2",
+    "median_value": 29.924890313740352,
+    "worst_name": "hi-bits_2",
+    "worst_value": 38.02750584484854
+  },
+  "Negate64": {
+    "best_name": "hi-bits_1",
+    "best_value": 25.462608259903426,
+    "median_name": "ufmbits_3",
+    "median_value": 27.600475756829166,
+    "worst_name": "lo-bits_3",
+    "worst_value": 32.383066541092454
+  },
+  "Negate8": {
+    "best_name": "ufmbits_2",
+    "best_value": 26.464219693443983,
+    "median_name": "hi-bits_0",
+    "median_value": 27.62845770191565,
+    "worst_name": "lo-bits_0",
+    "worst_value": 29.876055795609123
+  },
+  "NumInputs": {
+    "best_name": "90",
+    "best_value": 27.47223638883049,
+    "median_name": "25",
+    "median_value": 28.13889380377229,
+    "worst_name": "41",
+    "worst_value": 39.13834262285835
+  },
+  "NumOutputs": {
+    "best_name": "32",
+    "best_value": 27.273906821014645,
+    "median_name": "60",
+    "median_value": 27.948634268936026,
+    "worst_name": "51",
+    "worst_value": 39.79130687875217
+  },
+  "One16": {
+    "best_name": "unit_2",
+    "best_value": 25.547976880725784,
+    "median_name": "unit_3",
+    "median_value": 26.02162365255058,
+    "worst_name": "unit_4",
+    "worst_value": 26.111154803530482
+  },
+  "One32": {
+    "best_name": "unit_0",
+    "best_value": 24.690469934911256,
+    "median_name": "unit_2",
+    "median_value": 25.19683972685467,
+    "worst_name": "unit_1",
+    "worst_value": 26.285800788817582
+  },
+  "One64": {
+    "best_name": "unit_1",
+    "best_value": 24.74662246740359,
+    "median_name": "unit_4",
+    "median_value": 25.231900584034243,
+    "worst_name": "unit_2",
+    "worst_value": 26.101175243721542
+  },
+  "One8": {
+    "best_name": "unit_0",
+    "best_value": 29.666823112816143,
+    "median_name": "unit_2",
+    "median_value": 29.823048280840254,
+    "worst_name": "unit_1",
+    "worst_value": 31.54326282731502
+  },
+  "Or1": {
+    "best_name": "lo-bits_+_hi-bits_2",
+    "best_value": 21.938575376772974,
+    "median_name": "hi-bits_+_self_0",
+    "median_value": 24.4792327280748,
+    "worst_name": "hi-bits_+_inv_self_1",
+    "worst_value": 34.76028150371703
+  },
+  "Or16": {
+    "best_name": "ufmbits_+_lo-bits_1",
+    "best_value": 30.378302702602227,
+    "median_name": "ufmbits_+_self_1",
+    "median_value": 32.947915646954,
+    "worst_name": "ufmbits_+_hi-bits_3",
+    "worst_value": 47.11925366364111
+  },
+  "Or32": {
+    "best_name": "ufmbits_+_lo-bits_3",
+    "best_value": 29.24975943546531,
+    "median_name": "hi-bits_+_ufmbits_1",
+    "median_value": 32.6633194613768,
+    "worst_name": "lo-bits_+_inv_self_2",
+    "worst_value": 40.69113831278567
+  },
+  "Or64": {
+    "best_name": "lo-bits_+_inv_self_0",
+    "best_value": 28.27497534851846,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 30.54915075291714,
+    "worst_name": "ufmbits_+_ufmbits_2",
+    "worst_value": 40.38576709941571
+  },
+  "Or8": {
+    "best_name": "hi-bits_+_inv_self_1",
+    "best_value": 28.781181609789297,
+    "median_name": "ufmbits_+_inv_self_4",
+    "median_value": 31.14646165813886,
+    "worst_name": "ufmbits_+_hi-bits_4",
+    "worst_value": 40.92824706134167
+  },
+  "OutpointHash": {
+    "best_name": "86",
+    "best_value": 684.6974304676077,
+    "median_name": "30",
+    "median_value": 698.2986666666667,
+    "worst_name": "9",
+    "worst_value": 726.8280000000003
+  },
+  "OutputHash": {
+    "best_name": "17",
+    "best_value": 346.64025560640107,
+    "median_name": "95",
+    "median_value": 352.8512607689944,
+    "worst_name": "49",
+    "worst_value": 492.2940417451927
+  },
+  "OutputScriptHash": {
+    "best_name": "2",
+    "best_value": 63.27458582230711,
+    "median_name": "79",
+    "median_value": 65.4931747260199,
+    "worst_name": "52",
+    "worst_value": 84.06506442052486
+  },
+  "OutputScriptsHash": {
+    "best_name": "8",
+    "best_value": 67.07292595141833,
+    "median_name": "41",
+    "median_value": 68.81073326888233,
+    "worst_name": "82",
+    "worst_value": 90.81798722455049
+  },
+  "OutputValue": {
+    "best_name": "0",
+    "best_value": 36.737554300273395,
+    "median_name": "32",
+    "median_value": 38.82191492526313,
+    "worst_name": "60",
+    "worst_value": 49.178824402025995
+  },
+  "OutputValuesHash": {
+    "best_name": "45",
+    "best_value": 49.67323792696138,
+    "median_name": "67",
+    "median_value": 50.80244527518262,
+    "worst_name": "84",
+    "worst_value": 72.70764151343502
+  },
+  "OutputsHash": {
+    "best_name": "27",
+    "best_value": 60.408854471445345,
+    "median_name": "55",
+    "median_value": 61.26080174119903,
+    "worst_name": "47",
+    "worst_value": 84.07619094796843
+  },
+  "ParseLock": {
+    "best_name": "hi-bits_4",
+    "best_value": 31.115233155562947,
+    "median_name": "lo-bits_3",
+    "median_value": 35.63381592919047,
+    "worst_name": "hi-bits_1",
+    "worst_value": 37.24159775287828
+  },
+  "ParseSequence": {
+    "best_name": "0hi-bits_2",
+    "best_value": 34.12052657485773,
+    "median_name": "1hi-bits_2",
+    "median_value": 35.67053431872727,
+    "worst_name": "1ufmbits_4",
+    "worst_value": 48.862700257177046
+  },
+  "PointVerify1": {
+    "best_name": "sc_lo-bits_+_pt_ge_offc_fe_lo-bits_+_sc_lo-bits_+_pt_ge_offc_fe__6",
+    "best_value": 14867.426167958192,
+    "median_name": "sc_lo-bits_+_pt_ge_offc_fe_ufmbits_+_sc_ufmbits_+_pt_ge_offc_fe__11",
+    "median_value": 20205.797695834866,
+    "worst_name": "sc_hi-bits_+_pt_ge_oncurve_+_sc_ufmbits_+_pt_ge_oncurve_0",
+    "worst_value": 45774.49134898451
+  },
+  "RightExtend16_32": {
+    "best_name": "ufmbits_2",
+    "best_value": 29.04189250058864,
+    "median_name": "ufmbits_3",
+    "median_value": 29.67657907299813,
+    "worst_name": "hi-bits_1",
+    "worst_value": 31.444424081779594
+  },
+  "RightExtend16_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 33.516332853621606,
+    "median_name": "lo-bits_1",
+    "median_value": 34.2437523931555,
+    "worst_name": "hi-bits_1",
+    "worst_value": 35.891427345027225
+  },
+  "RightExtend32_64": {
+    "best_name": "ufmbits_1",
+    "best_value": 28.22438332994826,
+    "median_name": "ufmbits_2",
+    "median_value": 29.408279461017596,
+    "worst_name": "hi-bits_3",
+    "worst_value": 30.94514757993969
+  },
+  "RightExtend8_16": {
+    "best_name": "ufmbits_2",
+    "best_value": 28.382069730243582,
+    "median_name": "hi-bits_0",
+    "median_value": 30.631434479500353,
+    "worst_name": "lo-bits_2",
+    "worst_value": 36.669619088462134
+  },
+  "RightExtend8_32": {
+    "best_name": "ufmbits_3",
+    "best_value": 34.00612037134374,
+    "median_name": "lo-bits_4",
+    "median_value": 35.33836304474532,
+    "worst_name": "hi-bits_1",
+    "worst_value": 36.8647794626864
+  },
+  "RightExtend8_64": {
+    "best_name": "hi-bits_3",
+    "best_value": 49.591349727959056,
+    "median_name": "hi-bits_4",
+    "median_value": 50.99787315817984,
+    "worst_name": "lo-bits_3",
+    "worst_value": 66.46869218870866
+  },
+  "RightPadHigh16_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 27.353369122221594,
+    "median_name": "lo-bits_1",
+    "median_value": 28.124217650515035,
+    "worst_name": "ufmbits_1",
+    "worst_value": 35.12918414336875
+  },
+  "RightPadHigh16_64": {
+    "best_name": "hi-bits_0",
+    "best_value": 32.96933261159905,
+    "median_name": "hi-bits_4",
+    "median_value": 33.4170556686974,
+    "worst_name": "ufmbits_1",
+    "worst_value": 34.759983599689264
+  },
+  "RightPadHigh1_16": {
+    "best_name": "ufmbits_3",
+    "best_value": 52.00038274964855,
+    "median_name": "hi-bits_3",
+    "median_value": 54.84147270416412,
+    "worst_name": "ufmbits_1",
+    "worst_value": 73.445004469676
+  },
+  "RightPadHigh1_32": {
+    "best_name": "hi-bits_4",
+    "best_value": 87.33464188687476,
+    "median_name": "lo-bits_2",
+    "median_value": 89.22721217407042,
+    "worst_name": "hi-bits_3",
+    "worst_value": 92.35954055376001
+  },
+  "RightPadHigh1_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 159.27589346919385,
+    "median_name": "ufmbits_2",
+    "median_value": 161.19599461778682,
+    "worst_name": "lo-bits_0",
+    "worst_value": 162.6738093517884
+  },
+  "RightPadHigh1_8": {
+    "best_name": "hi-bits_2",
+    "best_value": 39.055701329522556,
+    "median_name": "lo-bits_4",
+    "median_value": 48.91765581207538,
+    "worst_name": "ufmbits_1",
+    "worst_value": 53.29789612426505
+  },
+  "RightPadHigh32_64": {
+    "best_name": "hi-bits_4",
+    "best_value": 27.60755583389023,
+    "median_name": "lo-bits_0",
+    "median_value": 29.02881339622727,
+    "worst_name": "ufmbits_3",
+    "worst_value": 37.06712160478276
+  },
+  "RightPadHigh8_16": {
+    "best_name": "ufmbits_4",
+    "best_value": 28.588321157029004,
+    "median_name": "ufmbits_1",
+    "median_value": 30.073786566123328,
+    "worst_name": "hi-bits_3",
+    "worst_value": 32.049936241312324
+  },
+  "RightPadHigh8_32": {
+    "best_name": "hi-bits_0",
+    "best_value": 33.05425596015659,
+    "median_name": "ufmbits_2",
+    "median_value": 33.99243739006194,
+    "worst_name": "lo-bits_0",
+    "worst_value": 35.46845748488683
+  },
+  "RightPadHigh8_64": {
+    "best_name": "hi-bits_4",
+    "best_value": 48.33085771289309,
+    "median_name": "ufmbits_2",
+    "median_value": 48.854583784866875,
+    "worst_name": "lo-bits_3",
+    "worst_value": 51.13632423044618
+  },
+  "RightPadLow16_32": {
+    "best_name": "hi-bits_2",
+    "best_value": 27.717711907142892,
+    "median_name": "ufmbits_1",
+    "median_value": 31.401376812164862,
+    "worst_name": "ufmbits_3",
+    "worst_value": 32.426174649085354
+  },
+  "RightPadLow16_64": {
+    "best_name": "hi-bits_4",
+    "best_value": 36.31169494281576,
+    "median_name": "hi-bits_0",
+    "median_value": 37.90496056497634,
+    "worst_name": "hi-bits_2",
+    "worst_value": 39.81411650358144
+  },
+  "RightPadLow1_16": {
+    "best_name": "ufmbits_0",
+    "best_value": 25.816152238033986,
+    "median_name": "hi-bits_0",
+    "median_value": 27.277093912710974,
+    "worst_name": "lo-bits_2",
+    "worst_value": 28.80800343902115
+  },
+  "RightPadLow1_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 26.929381403365753,
+    "median_name": "lo-bits_2",
+    "median_value": 27.760838481095607,
+    "worst_name": "ufmbits_4",
+    "worst_value": 34.27477022629016
+  },
+  "RightPadLow1_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 26.319756462171203,
+    "median_name": "hi-bits_0",
+    "median_value": 27.573245364771786,
+    "worst_name": "hi-bits_4",
+    "worst_value": 28.48480941214274
+  },
+  "RightPadLow1_8": {
+    "best_name": "ufmbits_3",
+    "best_value": 26.296651175630867,
+    "median_name": "hi-bits_1",
+    "median_value": 27.689708146717567,
+    "worst_name": "lo-bits_4",
+    "worst_value": 28.87451507272549
+  },
+  "RightPadLow32_64": {
+    "best_name": "ufmbits_4",
+    "best_value": 30.779998218016782,
+    "median_name": "hi-bits_3",
+    "median_value": 31.785691620908736,
+    "worst_name": "lo-bits_1",
+    "worst_value": 48.29253423673803
+  },
+  "RightPadLow8_16": {
+    "best_name": "ufmbits_2",
+    "best_value": 30.972144327959736,
+    "median_name": "hi-bits_2",
+    "median_value": 32.126503794575356,
+    "worst_name": "hi-bits_1",
+    "worst_value": 43.736468306135805
+  },
+  "RightPadLow8_32": {
+    "best_name": "lo-bits_0",
+    "best_value": 37.133049342178055,
+    "median_name": "hi-bits_1",
+    "median_value": 38.61228987728885,
+    "worst_name": "ufmbits_0",
+    "worst_value": 47.81112911354642
+  },
+  "RightPadLow8_64": {
+    "best_name": "ufmbits_0",
+    "best_value": 51.16938819228946,
+    "median_name": "ufmbits_4",
+    "median_value": 52.7703325710442,
+    "worst_name": "hi-bits_4",
+    "worst_value": 67.16232802333609
+  },
+  "RightRotate16": {
+    "best_name": "hi-bits_3",
+    "best_value": 30.483240683395998,
+    "median_name": "ufmbits_0",
+    "median_value": 32.675710336438534,
+    "worst_name": "lo-bits_0",
+    "worst_value": 36.16485846230935
+  },
+  "RightRotate32": {
+    "best_name": "hi-bits_1",
+    "best_value": 29.683835734241416,
+    "median_name": "ufmbits_4",
+    "median_value": 30.996353216178107,
+    "worst_name": "ufmbits_2",
+    "worst_value": 39.50198771367705
+  },
+  "RightRotate64": {
+    "best_name": "hi-bits_2",
+    "best_value": 30.865548303998708,
+    "median_name": "lo-bits_1",
+    "median_value": 33.83682562494892,
+    "worst_name": "hi-bits_1",
+    "worst_value": 40.89572411120468
+  },
+  "RightRotate8": {
+    "best_name": "lo-bits_3",
+    "best_value": 27.723302539558432,
+    "median_name": "hi-bits_3",
+    "median_value": 28.784947760191216,
+    "worst_name": "hi-bits_4",
+    "worst_value": 40.82255602079409
+  },
+  "RightShift16": {
+    "best_name": "lo-bits_2",
+    "best_value": 31.1500395004557,
+    "median_name": "hi-bits_0",
+    "median_value": 32.47985073733298,
+    "worst_name": "ufmbits_0",
+    "worst_value": 37.012261311100104
+  },
+  "RightShift32": {
+    "best_name": "ufmbits_2",
+    "best_value": 30.304941768394297,
+    "median_name": "hi-bits_0",
+    "median_value": 31.490941630220323,
+    "worst_name": "lo-bits_2",
+    "worst_value": 40.63765374575396
+  },
+  "RightShift64": {
+    "best_name": "ufmbits_3",
+    "best_value": 29.008581985453233,
+    "median_name": "lo-bits_0",
+    "median_value": 30.02374394900528,
+    "worst_name": "hi-bits_0",
+    "worst_value": 32.576821845555415
+  },
+  "RightShift8": {
+    "best_name": "lo-bits_0",
+    "best_value": 29.439146295371707,
+    "median_name": "ufmbits_3",
+    "median_value": 31.257942627476236,
+    "worst_name": "hi-bits_2",
+    "worst_value": 38.48231541240914
+  },
+  "RightShiftWith16": {
+    "best_name": "hi-bits_4",
+    "best_value": 31.54731868202085,
+    "median_name": "lo-bits_0",
+    "median_value": 44.209065743353925,
+    "worst_name": "ufmbits_3",
+    "worst_value": 52.75281484115069
+  },
+  "RightShiftWith32": {
+    "best_name": "hi-bits_3",
+    "best_value": 31.401676501257533,
+    "median_name": "lo-bits_4",
+    "median_value": 41.336542823745376,
+    "worst_name": "ufmbits_1",
+    "worst_value": 50.387324589131715
+  },
+  "RightShiftWith64": {
+    "best_name": "lo-bits_4",
+    "best_value": 28.687548729289066,
+    "median_name": "hi-bits_3",
+    "median_value": 30.415865861559126,
+    "worst_name": "ufmbits_0",
+    "worst_value": 40.51201134163448
+  },
+  "RightShiftWith8": {
+    "best_name": "lo-bits_3",
+    "best_value": 34.0418890536673,
+    "median_name": "ufmbits_4",
+    "median_value": 37.9552592155228,
+    "worst_name": "ufmbits_3",
+    "worst_value": 39.592595317442886
+  },
+  "Rightmost16_1": {
+    "best_name": "hi-bits_4",
+    "best_value": 25.45474169347816,
+    "median_name": "hi-bits_0",
+    "median_value": 26.29173465221814,
+    "worst_name": "lo-bits_3",
+    "worst_value": 35.58535152764685
+  },
+  "Rightmost16_2": {
+    "best_name": "hi-bits_4",
+    "best_value": 28.512304021418828,
+    "median_name": "lo-bits_4",
+    "median_value": 30.525817490029635,
+    "worst_name": "ufmbits_2",
+    "worst_value": 34.91381873174706
+  },
+  "Rightmost16_4": {
+    "best_name": "ufmbits_3",
+    "best_value": 25.198821303232013,
+    "median_name": "ufmbits_0",
+    "median_value": 26.941519688876042,
+    "worst_name": "lo-bits_0",
+    "worst_value": 33.268380470599475
+  },
+  "Rightmost16_8": {
+    "best_name": "lo-bits_4",
+    "best_value": 25.67274436068679,
+    "median_name": "lo-bits_1",
+    "median_value": 27.11118212140842,
+    "worst_name": "ufmbits_2",
+    "worst_value": 34.828771235700486
+  },
+  "Rightmost32_1": {
+    "best_name": "lo-bits_1",
+    "best_value": 25.422622456627924,
+    "median_name": "hi-bits_4",
+    "median_value": 27.44493377031238,
+    "worst_name": "ufmbits_4",
+    "worst_value": 33.24510330781754
+  },
+  "Rightmost32_16": {
+    "best_name": "hi-bits_1",
+    "best_value": 27.311651791237068,
+    "median_name": "lo-bits_0",
+    "median_value": 28.680051634761035,
+    "worst_name": "hi-bits_0",
+    "worst_value": 37.03322857163032
+  },
+  "Rightmost32_2": {
+    "best_name": "lo-bits_0",
+    "best_value": 25.900915381834007,
+    "median_name": "lo-bits_1",
+    "median_value": 26.666972905113152,
+    "worst_name": "lo-bits_4",
+    "worst_value": 28.063146231610776
+  },
+  "Rightmost32_4": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.191188559916924,
+    "median_name": "ufmbits_2",
+    "median_value": 27.710333889167913,
+    "worst_name": "lo-bits_0",
+    "worst_value": 33.30316030767245
+  },
+  "Rightmost32_8": {
+    "best_name": "hi-bits_2",
+    "best_value": 26.979403011438517,
+    "median_name": "lo-bits_3",
+    "median_value": 28.191401976696394,
+    "worst_name": "hi-bits_4",
+    "worst_value": 36.698142406448945
+  },
+  "Rightmost64_1": {
+    "best_name": "ufmbits_2",
+    "best_value": 27.10509134594132,
+    "median_name": "hi-bits_1",
+    "median_value": 28.006445217900627,
+    "worst_name": "ufmbits_3",
+    "worst_value": 33.75386434035274
+  },
+  "Rightmost64_16": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.885139470783493,
+    "median_name": "hi-bits_0",
+    "median_value": 30.248939607505783,
+    "worst_name": "lo-bits_4",
+    "worst_value": 39.444732394031085
+  },
+  "Rightmost64_2": {
+    "best_name": "lo-bits_4",
+    "best_value": 26.559003527265876,
+    "median_name": "hi-bits_4",
+    "median_value": 28.975841035273035,
+    "worst_name": "hi-bits_1",
+    "worst_value": 36.793501455072935
+  },
+  "Rightmost64_32": {
+    "best_name": "ufmbits_0",
+    "best_value": 29.68424190280921,
+    "median_name": "lo-bits_0",
+    "median_value": 33.129597818322914,
+    "worst_name": "hi-bits_1",
+    "worst_value": 37.58573524102103
+  },
+  "Rightmost64_4": {
+    "best_name": "ufmbits_4",
+    "best_value": 26.9015665323532,
+    "median_name": "lo-bits_0",
+    "median_value": 27.43307899757243,
+    "worst_name": "hi-bits_4",
+    "worst_value": 28.61213486735769
+  },
+  "Rightmost64_8": {
+    "best_name": "lo-bits_0",
+    "best_value": 27.731601288633225,
+    "median_name": "ufmbits_2",
+    "median_value": 33.084332338573766,
+    "worst_name": "hi-bits_2",
+    "worst_value": 36.93534784356178
+  },
+  "Rightmost8_1": {
+    "best_name": "ufmbits_3",
+    "best_value": 24.970630763320774,
+    "median_name": "lo-bits_2",
+    "median_value": 27.17720171331985,
+    "worst_name": "hi-bits_0",
+    "worst_value": 32.35299384190753
+  },
+  "Rightmost8_2": {
+    "best_name": "lo-bits_1",
+    "best_value": 24.692578758189967,
+    "median_name": "ufmbits_1",
+    "median_value": 25.415165417129042,
+    "worst_name": "hi-bits_3",
+    "worst_value": 27.247343090688155
+  },
+  "Rightmost8_4": {
+    "best_name": "lo-bits_4",
+    "best_value": 24.755193883864177,
+    "median_name": "ufmbits_2",
+    "median_value": 25.452874608445473,
+    "worst_name": "lo-bits_2",
+    "worst_value": 27.35188125241447
+  },
+  "ScalarAdd": {
+    "best_name": "sc_ufmbits_+_scalar_outofrange_2",
+    "best_value": 408.49596423805383,
+    "median_name": "sc_ufmbits_+_self_3",
+    "median_value": 410.22744963854007,
+    "worst_name": "sc_hi-bits_+_sc_lo-bits_0",
+    "worst_value": 421.1036603654145
+  },
+  "ScalarInvert": {
+    "best_name": "sc_lo-bits_4",
+    "best_value": 1431.3149191030361,
+    "median_name": "scalar_outofrange_3",
+    "median_value": 1746.9011868893647,
+    "worst_name": "scalar_outofrange_1",
+    "worst_value": 1753.365660477105
+  },
+  "ScalarIsZero": {
+    "best_name": "sc_ufmbits_4",
+    "best_value": 157.22423064392737,
+    "median_name": "sc_lo-bits_2",
+    "median_value": 159.96782091031739,
+    "worst_name": "sc_lo-bits_1",
+    "worst_value": 163.00968058350844
+  },
+  "ScalarMultiply": {
+    "best_name": "scalar_outofrange_+_inv_self_1",
+    "best_value": 441.31856492976164,
+    "median_name": "sc_hi-bits_+_scalar_outofrange_3",
+    "median_value": 442.98074048197225,
+    "worst_name": "scalar_outofrange_+_self_2",
+    "worst_value": 454.6318728584993
+  },
+  "ScalarMultiplyLambda": {
+    "best_name": "sc_ufmbits_3",
+    "best_value": 324.0128726830389,
+    "median_name": "scalar_outofrange_1",
+    "median_value": 324.88828232231515,
+    "worst_name": "sc_lo-bits_3",
+    "worst_value": 332.3412758707213
+  },
+  "ScalarNegate": {
+    "best_name": "sc_ufmbits_1",
+    "best_value": 284.2856459194507,
+    "median_name": "scalar_outofrange_1",
+    "median_value": 285.48893897848336,
+    "worst_name": "sc_lo-bits_0",
+    "worst_value": 291.88480385003686
+  },
+  "ScalarNormalize": {
+    "best_name": "sc_lo-bits_1",
+    "best_value": 275.837395851055,
+    "median_name": "sc_ufmbits_1",
+    "median_value": 277.2347256807852,
+    "worst_name": "sc_hi-bits_2",
+    "worst_value": 279.52377411097433
+  },
+  "ScalarSquare": {
+    "best_name": "sc_lo-bits_3",
+    "best_value": 319.7456134981359,
+    "median_name": "scalar_outofrange_2",
+    "median_value": 321.437657512917,
+    "worst_name": "scalar_outofrange_3",
+    "worst_value": 324.3097746370429
+  },
+  "Scale": {
+    "best_name": "scalar_outofrange_+_gej_offc_fe_ufmbits_1",
+    "best_value": 649.7998319493552,
+    "median_name": "sc_ufmbits_+_gej_zero_fe_hi-bits_4",
+    "median_value": 667.038061448733,
+    "worst_name": "sc_hi-bits_+_gej_oncurve_1",
+    "worst_value": 40477.76205999813
+  },
+  "ScriptCMR": {
+    "best_name": "18",
+    "best_value": 49.747374884162085,
+    "median_name": "50",
+    "median_value": 52.45420713919103,
+    "worst_name": "81",
+    "worst_value": 65.63496265070896
+  },
+  "Sha256Block": {
+    "best_name": "hi-bits_0",
+    "best_value": 417.16543891538174,
+    "median_name": "ufmbits_0",
+    "median_value": 418.52087924758894,
+    "worst_name": "ufmbits_4",
+    "worst_value": 429.6678615031787
+  },
+  "Sha256Ctx8Add1": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_+_hi-bits_0",
+    "best_value": 74.03721304667579,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_ufmbits_4",
+    "median_value": 214.78699855048265,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_4",
+    "worst_value": 366.98453880248763
+  },
+  "Sha256Ctx8Add128": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_+_hi-bits_3",
+    "best_value": 67.34947062166343,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_ufmbits_+_ufmbits_3",
+    "median_value": 210.83227399946153,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_ufmbits_1",
+    "worst_value": 974.3275053431029
+  },
+  "Sha256Ctx8Add16": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_hi-bits_4",
+    "best_value": 67.17067957782548,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_+_lo-bits_3",
+    "median_value": 207.69755315927847,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_1",
+    "worst_value": 428.81054374077416
+  },
+  "Sha256Ctx8Add2": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_+_lo-bits_1",
+    "best_value": 73.77400750106554,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_+_lo-bits_0",
+    "median_value": 217.57786214653098,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_lo-bits_3",
+    "worst_value": 376.3441643975157
+  },
+  "Sha256Ctx8Add256": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_+_lo-bits_3",
+    "best_value": 66.9215138503432,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_lo-bits_+_hi-bits_3",
+    "median_value": 215.795319271938,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_ufmbits_0",
+    "worst_value": 1580.3410085026837
+  },
+  "Sha256Ctx8Add32": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_ufmbits_+_lo-bits_+_ufmbits_2",
+    "best_value": 68.649894941711,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_lo-bits_2",
+    "median_value": 211.09328378435674,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_0",
+    "worst_value": 504.2022797472617
+  },
+  "Sha256Ctx8Add4": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_hi-bits_1",
+    "best_value": 67.34860062558919,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_hi-bits_+_lo-bits_4",
+    "median_value": 209.8992633455804,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_hi-bits_0",
+    "worst_value": 371.85129179769916
+  },
+  "Sha256Ctx8Add512": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_+_lo-bits_4",
+    "best_value": 69.19556158172341,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_ufmbits_+_hi-bits_3",
+    "median_value": 220.00769573258833,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_lo-bits_3",
+    "worst_value": 2854.329550330508
+  },
+  "Sha256Ctx8Add64": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_hi-bits_1",
+    "best_value": 67.8433409509438,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_lo-bits_+_lo-bits_3",
+    "median_value": 211.25531985178478,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_+_lo-bits_0",
+    "worst_value": 666.3633520877116
+  },
+  "Sha256Ctx8Add8": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_hi-bits_+_ufmbits_3",
+    "best_value": 66.80518440011022,
+    "median_name": "sha256ctx_varbuf-rndlen_+_hi-bits_+_ufmbits_+_ufmbits_1",
+    "median_value": 205.4553834696702,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_1",
+    "worst_value": 392.152625618351
+  },
+  "Sha256Ctx8AddBuffer511": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_ufmbits_+_hi-bits_4",
+    "best_value": 91.41328276427133,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_+_lo-bits_2",
+    "median_value": 235.2098317378875,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_hi-bits_+_hi-bits_4",
+    "worst_value": 2825.5644849727423
+  },
+  "Sha256Ctx8Finalize": {
+    "best_name": "sha256ctx_varbuf-maxlen_+_hi-bits_+_lo-bits_1",
+    "best_value": 66.37251983377297,
+    "median_name": "sha256ctx_varbuf-rndlen_+_ufmbits_+_hi-bits_0",
+    "median_value": 207.7464445231479,
+    "worst_name": "sha256ctx_varbuf-rndlen_+_lo-bits_+_lo-bits_0",
+    "worst_value": 456.0100339145012
+  },
+  "Sha256Ctx8Init": {
+    "best_name": "unit_0",
+    "best_value": 66.30460564414477,
+    "median_name": "unit_1",
+    "median_value": 66.36948533695316,
+    "worst_name": "unit_4",
+    "worst_value": 66.99384644375476
+  },
+  "Sha256Iv": {
+    "best_name": "unit_1",
+    "best_value": 50.214146481082025,
+    "median_name": "unit_4",
+    "median_value": 50.28873877506164,
+    "worst_name": "unit_3",
+    "worst_value": 50.38951190174547
+  },
+  "SigAllHash": {
+    "best_name": "80",
+    "best_value": 49.145334583816194,
+    "median_name": "17",
+    "median_value": 49.94569262794473,
+    "worst_name": "43",
+    "worst_value": 66.83266160532125
+  },
+  "Some1": {
+    "best_name": "hi-bits_2",
+    "best_value": 20.796003290696362,
+    "median_name": "ufmbits_3",
+    "median_value": 25.091709149020257,
+    "worst_name": "lo-bits_4",
+    "worst_value": 27.253122821008468
+  },
+  "Some16": {
+    "best_name": "ufmbits_3",
+    "best_value": 25.59953373842614,
+    "median_name": "ufmbits_2",
+    "median_value": 26.35938885400436,
+    "worst_name": "lo-bits_2",
+    "worst_value": 28.389351562822803
+  },
+  "Some32": {
+    "best_name": "hi-bits_4",
+    "best_value": 23.19514584140422,
+    "median_name": "ufmbits_4",
+    "median_value": 24.980602144493805,
+    "worst_name": "lo-bits_1",
+    "worst_value": 27.532779027525407
+  },
+  "Some64": {
+    "best_name": "hi-bits_2",
+    "best_value": 23.559564605649026,
+    "median_name": "ufmbits_1",
+    "median_value": 25.101432123972018,
+    "worst_name": "lo-bits_4",
+    "worst_value": 35.44701609525979
+  },
+  "Some8": {
+    "best_name": "hi-bits_4",
+    "best_value": 24.262413947315736,
+    "median_name": "lo-bits_4",
+    "median_value": 25.571350116656696,
+    "worst_name": "hi-bits_1",
+    "worst_value": 29.476618334157067
+  },
+  "Subtract16": {
+    "best_name": "hi-bits_+_lo-bits_0",
+    "best_value": 32.76826520264469,
+    "median_name": "hi-bits_+_ufmbits_2",
+    "median_value": 39.15164127400974,
+    "worst_name": "ufmbits_+_ufmbits_0",
+    "worst_value": 48.078776499207486
+  },
+  "Subtract32": {
+    "best_name": "lo-bits_+_self_3",
+    "best_value": 29.032348640204088,
+    "median_name": "hi-bits_+_lo-bits_0",
+    "median_value": 36.566901147088686,
+    "worst_name": "hi-bits_+_hi-bits_3",
+    "worst_value": 51.69501460699037
+  },
+  "Subtract64": {
+    "best_name": "lo-bits_+_hi-bits_0",
+    "best_value": 29.206833984660935,
+    "median_name": "lo-bits_+_ufmbits_0",
+    "median_value": 32.52152390586843,
+    "worst_name": "hi-bits_+_self_1",
+    "worst_value": 41.95760505875784
+  },
+  "Subtract8": {
+    "best_name": "lo-bits_+_hi-bits_2",
+    "best_value": 40.525244196466964,
+    "median_name": "hi-bits_+_self_3",
+    "median_value": 45.33619111754718,
+    "worst_name": "hi-bits_+_hi-bits_1",
+    "worst_value": 61.6387826731225
+  },
+  "Swu": {
+    "best_name": "lo-bits_4",
+    "best_value": 17806.20529636923,
+    "median_name": "hi-bits_3",
+    "median_value": 17994.668039080017,
+    "worst_name": "ufmbits_4",
+    "worst_value": 18041.44501896233
+  },
+  "TapEnvHash": {
+    "best_name": "17",
+    "best_value": 49.37341983752192,
+    "median_name": "23",
+    "median_value": 50.18935948823757,
+    "worst_name": "26",
+    "worst_value": 65.31097324023445
+  },
+  "TapdataInit": {
+    "best_name": "68",
+    "best_value": 649.3346512044278,
+    "median_name": "12",
+    "median_value": 654.5860453963446,
+    "worst_name": "20",
+    "worst_value": 737.400730001332
+  },
+  "TapleafHash": {
+    "best_name": "8",
+    "best_value": 49.237340706194544,
+    "median_name": "68",
+    "median_value": 54.20305286746503,
+    "worst_name": "73",
+    "worst_value": 68.42683658757552
+  },
+  "TapleafVersion": {
+    "best_name": "7",
+    "best_value": 27.559880871300052,
+    "median_name": "33",
+    "median_value": 29.86019265308075,
+    "worst_name": "39",
+    "worst_value": 38.51295309279458
+  },
+  "Tappath": {
+    "best_name": "21",
+    "best_value": 28.85944872428049,
+    "median_name": "69",
+    "median_value": 30.881279572087507,
+    "worst_name": "96",
+    "worst_value": 42.57465356320362
+  },
+  "TappathHash": {
+    "best_name": "0",
+    "best_value": 49.72057210201199,
+    "median_name": "50",
+    "median_value": 52.70504930179317,
+    "worst_name": "85",
+    "worst_value": 72.76615046689824
+  },
+  "TotalInputValue": {
+    "best_name": "5",
+    "best_value": 27.99548281267165,
+    "median_name": "26",
+    "median_value": 29.81234676700723,
+    "worst_name": "49",
+    "worst_value": 39.45063828217908
+  },
+  "TotalOutputValue": {
+    "best_name": "10",
+    "best_value": 27.295452430656695,
+    "median_name": "62",
+    "median_value": 28.34329313682742,
+    "worst_name": "90",
+    "worst_value": 36.70847789516231
+  },
+  "TransactionId": {
+    "best_name": "31",
+    "best_value": 49.54098152313642,
+    "median_name": "56",
+    "median_value": 51.12230164305957,
+    "worst_name": "85",
+    "worst_value": 71.31778822061993
+  },
+  "TxHash": {
+    "best_name": "11",
+    "best_value": 49.87610960667649,
+    "median_name": "90",
+    "median_value": 50.80564005889003,
+    "worst_name": "15",
+    "worst_value": 67.91925385023788
+  },
+  "TxIsFinal": {
+    "best_name": "92",
+    "best_value": 24.773855737288958,
+    "median_name": "26",
+    "median_value": 25.481547263041612,
+    "worst_name": "96",
+    "worst_value": 33.300289089663266
+  },
+  "TxLockDistance": {
+    "best_name": "9",
+    "best_value": 27.553898121887702,
+    "median_name": "50",
+    "median_value": 28.965656368437013,
+    "worst_name": "20",
+    "worst_value": 36.67661248323214
+  },
+  "TxLockDuration": {
+    "best_name": "5",
+    "best_value": 27.58264673835996,
+    "median_name": "63",
+    "median_value": 28.31370768261107,
+    "worst_name": "35",
+    "worst_value": 38.325095994002346
+  },
+  "TxLockHeight": {
+    "best_name": "43",
+    "best_value": 29.804412308329773,
+    "median_name": "38",
+    "median_value": 32.474845251780664,
+    "worst_name": "85",
+    "worst_value": 42.95249447703108
+  },
+  "TxLockTime": {
+    "best_name": "98",
+    "best_value": 27.89113549258276,
+    "median_name": "74",
+    "median_value": 28.693595534323823,
+    "worst_name": "8",
+    "worst_value": 38.37598096137171
+  },
+  "Verify": {
+    "best_name": "ufmbits_3",
+    "best_value": 19.92743102777683,
+    "median_name": "lo-bits_0",
+    "median_value": 22.18246019094238,
+    "worst_name": "hi-bits_4",
+    "worst_value": 23.423567433904118
+  },
+  "Version": {
+    "best_name": "88",
+    "best_value": 27.54081672902299,
+    "median_name": "23",
+    "median_value": 28.14560346244728,
+    "worst_name": "33",
+    "worst_value": 39.95377678306884
+  },
+  "Xor1": {
+    "best_name": "lo-bits_+_self_2",
+    "best_value": 21.115743550867496,
+    "median_name": "hi-bits_+_self_3",
+    "median_value": 23.10769145692572,
+    "worst_name": "lo-bits_+_inv_self_2",
+    "worst_value": 32.31626757276585
+  },
+  "Xor16": {
+    "best_name": "ufmbits_+_self_4",
+    "best_value": 28.557216563197077,
+    "median_name": "hi-bits_+_lo-bits_4",
+    "median_value": 33.45738205916034,
+    "worst_name": "ufmbits_+_inv_self_1",
+    "worst_value": 44.79661086900003
+  },
+  "Xor32": {
+    "best_name": "hi-bits_+_hi-bits_2",
+    "best_value": 28.516682251252384,
+    "median_name": "ufmbits_+_ufmbits_4",
+    "median_value": 31.34113719377722,
+    "worst_name": "ufmbits_+_self_0",
+    "worst_value": 44.713561048430485
+  },
+  "Xor64": {
+    "best_name": "hi-bits_+_ufmbits_3",
+    "best_value": 27.876507146575555,
+    "median_name": "hi-bits_+_hi-bits_3",
+    "median_value": 29.74972595956639,
+    "worst_name": "ufmbits_+_ufmbits_4",
+    "worst_value": 32.35578514765018
+  },
+  "Xor8": {
+    "best_name": "ufmbits_+_inv_self_4",
+    "best_value": 27.631420363436778,
+    "median_name": "ufmbits_+_ufmbits_3",
+    "median_value": 29.487083876493543,
+    "worst_name": "hi-bits_+_ufmbits_1",
+    "worst_value": 39.854628227910325
+  },
+  "XorXor1": {
+    "best_name": "ufmbits_3",
+    "best_value": 22.718032983070092,
+    "median_name": "hi-bits_0",
+    "median_value": 23.378575659134448,
+    "worst_name": "lo-bits_2",
+    "worst_value": 29.549634852595794
+  },
+  "XorXor16": {
+    "best_name": "hi-bits_4",
+    "best_value": 31.611731814760045,
+    "median_name": "ufmbits_4",
+    "median_value": 32.169792862811434,
+    "worst_name": "ufmbits_2",
+    "worst_value": 41.00605048591029
+  },
+  "XorXor32": {
+    "best_name": "hi-bits_2",
+    "best_value": 31.30573916181157,
+    "median_name": "ufmbits_3",
+    "median_value": 32.32547099530599,
+    "worst_name": "lo-bits_2",
+    "worst_value": 45.26905208983709
+  },
+  "XorXor64": {
+    "best_name": "hi-bits_1",
+    "best_value": 31.119420664990056,
+    "median_name": "lo-bits_2",
+    "median_value": 32.9829872845012,
+    "worst_name": "ufmbits_2",
+    "worst_value": 46.08671562001547
+  },
+  "XorXor8": {
+    "best_name": "hi-bits_1",
+    "best_value": 30.913236835662552,
+    "median_name": "hi-bits_4",
+    "median_value": 32.38394932167093,
+    "worst_name": "hi-bits_3",
+    "worst_value": 33.93618562316117
+  }
+}


### PR DESCRIPTION
These benchmark logs make up (or in the future will make up) the consensus critical cost values of jets used in various applications. Adding these logs will be useful so that we have a place to reference them.