### PR TITLE
cargo: bump rust-simplicity version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
-# Unreleased
+# 0.9.0 - 2026-08-26
 
-* Add `Value` and `Type` constructors for variable-length buffers and SHA256 `Ctx8` contexts;
-  change the signature of `Final::two_two_n` to return a result rather than panicking when `n`
-  is too large; add infallible `Final::two_two_n_fixed` for when `n` is known at compile-time
-  [#372][https://github.com/BlockstreamResearch/rust-simplicity/pull/372)
+* Fix `ConstructibleCmr::injr` computing an `injl` CMR [#369](https://github.com/BlockstreamResearch/rust-simplicity/pull/369)
+* Prevent integer overflow when computing allocation sizes in `simplicity-sys` [#370](https://github.com/BlockstreamResearch/rust-simplicity/pull/370)
+* Add `Value` and `Type` constructors for variable-length buffers and SHA256 `Ctx8` contexts [#372](https://github.com/BlockstreamResearch/rust-simplicity/pull/372)
+  * Change the signature of `Final::two_two_n` to return a result rather than panicking when `n`
+    is too large.
+  * Add infallible `Final::two_two_n_fixed` for when `n` is known at compile-time.
+* Modernize Merkle root internals and upgrade `bitcoin_hashes` and `hex-conservative`
+  [#373](https://github.com/BlockstreamResearch/rust-simplicity/pull/373)
+* Add a `Value` constructor from a SHA256 engine, expose more TMR functionality, and make more
+  Merkle root operations `const` [#374](https://github.com/BlockstreamResearch/rust-simplicity/pull/374)
+* Avoid exponential work during type finalization and stack overflows when dropping deeply nested
+  nodes and incomplete types [#375](https://github.com/BlockstreamResearch/rust-simplicity/pull/375)
+* Upgrade `elements` to 0.27 and `bitcoin_hashes` to 1.2, requiring `simplicity-sys` 0.7.1 [#376](https://github.com/BlockstreamResearch/rust-simplicity/pull/376)
+  * Remove the policy `Assembly` fragment and make policy serialization infallible.
+  * Fold `JetConstructible` into `CoreConstructible`.
+  * Remove the unused tapleaf hash argument from policy signature lookup.
 
 # 0.8.0 - 2026-05-28
 
@@ -37,4 +49,3 @@
 * Add debugging support to `ExecTracker` [#293](https://github.com/BlockstreamResearch/rust-simplicity/pull/293)
 * Separate linker symbols to allow multiple simplicity-sys versions in same tree [#297](https://github.com/BlockstreamResearch/rust-simplicity/pull/297)
 * Add base64 encoding and decoding support to programs [#299](https://github.com/BlockstreamResearch/rust-simplicity/pull/299)
-

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -582,7 +582,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 name = "simpcli"
 version = "0.3.0"
 dependencies = [
- "simplicity-lang 0.8.0",
+ "simplicity-lang 0.9.0",
 ]
 
 [[package]]
@@ -592,7 +592,7 @@ dependencies = [
  "base64 0.22.1",
  "libfuzzer-sys",
  "simplicity-lang 0.3.1",
- "simplicity-lang 0.8.0",
+ "simplicity-lang 0.9.0",
 ]
 
 [[package]]
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "simplicity-lang"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes 1.2.0",
@@ -625,7 +625,7 @@ dependencies = [
  "miniscript",
  "serde",
  "serde_json",
- "simplicity-sys 0.7.0",
+ "simplicity-sys 0.7.1",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "simplicity-sys"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bitcoin_hashes 1.2.0",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicity-lang"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 homepage = "https://github.com/BlockstreamResearch/rust-simplicity/"
@@ -31,14 +31,14 @@ ghost-cell = { version = "0.2.6", default-features = false }
 hashes = { package = "bitcoin_hashes", version = "1.2.0" }
 hex = { package = "hex-conservative", version = "1.2.0" }
 logos = { version = "0.15", optional = true }
-simplicity-sys = { version = "0.7.0", path = "./simplicity-sys" }
+simplicity-sys = { version = "0.7.1", path = "./simplicity-sys" }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
-simplicity-sys = { version = "0.7.0", path = "./simplicity-sys", features = [
+simplicity-sys = { version = "0.7.1", path = "./simplicity-sys", features = [
     "test-utils",
 ] }
 serde_json = "1.0.149"
@@ -69,4 +69,3 @@ cast_possible_wrap = "allow" # Same as above re code comment.
 cast_precision_loss = "warn"
 cast_ptr_alignment = "warn"
 cast_sign_loss = "allow" # All casts should include a code comment (except in test code).
-

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use rust-simplicity, this to your Cargo.toml:
 
 ```toml
 [dependencies]
-simplicity-lang = "0.6"
+simplicity-lang = "0.9.0"
 ```
 
 ## Quick Start

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,7 +16,7 @@ path = "fuzz_lib/lib.rs"
 libfuzzer-sys = "0.4"
 # We shouldn't need an explicit version on the next line, but Andrew's tools
 # choke on it otherwise. See https://github.com/nix-community/crate2nix/issues/373
-simplicity-lang = { path = "..", features = ["test-utils", "human_encoding"], version = "0.8.0" }
+simplicity-lang = { path = "..", features = ["test-utils", "human_encoding"], version = "0.9.0" }
 old_simplicity = { package = "simplicity-lang", version = "0.3.1", default-features = false }
 
 [dev-dependencies]

--- a/simpcli/Cargo.toml
+++ b/simpcli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 # todo add lexopt for command line parsing
-simplicity-lang = { version = "0.8.0", path = "..", features = [ "base64", "serde", "elements", "human_encoding" ] }
+simplicity-lang = { version = "0.9.0", path = "..", features = [ "base64", "serde", "elements", "human_encoding" ] }
 
 [[bin]]
 name = "simpcli"

--- a/simplicity-sys/Cargo.toml
+++ b/simplicity-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicity-sys"
-version = "0.7.0"
+version = "0.7.1"
 license = "CC0-1.0"
 homepage = "https://github.com/BlockstreamResearch/rust-simplicity/"
 repository = "https://github.com/BlockstreamResearch/rust-simplicity/"


### PR DESCRIPTION
Since 0.8.0, there are breaking public changes (quick AI summary):
- Final::two_two_n now returns Result instead of its previous behavior.
- Policy::Assembly / the Assembly fragment was removed.
- Public Elements/hash types move from Elements 0.25 and bitcoin_hashes 0.14 to Elements 0.27 and bitcoin_hashes 1.2.

---

Therefore I would go for the minor version bump 