### PR TITLE
wasm32: define c_uint_fast16_t as u32

### DIFF
--- a/simplicity-sys/src/ffi.rs
+++ b/simplicity-sys/src/ffi.rs
@@ -21,10 +21,8 @@ pub type c_size_t = usize;
 pub type c_uint_fast8_t = u8;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub type c_uint_fast16_t = u16;
-#[cfg(any(target_os = "windows", target_os = "android"))]
+#[cfg(any(target_os = "windows", target_os = "android", target_arch = "wasm32"))]
 pub type c_uint_fast16_t = u32;
-#[cfg(target_arch = "wasm32")]
-pub type c_uint_fast16_t = u16;
 #[cfg(not(any(
     target_os = "macos",
     target_os = "ios",


### PR DESCRIPTION
I've approached SimplicityHL by [compiling the SimplicityHL compiler to `wasm32-unknown-unknown`](https://github.com/hackbg/simf), so that I would be able to invoke it from JS.

After producing a program's P2TR address, the next step is to construct a spend PSET; trying to do that, I kept running into an opaque `JetFailed` error when calling `satisfy_with_env`.

I traced that to the `UWORD` size/align checks in `simplicity::ffi::c_jets::sanity_checks`. Defining `c_uint_fast16_t` it as `u32` on WASM seems to fix it.