### PR TITLE
Lock `human_encoding` module under a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default = ["elements"]
 elements = ["dep:elements", "bitcoin"]
 test-utils = ["simplicity-sys/test-utils"]
 serde = ["dep:serde", "bitcoin/serde", "elements/serde"]
+human_encoding = ["dep:logos"]
 
 [lib]
 name = "simplicity"
@@ -29,7 +30,7 @@ elements = { version = "0.25.0", optional = true, default-features = false }
 ghost-cell = { version = "0.2.6", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "0.14" }
 hex = { package = "hex-conservative", version = "0.2.1" }
-logos = "0.15"
+logos = { version = "0.15", optional = true }
 simplicity-sys = { version = "0.6.2", path = "./simplicity-sys" }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ path = "fuzz_lib/lib.rs"
 libfuzzer-sys = "0.4"
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
-simplicity-lang = { path = "..", features = ["test-utils"], version = "0.7.0" }
+simplicity-lang = { path = "..", features = ["test-utils", "human_encoding"], version = "0.7.0" }
 old_simplicity = { package = "simplicity-lang", version = "0.3.1", default-features = false }
 
 [dev-dependencies]

--- a/simpcli/Cargo.toml
+++ b/simpcli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 # todo add lexopt for command line parsing
-simplicity-lang = { version = "0.7.0", path = "..", features = [ "base64", "serde", "elements" ] }
+simplicity-lang = { version = "0.7.0", path = "..", features = [ "base64", "serde", "elements", "human_encoding" ] }
 
 [[bin]]
 name = "simpcli"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ mod analysis;
 mod bit_encoding;
 pub mod bit_machine;
 pub mod dag;
+#[cfg(feature = "human_encoding")]
 pub mod human_encoding;
 pub mod jet;
 mod merkle;

--- a/src/node/commit.rs
+++ b/src/node/commit.rs
@@ -309,11 +309,11 @@ mod tests {
     use std::fmt;
 
     use crate::decode::Error;
-    use crate::human_encoding::Forest;
-    use crate::jet::{Core, CoreEnv};
-    use crate::node::SimpleFinalizer;
-    use crate::{BitMachine, Value};
+    use crate::jet::Core;
+    #[cfg(feature = "human_encoding")]
+    use crate::{human_encoding::Forest, jet::CoreEnv, node::SimpleFinalizer, BitMachine, Value};
 
+    #[cfg(feature = "human_encoding")]
     #[cfg_attr(not(feature = "base64"), allow(unused_variables))]
     #[track_caller]
     fn assert_program_deserializable<J: Jet>(
@@ -473,6 +473,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "human_encoding")]
     fn shared_witnesses() {
         assert_program_deserializable::<Core>(
             "main := witness",
@@ -577,6 +578,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "human_encoding")]
     fn regression_177() {
         // `case (drop iden) iden` from upstream occurs-check test. Has an infinitely sized
         // input type. Will fail trying to unify the input type with the unit type before

--- a/src/node/display.rs
+++ b/src/node/display.rs
@@ -359,7 +359,7 @@ fn shorten<S: AsRef<str>>(s: S, max_len: usize) -> String {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "human_encoding"))]
 mod tests {
     use crate::human_encoding::Forest;
     use crate::jet::Core;

--- a/src/node/redeem.rs
+++ b/src/node/redeem.rs
@@ -610,13 +610,14 @@ impl<J: Jet> RedeemNode<J> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "human_encoding")]
     use crate::human_encoding::Forest;
     use crate::jet::Core;
     use crate::node::SimpleFinalizer;
-    use crate::types::Final;
     use hex::DisplayHex;
-    use std::collections::HashMap;
     use std::fmt;
+    #[cfg(all(feature = "elements", feature = "human_encoding"))]
+    use {crate::types::Final, std::collections::HashMap};
 
     #[cfg_attr(not(feature = "base64"), allow(unused_variables))]
     #[track_caller]
@@ -965,7 +966,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "elements")]
+    #[cfg(all(feature = "elements", feature = "human_encoding"))]
     fn assert_correct_pruning<JE: JetEnvironment>(
         unpruned_prog: &str,
         unpruned_wit: &HashMap<Arc<str>, Value>,
@@ -1017,7 +1018,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "elements")]
+    #[cfg(all(feature = "elements", feature = "human_encoding"))]
     fn prune() {
         use crate::jet::ElementsTxEnv;
 


### PR DESCRIPTION
This PR introduces a new feature flag, `human_encoding`, which locks the module of the same name.

It is a followup to the discussion in #354.