### PR TITLE
Update simplicity-lang dependency version to 0.6 on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use rust-simplicity, this to your Cargo.toml:
 
 ```toml
 [dependencies]
-simplicity-lang = "0.5"
+simplicity-lang = "0.6"
 ```
 
 ## Quick Start


### PR DESCRIPTION
The example in `Quick Start` implies the use of `Context::with_context` thats only available in 0.6