### PR TITLE
fix: fix injl typo in core constructible

### DIFF
--- a/src/merkle/cmr.rs
+++ b/src/merkle/cmr.rs
@@ -280,7 +280,7 @@ impl<'brand> CoreConstructible<'brand> for ConstructibleCmr<'brand> {
 
     fn injr(child: &Self) -> Self {
         ConstructibleCmr {
-            cmr: Cmr::injl(child.cmr),
+            cmr: Cmr::injr(child.cmr),
             inference_context: child.inference_context.shallow_clone(),
         }
     }


### PR DESCRIPTION
Found a simple typo via LLM scanning. 

I don't think it's particularly dangerous as we would have seen this by now. I think this API is hardly used