### PR TITLE
fix(bitmachine): fix frame data offsets send to tracker (fixes Execution reached a pruned branch)

### DIFF
--- a/src/bit_machine/frame.rs
+++ b/src/bit_machine/frame.rs
@@ -115,13 +115,12 @@ impl Frame {
         }
     }
 
-    /// Extend the present frame with a read-only reference the the data
-    /// and return the resulting struct.
-    pub(super) fn as_bit_iter<'a>(
+    /// Return an iterator over the frame's remaining bits, starting at the current cursor position.
+    pub(super) fn as_bit_iter_from_cursor<'a>(
         &self,
         data: &'a [u8],
     ) -> BitIter<core::iter::Copied<core::slice::Iter<'a, u8>>> {
-        BitIter::byte_slice_window(data, self.start, self.start + self.len)
+        BitIter::byte_slice_window(data, self.cursor, self.start + self.len)
     }
 }
 

--- a/src/bit_machine/mod.rs
+++ b/src/bit_machine/mod.rs
@@ -277,8 +277,11 @@ impl BitMachine {
         }
 
         'main_loop: loop {
-            // Make a copy of the input frame to give to the tracker.
+            // Capture read and write frames before the node action, to give to the tracker.
+            // The read frame cursor is where the node's input begins.
+            // The write frame cursor is where the node's output begins.
             let input_frame = self.read.last().map(Frame::shallow_copy);
+            let output_frame = self.write.last().map(Frame::shallow_copy);
             let mut jet_result = Ok(());
 
             match ip.inner() {
@@ -391,16 +394,15 @@ impl BitMachine {
                 // describes the Bit Machine "input" to the current node,
                 // no matter the node.
                 let read_iter = input_frame
-                    .map(|frame| frame.as_bit_iter(&self.data))
+                    .map(|frame| frame.as_bit_iter_from_cursor(&self.data))
                     .unwrap_or(crate::BitIter::from([].iter().copied()));
                 // See the docs on `tracker::NodeOutput` for more information about
                 // this match.
                 let output = match (ip.inner(), &jet_result) {
                     (node::Inner::Unit | node::Inner::Iden | node::Inner::Witness(_), _)
                     | (node::Inner::Jet(_), Ok(_)) => NodeOutput::Success(
-                        self.write
-                            .last()
-                            .map(|r| r.as_bit_iter(&self.data))
+                        output_frame
+                            .map(|frame| frame.as_bit_iter_from_cursor(&self.data))
                             .unwrap_or(crate::BitIter::from([].iter().copied())),
                     ),
                     (node::Inner::Jet(_), Err(_)) => NodeOutput::JetFailed,
@@ -430,7 +432,7 @@ impl BitMachine {
             let out_frame = self.write.last_mut().unwrap();
             out_frame.reset_cursor();
             let value = Value::from_padded_bits(
-                &mut out_frame.as_bit_iter(&self.data),
+                &mut out_frame.as_bit_iter_from_cursor(&self.data),
                 &program.arrow().target,
             )
             .expect("Decode value of output frame");
@@ -667,6 +669,37 @@ mod tests {
         BitMachine::for_program(&prog)
             .expect("program has reasonable bounds")
             .exec(&prog, &env)
+    }
+
+    #[test]
+    #[cfg(feature = "human_encoding")]
+    fn set_tracker_cursor_regression() {
+        // When a `case` node executes inside another `case` or `drop`, the read frame cursor
+        // is no longer at the frame's start. Before this fix, `exec_with_tracker` passed an
+        // iterator starting at frame.start to the tracker, so `SetTracker` read the wrong bit
+        // and recorded the wrong branch, leading to an assertl/assertr mismatch after pruning.
+        //
+        // Program: comp (pair (injl (injr unit)) unit) (case (case unit unit) unit)
+        // Intermediate frame bits: [0=L-tag of outer, 1=R-tag of inner]
+        // Outer case: peek bit 0 = 0 (LEFT), fwd(1), cursor moves to bit 1.
+        // Inner case: should read bit 1 = 1 (RIGHT).
+        // Bug: tracker received iterator from bit 0, read 0 (LEFT) → pruned wrong branch.
+        use crate::human_encoding::Forest;
+        use crate::types;
+        use std::collections::HashMap;
+
+        types::Context::with_context(|ctx| {
+            let s = "main := comp (pair (injl (injr unit)) unit) (case (case unit unit) unit)";
+            let program = Forest::parse::<crate::jet::Core>(s)
+                .expect("parse")
+                .to_witness_node(&ctx, &HashMap::new())
+                .expect("main root")
+                .finalize_pruned(&CoreEnv::new())
+                .expect("finalize and prune");
+            let mut mac = BitMachine::for_program(&program).expect("for_program");
+            mac.exec(&program, &CoreEnv::new())
+                .expect("pruned execution should succeed");
+        });
     }
 
     #[test]


### PR DESCRIPTION
Fixes some bugs where the data sent from the bitmachine to trackers would not start at the current cursor, resulting in some random junk being seen by the tracker. This doesn't have an effect on full programs, but when pruning this seems to generate an incorrect pruning, as seen in #337. 

The following code now prunes and runs correctly:
```rust 
fn add(elt: u32, acc: u32) -> u32 {
    let (_, sum): (bool, u32) = jet::add_32(elt, acc);
    sum
}

fn main() {
    let list: List<u32, 4> = list![5];
    let result: u32 = fold::<add, 4>(list, 0);
    assert!(jet::eq_32(result, 5));
}
```

Whereas previously it would fail on `Execution failed: Execution reached a pruned branch: fd6503b9fd020b8d4ed75deb14cc05bbcb91da392ba4b675f2b2345dabb1cde5`

Some excerpts from StderrTracker:
```
// Before fix
[  45] exec iden 2^32 → 2^32
       input 0x00000002
       output 0x00000005
       
// After fix
   [  45] exec iden 2^32 → 2^32
       input 0x00000005
       output 0x00000005

```

```
/// Before fix
[  46] exec iden (2^64? × 2^32?) × 1 → (2^64? × 2^32?) × 1
       input ((L(ε),R(0x00000005)),ε)
       output ((L(ε),L(ε)),ε)
       
// After fix
[  46] exec iden (2 × 2^32?) × 1 → (2 × 2^32?) × 1
       input ((0b0,R(0x00000005)),ε)
       output ((0b0,R(0x00000005)),ε)
```       
     

I haven't tried it on KyrylR 's specific SHRINCS test on that issue.

NOTE: I have based this off an older commit so I could test it with SimplicityHL, which doesn't compile with the latest `rust-simplicity`

NOTE: the unit test is written by Claude (Happy to remove it if needed)